### PR TITLE
Migrate notify callback test

### DIFF
--- a/cypress/e2e/external/notify-callback.cy.js
+++ b/cypress/e2e/external/notify-callback.cy.js
@@ -1,0 +1,20 @@
+'use strict'
+
+describe('Notify callback endpoint', () => {
+  before(() => {
+    cy.tearDown()
+    cy.setUp('notify-mock-notification')
+    cy.fixture('users.json').its('notifyCallbackTestEmail').as('userEmail')
+  })
+
+  it('when called by Notify sets the status of the notification to delivered', () => {
+    // Pretending to be the Notify Service, submit a callback to the service, which updates the status of the
+    // Notification record added in setup() to 'delivered'
+    cy.simulateNotifyCallback('82fda2b8-0a53-4f02-bcaa-1e13949b250b')
+      .its('status', { log: false }).should('equal', 204)
+
+    cy.get('@userEmail').then((userEmail) => {
+      cy.lastNotification(userEmail).its('data[0].notify_status').should('equal', 'delivered')
+    })
+  })
+})


### PR DESCRIPTION
This test has to replicate the GOV.UK notify service hitting an endpoint we've provided for callbacks. For whatever reason, the previous team brought in [axios](https://www.npmjs.com/package/axios) to do this, even though sending HTTP requests is the core of Cypress!

So, most of the work was done in the initial commit (can you tell if some of these tests were migrated a while ago!?) but we've managed to strip out all the additional dependencies the old code was reliant on. Even said goodbye to [Lodash](https://www.npmjs.com/package/lodash)!