### PR TITLE
Migrate Login tests

### DIFF
--- a/cypress/e2e/external/login-logout.cy.js
+++ b/cypress/e2e/external/login-logout.cy.js
@@ -1,0 +1,34 @@
+'use strict'
+
+describe('Login and log out (external)', () => {
+  before(() => {
+    cy.tearDown()
+    cy.setUp('barebones')
+    cy.fixture('users.json').its('external').as('userEmail')
+  })
+
+  it('can log in and out as an external user', () => {
+    cy.visit(Cypress.env('externalUrl'))
+
+    // tap the sign in button on the welcome page
+    cy.get('a[href*="/signin"]').click()
+
+    //  Enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    //  Click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    //  Assert the user signed in
+    cy.contains('Add licences or give access')
+
+    //  Click Sign out Button
+    cy.get('#signout').click()
+
+    //  Assert we are signed out
+    cy.contains("You're signed out").should('be.visible')
+  })
+})

--- a/cypress/e2e/internal/login-logout.cy.js
+++ b/cypress/e2e/internal/login-logout.cy.js
@@ -1,0 +1,31 @@
+'use strict'
+
+describe('Login and log out (internal)', () => {
+  before(() => {
+    cy.tearDown()
+    cy.setUp('barebones')
+    cy.fixture('users.json').its('billingAndData').as('userEmail')
+  })
+
+  it('can log in and out as an internal user', () => {
+    cy.visit('/')
+
+    //  Enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    //  Click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    //  Assert the user signed in
+    cy.contains('Enter a licence number, customer name')
+
+    //  Click Sign out Button
+    cy.get('#signout').click()
+
+    //  Assert we are signed out
+    cy.contains("You're signed out").should('be.visible')
+  })
+})

--- a/cypress/fixtures/users.json
+++ b/cypress/fixtures/users.json
@@ -1,0 +1,17 @@
+{
+  "external": "acceptance-test.external@example.com",
+  "externalNew": "acceptance-test.external-new@example.com",
+  "externalAccessSharing": "acceptance-test-access-sharing.external@example.com",
+  "externalAccessSharingNew": "acceptance-test-access-sharing.external.new@example.com",
+  "agent": "acceptance-test.agent@example.com",
+  "returnsAgent": "acceptance-test.returns-agent@example.com",
+  "notifyCallbackTestEmail": "notify-callback-test@example.com",
+  "super": "acceptance-test.internal.super@defra.gov.uk",
+  "wirs": "acceptance-test.internal.wirs@defra.gov.uk",
+  "nps": "acceptance-test.internal.nps@defra.gov.uk",
+  "npsDigitise": "acceptance-test.internal.nps_digitise@defra.gov.uk",
+  "npsDigitiseApprover": "acceptance-test.internal.nps_digitise_approver@defra.gov.uk",
+  "environmentOfficer": "acceptance-test.internal.environment_officer@defra.gov.uk",
+  "billingAndData": "acceptance-test.internal.billing_and_data@defra.gov.uk",
+  "psc": "acceptance-test.internal.psc@defra.gov.uk"
+}


### PR DESCRIPTION
The existing tests have one that confirms login into the external app works. We migrate that along with adding one for the internal app. It made sense to us to have the same test for both apps. Plus it allows us to confirm all is working for both apps with our first test.
