### PR TITLE
Use external URL for last email check

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -56,7 +56,7 @@ Cypress.Commands.add('lastNotification', (email) => {
   cy.log('Getting last email sent to Notify')
 
   cy.request({
-    url: `${Cypress.env('externalUrl')}/notifications/last?email=${email}`,
+    url: `/notifications/last?email=${email}`,
     log: false,
     method: 'GET'
   }).then((response) => {


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-ui/pull/2267

We found that the endpoint `/notifications/last` was not available in our non-prod environments because of a dependence on the old `TEST_MODE` env var. When updating that, we realised we were maintaining the same logic in both the internal and external apps. We only need it in one for our acceptance tests to work, so we've deleted the external endpoint and updated the internal one.

That means we need to update the custom command that uses it.