### PR TITLE
Migrate external reset password test

### DIFF
--- a/cypress/e2e/external/reset-password/journey.cy.js
+++ b/cypress/e2e/external/reset-password/journey.cy.js
@@ -1,0 +1,51 @@
+'use strict'
+
+describe('Reset password journey (external)', () => {
+  before(() => {
+    cy.tearDown()
+    cy.setUp('barebones')
+  })
+
+  beforeEach(() => {
+    cy.fixture('users.json').its('external').as('userEmail')
+  })
+
+  it('displays the change password page when the link in the email is clicked and automatically logs in when the password is changed', () => {
+    // Navigate to the signin page
+    cy.visit(Cypress.env('externalUrl'))
+    cy.get('a[href*="/signin"]').click()
+
+    // Navigate to the reset your password page
+    cy.get('a[href*="/reset_password').click()
+
+    // Test setting a valid email address
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('button.govuk-button.govuk-button--start').click()
+    cy.contains('Check your email').should('have.class', 'govuk-heading-l')
+
+    cy.get('@userEmail').then((userEmail) => {
+      cy.lastNotification(userEmail).then((body) => {
+        let resetUrl = body.data[0].personalisation.reset_url
+        resetUrl = resetUrl.replace((/^https?:\/\/[^/]+\//g).exec(resetUrl), Cypress.env('externalUrl') + '/')
+        cy.log(resetUrl)
+        cy.visit(resetUrl)
+
+        cy.contains('Change your password').should('be.visible')
+        cy.contains('Enter a new password').should('be.visible')
+        cy.contains('Confirm your password').should('be.visible')
+
+        const newPassword = `${Cypress.env('defaultPassword')}1234`
+        cy.get('[id=password]').type(newPassword)
+        cy.get('[id=confirmPassword]').type(newPassword)
+        cy.get('button.govuk-button').click()
+
+        cy.contains('View licences').should('have.attr', 'href', '/licences')
+        cy.contains('Manage returns').should('have.attr', 'href', '/returns')
+        cy.contains('Add licences or give access').should('have.attr', 'href', '/manage_licences')
+        cy.contains('Your licences').should('have.class', 'govuk-heading-l')
+      })
+    })
+  })
+})

--- a/cypress/e2e/external/reset-password/validation.cy.js
+++ b/cypress/e2e/external/reset-password/validation.cy.js
@@ -1,0 +1,36 @@
+'use strict'
+
+describe('Reset password validation (external)', () => {
+  beforeEach(() => {
+    cy.fixture('users.json').its('external').as('userEmail')
+  })
+
+  it('validates the input in the reset password email screen before redirecting to the success page if valid', () => {
+    // Navigate to the signin page
+    cy.visit(Cypress.env('externalUrl'))
+    cy.get('a[href*="/signin"]').click()
+
+    // Navigate to the reset your password page
+    cy.get('a[href*="/reset_password').click()
+    cy.contains('Reset your password').should('have.class', 'govuk-heading-l')
+    cy.contains('Email address').should('have.class', 'govuk-label')
+
+    // Test submitting nothing
+    cy.get('button.govuk-button.govuk-button--start').click()
+    cy.contains('Enter an email address').should('have.attr', 'href', '#email')
+
+    // Test submitting an invalid email address
+    cy.get('input#email').type('invalid....email')
+    cy.get('button.govuk-button.govuk-button--start').click()
+    cy.contains('Enter an email address in the correct format').should('have.attr', 'href', '#email')
+    cy.get('input#email').clear()
+
+    // Test setting a valid email address
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('button.govuk-button.govuk-button--start').click()
+    cy.contains('Check your email').should('have.class', 'govuk-heading-l')
+    cy.contains('Has the email not arrived?').should('have.attr', 'href', '/reset_password_resend_email')
+  })
+})


### PR DESCRIPTION
This migration highlighted that the previous tests didn't really understand the use of `it()` blocks and that they should be tests in isolation. Instead, they seemed to be more of a way of breaking up what was going on in the file.

In Cypress v12 `testIsolation` is enabled by default. This means Cypress [resets the browser context _before_ each test](https://docs.cypress.io/guides/references/migration-guide#Test-Isolation). Each `it()` block is considered a test. So, any that could not be run in isolation will now fail and this definitely applied to 'reset password'.

On top of that, it was again sending [axios requests](https://www.npmjs.com/package/axios) instead of using Cypress, and doing so to get an ID we hard code when setting up the test data. So we've been able to make some improvements, removing unnecessary dependencies (done in the initial commit) and streamlining the tests themselves.

Having looked at the existing tests, they were both checking validation and that the journey worked. So, we've used that as a basis for creating 2 tests that do the same thing but which can now be run in isolation.