### PR TITLE
Feature/share access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ output.html
 
 # Ignore your project specific .config.yml config files
 *.config.yml
+*.config-bs*

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Into that file you'll need to add as a minimum this
 # immediately failing because the element cannot be found. This defaults to 2
 # seconds but with the need to confirm emails via mailinator, we have found we
 # need to increase this time to at least 5 seconds
-max_wait_time: 5
+max_wait_time: 10
 
 custom:
   accounts:
@@ -121,8 +121,7 @@ To have consistency across the project the following tags are defined and should
 |@basic|Features used for basic regression testing as part of Continuous Integration|
 |@readonly|Any feature which doesn't change user data on the service.|
 |@readwrite|Any feature which amends user data on the service.  Do not run on a live environment.|
-|@backoffice|Any feature or scenario expected to be run against the back office Dynamics application|
-|@happypath|A scenario which details a complete registration with no errors|
+|@bs|Features to run as part of a Browserstack test.  (Essentially anything that can be run more than once without needing to clear the database)|
 |@functional|Any feature or scenario which is testing just a specific function of the service e.g. validation errors|
 |@broken|A scenario which is known to be broken due to the service not meeting expected behaviour|
 |@ci|A feature that is intended to be run only on our continuous integration service (you should never need to use this tag).|

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Into that file you'll need to add as a minimum this
 # immediately failing because the element cannot be found. This defaults to 2
 # seconds but with the need to confirm emails via mailinator, we have found we
 # need to increase this time to at least 5 seconds
-max_wait_time: 10
+max_wait_time: 5
 
 custom:
   accounts:

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ end
 
 desc "Run all scenarios (eq to bundle exec quke)"
 task :run do
-  sh %( QUKE_CONFIG=.config.yml bundle exec quke )
+  sh %( bundle exec quke )
 end
 
 desc "Runs the tests used by continuous integration to check the project"
@@ -31,28 +31,14 @@ end
 # To run Browserstack tests, use bundle exec rake bs
 
 desc "Run all browser tests"
-task bs: %i[ios_safari]
-# separate browsers with spaces
+  task bs: %i[ios_safari android_chrome samsung]
 
 # rubocop:disable Metrics/LineLength
-# Text for task bs: win7_ie9 win7_ie11 win7_chrome win7_ff win10_edge macos_safari macos_chrome macos_ff ios_safari android_chrome samsung
+# Select browsers from the following, separated by spaces: win7_ie9 win7_ie11 win7_chrome win7_ff win10_edge macos_safari macos_chrome macos_ff ios_safari android_chrome samsung
 # rubocop:enable Metrics/LineLength
-
-# Browsers from GOV.UK 9Mar18, with latest versions:
-
-# win7_ie9 pass
-# win7_ie11 pass
-# win7_chrome (v64) pass
-# win7_ff (v58) pass
-# win10_edge pass
-# macos_safari pass
-# macos_chrome (v64) pass
-# macos_ff (v58) pass
-# ios_safari FAIL
-# ios_chrome PASS MANUAL
-# android_chrome pass
-# samsung (Galaxy S8) pass
-# winphone_ie pass MANUAL
+# Current versions are Chrome 64 and Firefox 58.
+# The following browsers are not currently supported by Browserstack and need to be tested manually:
+# iOS Chrome and Windows Phone with IE
 
 desc "Run Windows 7 IE9 test"
 task :win7_ie9 do
@@ -108,5 +94,3 @@ desc "Run iOS Safari test"
 task :ios_safari do
   sh %( QUKE_CONFIG=.config-bs-ios_safari.yml bundle exec quke --tags @bs)
 end
-
-# Haven't done the rest yet, I want to see if the first one works.

--- a/Rakefile
+++ b/Rakefile
@@ -16,7 +16,7 @@ end
 
 desc "Run all scenarios (eq to bundle exec quke)"
 task :run do
-  sh %( bundle exec quke )
+  sh %( QUKE_CONFIG=.config.yml bundle exec quke )
 end
 
 desc "Runs the tests used by continuous integration to check the project"
@@ -24,3 +24,79 @@ task :ci do
   Rake::Task["rubocop"].invoke
   sh %( QUKE_CONFIG=.config-ci.yml bundle exec quke --tags @ci )
 end
+
+# The following is copied from
+# https://github.com/DEFRA/waste-carriers-acceptance-tests/blob/master/Rakefile
+#
+# To run Browserstack tests, use bundle exec rake bs
+
+desc "Run all browser tests"
+task bs: %i[ios_safari ios_chrome android_chrome winphone_ie]
+# separate browsers with spaces
+
+# rubocop:disable Metrics/LineLength
+# Text for task bs: win7_ie9 win7_ie11 win7_chrome win7_ff win10_edge macos_safari macos_chrome macos_ff ios_safari ios_chrome android_chrome samsung winphone_ie
+# rubocop:enable Metrics/LineLength
+
+# Browsers from GOV.UK 9Mar18, with latest versions:
+
+# win7_ie9 pass (basic)
+# win7_ie11 pass
+# win7_chrome (v64) pass
+# win7_ff (v58) pass
+# win10_edge pass
+# macos_safari pass
+# macos_chrome (v64) pass
+# macos_ff (v58) pass
+# ios_safari
+# ios_chrome NOT POSSIBLE ON BS - TEST MANUALLY
+# android_chrome
+# samsung (Galaxy S8) pass
+# winphone_ie
+
+desc "Run Windows 7 IE9 test"
+task :win7_ie9 do
+  sh %( QUKE_CONFIG=.config-bs-win7_ie9.yml bundle exec quke --tags @wip)
+end
+
+desc "Run Windows 7 IE11 test"
+task :win7_ie11 do
+  sh %( QUKE_CONFIG=.config-bs-win7_ie11.yml bundle exec quke --tags @basic)
+end
+
+desc "Run Windows 7 Chrome test"
+task :win7_chrome do
+  sh %( QUKE_CONFIG=.config-bs-win7_chrome.yml bundle exec quke --tags @basic)
+end
+
+desc "Run Windows 7 Firefox test"
+task :win7_ff do
+  sh %( QUKE_CONFIG=.config-bs-win7_ff.yml bundle exec quke --tags @basic)
+end
+
+desc "Run Windows 10 Edge test"
+task :win10_edge do
+  sh %( QUKE_CONFIG=.config-bs-win10_edge.yml bundle exec quke --tags @basic)
+end
+
+desc "Run Mac Safari test"
+task :macos_safari do
+  sh %( QUKE_CONFIG=.config-bs-macos_safari.yml bundle exec quke --tags @basic)
+end
+
+desc "Run Mac Chrome test"
+task :macos_chrome do
+  sh %( QUKE_CONFIG=.config-bs-macos_chrome.yml bundle exec quke --tags @basic)
+end
+
+desc "Run Mac Firefox test"
+task :macos_ff do
+  sh %( QUKE_CONFIG=.config-bs-macos_ff.yml bundle exec quke --tags @basic)
+end
+
+desc "Run Samsung Galaxy test"
+task :samsung do
+  sh %( QUKE_CONFIG=.config-bs-samsung.yml bundle exec quke --tags @basic)
+end
+
+# Haven't done the rest yet, I want to see if the first one works.

--- a/Rakefile
+++ b/Rakefile
@@ -31,16 +31,16 @@ end
 # To run Browserstack tests, use bundle exec rake bs
 
 desc "Run all browser tests"
-task bs: %i[ios_safari ios_chrome android_chrome winphone_ie]
+task bs: %i[ios_safari]
 # separate browsers with spaces
 
 # rubocop:disable Metrics/LineLength
-# Text for task bs: win7_ie9 win7_ie11 win7_chrome win7_ff win10_edge macos_safari macos_chrome macos_ff ios_safari ios_chrome android_chrome samsung winphone_ie
+# Text for task bs: win7_ie9 win7_ie11 win7_chrome win7_ff win10_edge macos_safari macos_chrome macos_ff ios_safari android_chrome samsung
 # rubocop:enable Metrics/LineLength
 
 # Browsers from GOV.UK 9Mar18, with latest versions:
 
-# win7_ie9 pass (basic)
+# win7_ie9 pass
 # win7_ie11 pass
 # win7_chrome (v64) pass
 # win7_ff (v58) pass
@@ -48,55 +48,65 @@ task bs: %i[ios_safari ios_chrome android_chrome winphone_ie]
 # macos_safari pass
 # macos_chrome (v64) pass
 # macos_ff (v58) pass
-# ios_safari
-# ios_chrome NOT POSSIBLE ON BS - TEST MANUALLY
-# android_chrome
+# ios_safari FAIL
+# ios_chrome PASS MANUAL
+# android_chrome pass
 # samsung (Galaxy S8) pass
-# winphone_ie
+# winphone_ie pass MANUAL
 
 desc "Run Windows 7 IE9 test"
 task :win7_ie9 do
-  sh %( QUKE_CONFIG=.config-bs-win7_ie9.yml bundle exec quke --tags @wip)
+  sh %( QUKE_CONFIG=.config-bs-win7_ie9.yml bundle exec quke --tags @bs)
 end
 
 desc "Run Windows 7 IE11 test"
 task :win7_ie11 do
-  sh %( QUKE_CONFIG=.config-bs-win7_ie11.yml bundle exec quke --tags @basic)
+  sh %( QUKE_CONFIG=.config-bs-win7_ie11.yml bundle exec quke --tags @bs)
 end
 
 desc "Run Windows 7 Chrome test"
 task :win7_chrome do
-  sh %( QUKE_CONFIG=.config-bs-win7_chrome.yml bundle exec quke --tags @basic)
+  sh %( QUKE_CONFIG=.config-bs-win7_chrome.yml bundle exec quke --tags @bs)
 end
 
 desc "Run Windows 7 Firefox test"
 task :win7_ff do
-  sh %( QUKE_CONFIG=.config-bs-win7_ff.yml bundle exec quke --tags @basic)
+  sh %( QUKE_CONFIG=.config-bs-win7_ff.yml bundle exec quke --tags @bs)
 end
 
 desc "Run Windows 10 Edge test"
 task :win10_edge do
-  sh %( QUKE_CONFIG=.config-bs-win10_edge.yml bundle exec quke --tags @basic)
+  sh %( QUKE_CONFIG=.config-bs-win10_edge.yml bundle exec quke --tags @bs)
 end
 
 desc "Run Mac Safari test"
 task :macos_safari do
-  sh %( QUKE_CONFIG=.config-bs-macos_safari.yml bundle exec quke --tags @basic)
+  sh %( QUKE_CONFIG=.config-bs-macos_safari.yml bundle exec quke --tags @bs)
 end
 
 desc "Run Mac Chrome test"
 task :macos_chrome do
-  sh %( QUKE_CONFIG=.config-bs-macos_chrome.yml bundle exec quke --tags @basic)
+  sh %( QUKE_CONFIG=.config-bs-macos_chrome.yml bundle exec quke --tags @bs)
 end
 
 desc "Run Mac Firefox test"
 task :macos_ff do
-  sh %( QUKE_CONFIG=.config-bs-macos_ff.yml bundle exec quke --tags @basic)
+  sh %( QUKE_CONFIG=.config-bs-macos_ff.yml bundle exec quke --tags @bs)
 end
 
-desc "Run Samsung Galaxy test"
+desc "Run Android Chrome test"
+task :android_chrome do
+  sh %( QUKE_CONFIG=.config-bs-android_chrome.yml bundle exec quke --tags @bs)
+end
+
+desc "Run Samsung test"
 task :samsung do
-  sh %( QUKE_CONFIG=.config-bs-samsung.yml bundle exec quke --tags @basic)
+  sh %( QUKE_CONFIG=.config-bs-samsung.yml bundle exec quke --tags @bs)
+end
+
+desc "Run iOS Safari test"
+task :ios_safari do
+  sh %( QUKE_CONFIG=.config-bs-ios_safari.yml bundle exec quke --tags @bs)
 end
 
 # Haven't done the rest yet, I want to see if the first one works.

--- a/Rakefile
+++ b/Rakefile
@@ -31,7 +31,7 @@ end
 # To run Browserstack tests, use bundle exec rake bs
 
 desc "Run all browser tests"
-  task bs: %i[ios_safari android_chrome samsung]
+task bs: %i[ios_safari android_chrome samsung]
 
 # rubocop:disable Metrics/LineLength
 # Select browsers from the following, separated by spaces: win7_ie9 win7_ie11 win7_chrome win7_ff win10_edge macos_safari macos_chrome macos_ff ios_safari android_chrome samsung

--- a/features/basic_licence_checks.feature
+++ b/features/basic_licence_checks.feature
@@ -6,8 +6,7 @@ Feature: Basic licence checks
 
   Background:
     Given I sign into my account as "water_user1"
-    
-    # And I access the first licence
+    And I access the first licence
 
   Scenario: Contact details are shown for licence
     When I check the licence contact details

--- a/features/basic_licence_checks.feature
+++ b/features/basic_licence_checks.feature
@@ -1,4 +1,4 @@
-@basic @readonly
+@basic @readonly @bs
 Feature: Basic licence checks
   As a business with a water abstraction licence
   I want to be able to check my licence details
@@ -6,7 +6,8 @@ Feature: Basic licence checks
 
   Background:
     Given I sign into my account as "water_user1"
-    And I access the first licence
+    
+    # And I access the first licence
 
   Scenario: Contact details are shown for licence
     When I check the licence contact details

--- a/features/basic_login.feature
+++ b/features/basic_login.feature
@@ -1,4 +1,4 @@
-@basic @readonly
+@basic @readonly @bs
 Feature: Basic login
   As a business with water abstraction licences
   I want to be given help when I have problem signing into my account

--- a/features/manage_password.feature
+++ b/features/manage_password.feature
@@ -1,4 +1,4 @@
-@readonly
+@readonly @bs
 Feature: Manage password
   As a viewer of water abstraction licences
   I want to update my password
@@ -6,7 +6,8 @@ Feature: Manage password
 
   Background: Go to Change Password screen
     Given I sign into my account as "water_user1"
-    When I select Change Password
+    And I select Change Password
+    When I enter my correct password
     Then I am on the Change Password page
 
   Scenario: Enter short password

--- a/features/page_objects/change_password_reauthenticate_page.rb
+++ b/features/page_objects/change_password_reauthenticate_page.rb
@@ -1,0 +1,13 @@
+class ChangePasswordReauthenticatePage < SitePrism::Page
+
+  element(:header, ".heading-large")
+  element(:password, "#password")
+  element(:submit_button, ".button-start")
+  element(:error_heading, "#error-summary-heading")
+
+  def submit(args = {})
+    password.set(args[:password]) if args.key?(:password)
+    submit_button.click
+  end
+
+end

--- a/features/page_objects/front_office_app.rb
+++ b/features/page_objects/front_office_app.rb
@@ -43,6 +43,10 @@ class FrontOfficeApp
     @last_page = MailinatorDetailsPage.new
   end
 
+  def change_password_reauthenticate_page
+    @last_page = ChangePasswordReauthenticatePage.new
+  end
+
   def change_password_page
     @last_page = ChangePasswordPage.new
   end

--- a/features/page_objects/front_office_app.rb
+++ b/features/page_objects/front_office_app.rb
@@ -107,4 +107,12 @@ class FrontOfficeApp
     @last_page = RegisterSecurityCodePage.new
   end
 
+  def manage_licences_page
+    @last_page = ManageLicencesPage.new
+  end
+
+  def manage_give_access_page
+    @last_page = ManageGiveAccessPage.new
+  end
+
 end

--- a/features/page_objects/licence_details_page.rb
+++ b/features/page_objects/licence_details_page.rb
@@ -13,8 +13,8 @@ class LicenceDetailsPage < SitePrism::Page
   element(:cancel_link, "#nameForm a")
   element(:contact_details, "a[href$='/contact']")
   element(:points_link, "a[href$='/points']")
-  element(:purposes_link, "a[href$='/purposes']")
   element(:conditions_link, "a[href$='/conditions']")
+  element(:purpose_period_amounts_link, "a[href$='/purposes']")
   elements(:page_links, "a")
 
   def submit(args = {})

--- a/features/page_objects/licence_details_page.rb
+++ b/features/page_objects/licence_details_page.rb
@@ -1,6 +1,8 @@
 class LicenceDetailsPage < SitePrism::Page
 
   # Water abstraction licence
+  element(:banner_links, ".header-proposition")
+  element(:manage_licences_link, "#proposition-links li+ li a")
   element(:abstraction_licences_link, "#content li:nth-child(1) a")
   element(:licence_breadcrumb, "#content li+ li a")
   element(:back_link, ".link-back")

--- a/features/page_objects/licences_page.rb
+++ b/features/page_objects/licences_page.rb
@@ -4,11 +4,11 @@ class LicencesPage < SitePrism::Page
 
   element(:changepw, ".header-links a:nth-child(1)")
   element(:heading, ".heading-large")
-  elements(:licences, ".heading-medium")
+  elements(:licences, ".license-result__column--number a")
   # see https://github.com/natritmeyer/site_prism#element-collections
-  elements(:view_links, ".license-result__column--view")
-  element(:first_licence, ".license-results-header+ .license-result .heading-medium")
-  element(:licence_result_no, ".license-results-header+ .license-result .heading-medium")
+  elements(:view_links, ".license-result a")
+  element(:first_licence, ".license-results-header+ .license-result a")
+  element(:licence_result_no, ".license-results-header+ .license-result a")
   element(:licence_result_name, ".license-results-header+ .license-result .license-result__column--description")
   element(:email_form, "#emailAddress")
   element(:search_form, "#licenceNumber")
@@ -23,7 +23,7 @@ class LicencesPage < SitePrism::Page
 
   def submit(args = {})
     return unless args.key?(:licence)
-    licences.find { |btn| btn.text == args[:licence] }.click
+    find_link(args[:licence]).click
   end
 
   def search(args = {})

--- a/features/page_objects/licences_page.rb
+++ b/features/page_objects/licences_page.rb
@@ -2,8 +2,11 @@ class LicencesPage < SitePrism::Page
 
   # Your water abstraction licences
 
+  element(:banner_links, ".header-proposition")
+  element(:manage_licences_link, "#proposition-links li+ li a")
   element(:changepw, ".header-links a:nth-child(1)")
   element(:heading, ".heading-large")
+  element(:content, "#content")
   elements(:licences, ".license-result__column--number a")
   # see https://github.com/natritmeyer/site_prism#element-collections
   elements(:view_links, ".license-result a")
@@ -14,10 +17,7 @@ class LicencesPage < SitePrism::Page
   element(:search_form, "#licenceNumber")
   element(:search_button, "#searchButton")
   element(:triangle, ".sort-icon")
-  element(:serialno_link, ".license-results-header__column:nth-child(1) a")
-  element(:licencename_link, ".license-results-header__column+ .license-results-header__column a")
   element(:johnlicence, ".license-result:nth-child(133) .heading-medium") # 18/54/17/0361
-  element(:content, "#content") # all page content
   element(:firstlicence, ".license-results-header+ .license-result .heading-medium")
   element(:lastlicence, ".license-result:last-child .heading-medium")
 

--- a/features/page_objects/manage_give_access_page.rb
+++ b/features/page_objects/manage_give_access_page.rb
@@ -1,0 +1,21 @@
+class ManageGiveAccessPage < SitePrism::Page
+
+  # Your water abstraction licences
+
+  element(:manage_licences_link, "#proposition-links li+ li a")
+  element(:changepw, ".header-links a:nth-child(1)")
+  element(:heading, ".heading-large")
+  element(:content, "#content")
+  element(:email_form, "#email")
+  element(:add_user_button, ".button-start")
+
+  def generate_email
+    @random_email = "mywail" + rand(0..999_999_999).to_s + "@mailinator.com"
+  end
+
+  def submit(args = {})
+    email_form.set(args[:email_address]) if args.key?(:email_address)
+    add_user_button.click
+  end
+
+end

--- a/features/page_objects/manage_licences_page.rb
+++ b/features/page_objects/manage_licences_page.rb
@@ -1,0 +1,13 @@
+class ManageLicencesPage < SitePrism::Page
+
+  # Your water abstraction licences
+
+  element(:manage_licences_link, "#proposition-links li+ li a")
+  element(:changepw, ".header-links a:nth-child(1)")
+  element(:heading, ".heading-large")
+  element(:content, "#content")
+  element(:add_user_button, ".button")
+  element(:access_more_licences_link, ".tabs a")
+  elements(:people_with_access, "#results .heading-medium")
+
+end

--- a/features/register_and_share.feature
+++ b/features/register_and_share.feature
@@ -1,10 +1,10 @@
 @readwrite
-Feature: Register
+Feature: Register and share
   As a user with a water abstraction licence
   I want to register with the service
-  So that I can view my licence
+  So that I can view my licence and share access with my agent
 
-Scenario: Register a licence
+Scenario: Register and share licences
   Given I am a new user
   When I register my email address on the service
   Then I receive an email with sign in details
@@ -25,3 +25,14 @@ Scenario: Register a licence
   And I sign into my account as "water_user1"
   When I enter an email address on the licence holder's email field
   Then all licences containing that term are shown on screen
+
+  Given I can sign in with my new email address
+  And I am on the external abstraction licences page
+  And I can see the manage licences link
+  When I go to the manage licences link
+  Then I am on the manage your licences page
+
+  Given I am on the manage your licences page
+  When I add an agent to view my licences
+  Then I receive confirmation that the agent has received an email
+  And the agent can log in and view the licences I registered

--- a/features/rename_licence.feature
+++ b/features/rename_licence.feature
@@ -7,7 +7,7 @@ Feature: Rename licence
   Background:
     Given I sign into my account as "water_user1"
     And I select a particular licence
-    When I select the "Name this licence" link
+    When I select the link to name the licence
 
   Scenario: Reset licence name
     When I reset the licence name

--- a/features/rename_licence.feature
+++ b/features/rename_licence.feature
@@ -1,4 +1,4 @@
-@readwrite
+@readwrite @bs
 Feature: Rename licence
   As a business with a water abstraction licence
   I want to be able to check my licence details

--- a/features/search_filter.feature
+++ b/features/search_filter.feature
@@ -26,6 +26,10 @@ Scenario: Sort licences by name
   When I select the licence name heading
   Then the table is sorted by licence name in ascending order
 
+Scenario: Sort licences by end date
+  When I select the end date heading
+  Then the table is sorted by end date in ascending order
+
 Scenario: Sort licences by number
   When I select the licence name heading
   And I select the licence number heading

--- a/features/search_filter.feature
+++ b/features/search_filter.feature
@@ -1,4 +1,4 @@
-@readonly
+@readonly @bs
 Feature: Search and filter on licences page
 
 Background:

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -40,12 +40,12 @@ Then(/^I am on the licence points page$/) do
 end
 
 When(/^I check the licence purposes$/) do
-  @front_app.licences_page.click_link(text: "your abstraction purpose")
+  @front_app.licences_page.click_link(text: "View details of your purpose")
 end
 
 Then(/^I am on the licence purposes page$/) do
   expect(@front_app.licence_purposes_page.current_url).to include "/purposes"
-  expect(@front_app.licence_purposes_page).to have_text("Abstraction purposes for licence")
+  expect(@front_app.licence_purposes_page).to have_text("Abstraction details for licence")
 end
 
 When(/^I check the licence conditions$/) do

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -59,7 +59,7 @@ Then(/^I am on the licence conditions page$/) do
   expect(@front_app.licence_conditions_page.disclaimer).to have_text("You must refer to the paper copy of your licence")
 end
 
-Given(/^I select the "Name this licence" link$/) do
+Given(/^I select the link to name the licence$/) do
   @front_app.licence_details_page.click_name_or_rename
 end
 
@@ -74,14 +74,14 @@ Given(/^I enter a licence name which is invalid$/) do
 end
 
 Given(/^the expected licence name appears on the licence summary page$/) do
-  @front_app.licence_details_page.back_link.click
+  @front_app.licences_page.click_link(text: "Licences")
   @front_app.licences_page.wait_for_search_form
   @front_app.licences_page.search(search_form: "/")
   expect(@front_app.licences_page).to have_text(@expected_licence_name.to_s)
 end
 
 Given(/^the licence name is searchable on the abstraction licences page$/) do
-  @front_app.licence_details_page.abstraction_licences_link.click
+  @front_app.licences_page.click_link(text: "Licences")
   @expected_search_result = @expected_licence_name
   @expected_result_count = 1
   @front_app.licences_page.search(

--- a/features/step_definitions/general_steps.rb
+++ b/features/step_definitions/general_steps.rb
@@ -75,6 +75,7 @@ end
 
 Given(/^the expected licence name appears on the licence summary page$/) do
   @front_app.licence_details_page.back_link.click
+  @front_app.licences_page.wait_for_search_form
   @front_app.licences_page.search(search_form: "/")
   expect(@front_app.licences_page).to have_text(@expected_licence_name.to_s)
 end

--- a/features/step_definitions/manage_licences_steps.rb
+++ b/features/step_definitions/manage_licences_steps.rb
@@ -1,0 +1,48 @@
+
+Given(/^I can see the manage licences link$/) do
+  expect(@front_app.licences_page.banner_links).to have_text("Manage your licences")
+end
+
+Given(/^I go to the manage licences link$/) do
+  @front_app.licences_page.manage_licences_link.click
+end
+
+Then(/^I am on the manage your licences page$/) do
+  expect(@front_app.manage_licences_page.heading).to have_text("Manage your licences")
+end
+
+Given(/^I add an agent to view my licences$/) do
+  @front_app.manage_licences_page.add_user_button.click
+  expect(@front_app.manage_give_access_page.heading).to have_text("Give access to view your licences")
+  @geoff_email = @front_app.manage_give_access_page.generate_email.to_s
+  @front_app.manage_give_access_page.submit(email_address: @geoff_email)
+  puts "Agent's email address is: " + @geoff_email
+end
+
+Given(/^I receive confirmation that the agent has received an email$/) do
+  expect(@front_app.manage_give_access_page.heading).to have_text("Access email sent to")
+end
+
+Given(/^the agent can log in and view the licences I registered$/) do
+  @environment = Quke::Quke.config.custom["current_environment"].to_s
+  @front_app.mailinator_home_page.load
+  @front_app.mailinator_home_page.wait_for_inbox
+  @front_app.mailinator_home_page.submit(inbox: @geoff_email)
+  @front_app.mailinator_inbox_page.wait_for_email
+  @front_app.mailinator_inbox_page.email[0].from.click
+
+  @front_app.mailinator_inbox_page.email_details do |frame|
+    @new_window = window_opened_by { frame.create_password.click }
+  end
+
+  within_window @new_window do
+    @front_app.register_create_pw_page.submit(
+      password: Quke::Quke.config.custom["data"][@environment]["accounts"]["water_user2"]["password"],
+      confirmpw: Quke::Quke.config.custom["data"][@environment]["accounts"]["water_user2"]["password"]
+    )
+    @front_app.licences_page.submit(licence: @licence_reg)
+    expect(@front_app.licence_details_page.licence_breadcrumb).to have_text(@licence_reg)
+    expect(@front_app.licence_details_page).to have_no_manage_licences_link
+  end
+
+end

--- a/features/step_definitions/password_steps.rb
+++ b/features/step_definitions/password_steps.rb
@@ -8,6 +8,12 @@ Given(/^I am on the Change Password page$/) do
   expect(@front_app.change_password_page.current_url).to include "/update_password"
 end
 
+Given(/^I enter my correct password$/) do
+  @front_app.change_password_reauthenticate_page.submit(
+    password: Quke::Quke.config.custom["data"][@environment]["accounts"]["water_user1"]["password"]
+  )
+end
+
 Given(/^I enter a password which is too short$/) do
   @front_app.change_password_page.submit(
     password: "Is$h0rt",

--- a/features/step_definitions/search_filter_steps.rb
+++ b/features/step_definitions/search_filter_steps.rb
@@ -47,22 +47,30 @@ Given(/^I can see the original number of licences$/) do
 end
 
 Given(/^I select the licence name heading$/) do
-  @front_app.licences_page.licencename_link.click
+  @front_app.licences_page.submit(licence: "Licence name")
 end
 
 Given(/^the table is sorted by licence name in ascending order$/) do
-  expect(@front_app.licences_page.licencename_link.text).to have_text("Licence name ▲")
+  expect(@front_app.licences_page.content.text).to have_text("Licence name ▲")
+end
+
+Given(/^I select the end date heading$/) do
+  @front_app.licences_page.submit(licence: "End date")
+end
+
+Given(/^the table is sorted by end date in ascending order$/) do
+  expect(@front_app.licences_page.content.text).to have_text("End date ▲")
 end
 
 Given(/^I select the licence number heading$/) do
-  @front_app.licences_page.serialno_link.click
+  @front_app.licences_page.submit(licence: "Licence number")
 end
 
 Given(/^the table is sorted by licence number in ascending order$/) do
   @environment = Quke::Quke.config.custom["current_environment"].to_s
   @top_licence = Quke::Quke.config.custom["data"][@environment]["licence_top"].to_s
   @btm_licence = Quke::Quke.config.custom["data"][@environment]["licence_bottom"].to_s
-  expect(@front_app.licences_page.serialno_link.text).to have_text("Licence serial number ▲")
+  expect(@front_app.licences_page.content.text).to have_text("Licence number ▲")
   expect(page.body.index(@top_licence)).to be < page.body.index(@btm_licence)
 end
 


### PR DESCRIPTION
Expanded the register feature to include granting access to agents to view licences, as well as Browserstack support and changes to match latest UI.

There is one more puts statement which I believe to be helpful to anyone executing or maintaining the tests - this helps a user see which licence holder and agent was used as part of each test.