### PR TITLE
Revert empty POST requests workaround

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -36,7 +36,6 @@ Cypress.Commands.add('setUp', (testKey) => {
     headers: {
       authorization: `Bearer ${Cypress.env('jwtToken')}`
     },
-    body: { dummy: 'Because the WAF blocks empty POST requests' },
     timeout: 60000
   }).its('status', { log: false }).should('equal', 204)
 })
@@ -51,7 +50,6 @@ Cypress.Commands.add('tearDown', () => {
     headers: {
       authorization: `Bearer ${Cypress.env('jwtToken')}`
     },
-    body: { dummy: 'Because the WAF blocks empty POST requests' },
     timeout: 60000
   }).its('status', { log: false }).should('equal', 200)
 })


### PR DESCRIPTION
We can now revert the change made in [Add a body to our POST requests](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/6) as web-ops, being their usual bad-ass selves, have already updated the WAF to remove the block on POSTs with no bodies.