### PR TITLE
Add a body to our POST requests

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -35,7 +35,8 @@ Cypress.Commands.add('setUp', (testKey) => {
     method: 'POST',
     headers: {
       authorization: `Bearer ${Cypress.env('jwtToken')}`
-    }
+    },
+    body: { dummy: 'Because the WAF blocks empty POST requests' }
   }).its('status', { log: false }).should('equal', 204)
 })
 
@@ -48,7 +49,8 @@ Cypress.Commands.add('tearDown', () => {
     method: 'POST',
     headers: {
       authorization: `Bearer ${Cypress.env('jwtToken')}`
-    }
+    },
+    body: { dummy: 'Because the WAF blocks empty POST requests' }
   }).its('status', { log: false }).should('equal', 200)
 })
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -36,7 +36,8 @@ Cypress.Commands.add('setUp', (testKey) => {
     headers: {
       authorization: `Bearer ${Cypress.env('jwtToken')}`
     },
-    body: { dummy: 'Because the WAF blocks empty POST requests' }
+    body: { dummy: 'Because the WAF blocks empty POST requests' },
+    timeout: 60000
   }).its('status', { log: false }).should('equal', 204)
 })
 
@@ -50,7 +51,8 @@ Cypress.Commands.add('tearDown', () => {
     headers: {
       authorization: `Bearer ${Cypress.env('jwtToken')}`
     },
-    body: { dummy: 'Because the WAF blocks empty POST requests' }
+    body: { dummy: 'Because the WAF blocks empty POST requests' },
+    timeout: 60000
   }).its('status', { log: false }).should('equal', 200)
 })
 


### PR DESCRIPTION
Testing against the environments was failing because the tear-down requests were returning an error. After investigating the issue we have found the requests are being rejected by the [Silverline WAF](https://www.f5.com/cloud/products/distributed-cloud-waf) used in our AWS environments because they don't have a body. For 'reasons' there is a policy to automatically reject POST requests with no body.

We're getting that changed but in the meantime adding a dummy body bypasses the issue. In getting this working we also found that the test data tear-down and setup actions take longer than the default 30 seconds in some of our non-prod environments. So, this change also includes an increase in the response timeout for those specific requests.