### PR TITLE
Migrate the user returns view test

### DIFF
--- a/cypress/e2e/external/view-returns.cy.js
+++ b/cypress/e2e/external/view-returns.cy.js
@@ -1,0 +1,34 @@
+'use strict'
+
+describe('View returns (external)', () => {
+  before(() => {
+    cy.tearDown()
+    cy.setUp('barebones')
+    cy.fixture('users.json').its('external').as('userEmail')
+  })
+
+  it('login as an existing user and view returns', () => {
+    cy.visit(Cypress.env('externalUrl'))
+
+    // tap the sign in button on the welcome page
+    cy.get('a[href*="/signin"]').click()
+
+    //  Enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    //  Click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    // Select a licence to view returns and their status
+    cy.contains('AT/CURR/MONTHLY/02').click()
+    cy.get('#tab_returns').click()
+    cy.get('#returns').should('be.visible')
+    cy.get('.govuk-tag').should('be.visible').and('contain.text', 'Due')
+    cy.get('.govuk-tag').should('be.visible').and('contain.text', 'Overdue')
+    cy.get('.govuk-tag').should('be.visible').and('contain.text', 'Complete')
+    cy.get('.govuk-tag').should('be.visible').and('contain.text', 'Overdue')
+  })
+})


### PR DESCRIPTION
This change migrates the [user-returns-view test](https://github.com/DEFRA/water-abstraction-ui/blob/main/cypress/integration/external/user-returns-view.spec.js).

That's it! 😁 