### PR TITLE
Migrate sharing licence access external tests

### DIFF
--- a/cypress/e2e/external/reset-password/journey.cy.js
+++ b/cypress/e2e/external/reset-password/journey.cy.js
@@ -27,10 +27,9 @@ describe('Reset password journey (external)', () => {
 
     cy.get('@userEmail').then((userEmail) => {
       cy.lastNotification(userEmail).then((body) => {
-        let resetUrl = body.data[0].personalisation.reset_url
-        resetUrl = resetUrl.replace((/^https?:\/\/[^/]+\//g).exec(resetUrl), Cypress.env('externalUrl') + '/')
-        cy.log(resetUrl)
-        cy.visit(resetUrl)
+        cy.extractNotificationLink(body, 'reset_url', Cypress.env('externalUrl')).then((link) => {
+          cy.visit(link)
+        })
 
         cy.contains('Change your password').should('be.visible')
         cy.contains('Enter a new password').should('be.visible')

--- a/cypress/e2e/external/sharing-access-with-existing-user.cy.js
+++ b/cypress/e2e/external/sharing-access-with-existing-user.cy.js
@@ -1,0 +1,50 @@
+'use strict'
+
+describe('Sharing license access with another user (external)', () => {
+  before(() => {
+    cy.tearDown()
+    cy.setUp('barebones')
+    cy.fixture('users.json').its('external').as('firstUserEmail')
+    cy.fixture('users.json').its('externalAccessSharing').as('secondUserEmail')
+  })
+
+  it('allows a user to grant access to a licence to another user', () => {
+    //  First user logs in
+    cy.visit(Cypress.env('externalUrl'))
+    cy.get('a[href*="/signin"]').click()
+    cy.get('@firstUserEmail').then((email) => {
+      cy.get('input#email').type(email)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    //  view and assign the licence
+    cy.get('.licence-result__column > a').contains('AT/CURR/DAILY/01').should('be.visible')
+    cy.get('#navbar-manage').contains('Add licences or give access').click()
+    cy.get('.govuk-list').contains('Give or remove access to your licence information').click()
+    cy.get('.govuk-button').contains('Give access').click()
+    cy.get('@secondUserEmail').then((email) => {
+      cy.get('input#email').type(email)
+    })
+    cy.get('.form > .govuk-button').click()
+
+    // First user logs out
+    cy.get('.govuk-link').contains('Return to give access').click()
+    cy.get('#signout').click()
+
+    // Second user logs in
+    cy.visit(Cypress.env('externalUrl'))
+    cy.get('a[href*="/signin"]').click()
+    cy.get('@firstUserEmail').then((email) => {
+      cy.get('input#email').type(email)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    // Assert they can see the same licence
+    cy.get('.licence-result__column > a').contains('AT/CURR/DAILY/01').should('be.visible')
+
+    // Sign out
+    cy.get('#signout').click()
+  })
+})

--- a/cypress/e2e/external/sharing-access-with-new-user.cy.js
+++ b/cypress/e2e/external/sharing-access-with-new-user.cy.js
@@ -1,0 +1,63 @@
+'use strict'
+
+describe('Sharing license access with a new user (external)', () => {
+  before(() => {
+    cy.tearDown()
+    cy.setUp('barebones')
+    cy.fixture('users.json').its('external').as('firstUserEmail')
+    cy.fixture('users.json').its('externalAccessSharingNew').as('secondUserEmail')
+  })
+
+  it('allows a user to grant access to a licence to new user', () => {
+    //  First user logs in
+    cy.visit(Cypress.env('externalUrl'))
+    cy.get('a[href*="/signin"]').click()
+    cy.get('@firstUserEmail').then((email) => {
+      cy.get('input#email').type(email)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    //  view and assign the licence
+    cy.get('.licence-result__column > a').contains('AT/CURR/DAILY/01').should('be.visible')
+    cy.get('#navbar-manage').contains('Add licences or give access').click()
+    cy.get('.govuk-list').contains('Give or remove access to your licence information').click()
+    cy.get('.govuk-button').contains('Give access').click()
+    cy.get('@secondUserEmail').then((email) => {
+      cy.get('input#email').type(email)
+    })
+    cy.get('#returns').check()
+    cy.get('.form > .govuk-button').click()
+
+    // First user logs out
+    cy.get('.govuk-link').contains('Return to give access').click()
+    cy.get('#signout').click()
+
+    // Second user registers using link in email received
+    cy.get('@secondUserEmail').then((email) => {
+      cy.lastNotification(email).then((body) => {
+        cy.extractNotificationLink(body, 'link', Cypress.env('externalUrl')).then((link) => {
+          cy.log(link)
+          cy.visit(link)
+        })
+
+        // let registrationUrl = body.data[0].personalisation.link
+        // registrationUrl = registrationUrl.replace(
+        //   (/^https?:\/\/[^/]+\//g).exec(registrationUrl), Cypress.env('externalUrl') + '/'
+        // )
+        // cy.log(registrationUrl)
+        // cy.visit(registrationUrl)
+
+        cy.get('input#password').type(Cypress.env('defaultPassword'))
+        cy.get('input#confirmPassword').type(Cypress.env('defaultPassword'))
+        cy.get('form').submit()
+
+        // Assert they can see the same licence
+        cy.get('.licence-result__column > a').contains('AT/CURR/DAILY/01').should('be.visible')
+
+        // Sign out
+        cy.get('#signout').click()
+      })
+    })
+  })
+})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -66,6 +66,15 @@ Cypress.Commands.add('lastNotification', (email) => {
   })
 })
 
+Cypress.Commands.add('extractNotificationLink', (body, linkType, url) => {
+  cy.log(`Extracting ${linkType} link from Notify email`)
+
+  let link = body.data[0].personalisation[linkType]
+  link = link.replace((/^https?:\/\/[^/]+\//g).exec(link), url + '/')
+
+  return cy.wrap(link)
+})
+
 Cypress.Commands.add('simulateNotifyCallback', (notificationId) => {
   cy.log('Simulating a Notify callback request')
 


### PR DESCRIPTION
This migrates 2 external tests. Both are to do with an existing user with access to a licence granting access to another.

In the first test, the other user already exists in the system. In the second the user is new, which involves an email being sent to them and the test, therefore, needing to follow the link to register.

This is the second time we've had to manipulate the body of the last notification received. We're jumping the gun on the [rule of 3](https://en.wikipedia.org/wiki/Rule_of_three_(computer_programming)) but as it was already a gnarly bit of code we using this as an excuse to clean it up.