### PR TITLE
Migrate user submitting returns test

### DIFF
--- a/cypress/e2e/external/returns/metered-readings-return.cy.js
+++ b/cypress/e2e/external/returns/metered-readings-return.cy.js
@@ -1,0 +1,106 @@
+'use strict'
+
+describe('Submit metered readings return (external)', () => {
+  before(() => {
+    cy.tearDown()
+    cy.setUp('barebones')
+    cy.fixture('users.json').its('external').as('userEmail')
+  })
+
+  it('login as an existing user and submit returns', () => {
+    cy.visit(Cypress.env('externalUrl'))
+
+    // tap the sign in button on the welcome page
+    cy.get('a[href*="/signin"]').click()
+
+    //  Enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    //  Click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    // Select a licence to submit returns for
+    cy.contains('AT/CURR/MONTHLY/02').click()
+    cy.get('#tab_returns').click()
+    cy.get('#returns').should('be.visible')
+
+    // Start the return journey - return reference 9999992
+    cy.get(':nth-child(1) > [scope="row"] > a').click()
+
+    // --> Have you extracted water in this period?
+    // Check validation - enter nothing
+    cy.get('form>.govuk-button').click()
+    cy.get('.govuk-list > li > a').should('have.text', 'Has any water been abstracted?')
+    // Click 'Yes' and continue
+    cy.get('input[value="false"]').check()
+    cy.get('form>.govuk-button').click()
+
+    // --> How are you reporting your figures?
+    // Check validation - enter nothing
+    cy.get('form>.govuk-button').click()
+    cy.get('.govuk-list > li > a').should('have.text', 'Select readings from one meter, or other (abstraction volumes)')
+    // Click 'Readings from a single meter' and continue
+    cy.get('input[value="oneMeter,measured"]').check()
+    cy.get('form>.govuk-button').click()
+
+    // --> Did your meter reset in this abstraction period?
+    // Check validation - enter nothing
+    cy.get('form>.govuk-button').click()
+    cy.get('.govuk-list > li > a').should('have.text', 'Has your meter reset or rolled over?')
+    // Click 'No' and continue
+    cy.get('input[value="false"]').check()
+    cy.get('form>.govuk-button').click()
+
+    // --> Which units are you using?
+    // Check validation - enter nothing
+    cy.get('form>.govuk-button').click()
+    cy.get('.govuk-list > li > a').should('have.text', 'Select a unit of measurement')
+    // Click 'Cubic metres' and continue
+    cy.get('[type="radio"]').check('m³')
+    cy.get('form>.govuk-button').click()
+
+    // --> Enter your readings exactly as they appear on your meter
+    // Check validation - enter nothing
+    cy.get('form>.govuk-button').click()
+    cy.get('.govuk-list > li > a').should('have.text', 'Enter a meter start reading')
+    // Check validation - enter negative numbers
+    cy.get('input[name="startReading"]').type('-1')
+    cy.get('input[name="2021-01-01_2021-01-31"]').type('10')
+    cy.get('input[name="2021-02-01_2021-02-28"]').type('20')
+    cy.get('form>.govuk-button').click()
+    cy.get('.govuk-list > li > a').should('have.text', 'This number should be positive')
+    // Check validation - enter non-incrementing numbers
+    cy.get('input[name="startReading"]').clear().type('10')
+    cy.get('input[name="2021-01-01_2021-01-31"]').clear().type('0')
+    cy.get('input[name="2021-02-01_2021-02-28"]').clear().type('20')
+    cy.get('form>.govuk-button').click()
+    cy.get('.govuk-list > li > a').should('have.text', 'Each meter reading should be higher than or equal to the last')
+    // Enter valid readings and continue
+    cy.get('input[name="startReading"]').clear().type('0')
+    cy.get('input[name="2021-01-01_2021-01-31"]').clear().type('10')
+    cy.get('input[name="2021-02-01_2021-02-28"]').clear().type('20')
+    cy.get('form>.govuk-button').click()
+
+    // --> Your current meter details
+    // Check validation - enter nothing
+    cy.get('form>.govuk-button').click()
+    cy.get('.govuk-list > li > a').should('have.text', 'Enter the make of your meter')
+    // Enter valid details and continue
+    cy.get('input[name="manufacturer"]').type('Test Water Meter')
+    cy.get('input[name="serialNumber"]').type('Test serial number')
+    cy.get('#isMultiplier').check()
+    cy.get('form>.govuk-button').click()
+
+    // Confirm and submit the details
+    cy.get('h2.govuk-heading-l').should('contain.text', 'Confirm your return')
+    // Check the calculated total
+    cy.get(':nth-child(3) > strong').should('contain.text', '200')
+    cy.get('form>.govuk-button').click()
+
+    // Confirm Return submitted
+    cy.get('.panel__title').should('contain.text', 'Return submitted')
+  })
+})

--- a/cypress/e2e/external/returns/null-return.cy.js
+++ b/cypress/e2e/external/returns/null-return.cy.js
@@ -1,0 +1,45 @@
+'use strict'
+
+describe('Submit null return (external)', () => {
+  before(() => {
+    cy.tearDown()
+    cy.setUp('barebones')
+    cy.fixture('users.json').its('external').as('userEmail')
+  })
+
+  it('login as an existing user and submit returns', () => {
+    cy.visit(Cypress.env('externalUrl'))
+
+    // tap the sign in button on the welcome page
+    cy.get('a[href*="/signin"]').click()
+
+    //  Enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    //  Click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    // Select a licence to submit returns for
+    cy.contains('AT/CURR/MONTHLY/02').click()
+    cy.get('#tab_returns').click()
+    cy.get('#returns').should('be.visible')
+
+    // Start the return journey - return reference 9999990
+    cy.get(':nth-child(4) > [scope="row"] > a').click()
+
+    // --> Have you extracted water in this period?
+    // Click 'No' and continue
+    cy.get('input[value="true"]').check()
+    cy.get('form>.govuk-button').click()
+
+    // Confirm and submit the details
+    cy.get('h2.govuk-heading-l').should('contain.text', 'Nil return')
+    cy.get('form>.govuk-button').click()
+
+    // Confirm Return submitted
+    cy.get('.panel__title').should('contain.text', 'Return submitted')
+  })
+})

--- a/cypress/e2e/external/returns/volumes-gallons-return.cy.js
+++ b/cypress/e2e/external/returns/volumes-gallons-return.cy.js
@@ -1,0 +1,75 @@
+'use strict'
+
+describe('Submit volumes in gallons return (external)', () => {
+  before(() => {
+    cy.tearDown()
+    cy.setUp('barebones')
+    cy.fixture('users.json').its('external').as('userEmail')
+  })
+
+  it('login as an existing user and submit returns', () => {
+    cy.visit(Cypress.env('externalUrl'))
+
+    // tap the sign in button on the welcome page
+    cy.get('a[href*="/signin"]').click()
+
+    //  Enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    //  Click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    // Select a licence to submit returns for
+    cy.contains('AT/CURR/MONTHLY/02').click()
+    cy.get('#tab_returns').click()
+    cy.get('#returns').should('be.visible')
+
+    // Start the return journey - return reference 9999991
+    cy.get(':nth-child(2) > [scope="row"] > a').click()
+
+    // --> Have you extracted water in this period?
+    // Click 'Yes' and continue
+    cy.get('input[value="false"]').check()
+    cy.get('form>.govuk-button').click()
+
+    // --> How are you reporting your figures?
+    // Click 'Volumes from one or more meters' and continue
+    cy.get('input[value="abstractionVolumes,measured"]').check()
+    cy.get('form>.govuk-button').click()
+
+    // --> Which units are you using?
+    // Click 'Gallons' and continue
+    cy.get('input[value="gal"]').check()
+    cy.get('form>.govuk-button').click()
+
+    // --> Your abstraction volumes
+    // Enter valid volumes with some gaps and continue
+    cy.get('input[name="2020-01-01_2020-01-31"]').type('1')
+    cy.get('input[name="2020-02-01_2020-02-29"]').type('1')
+    cy.get('input[name="2020-03-01_2020-03-31"]').type('1')
+    cy.get('input[name="2020-04-01_2020-04-30"]').type('1')
+    cy.get('input[name="2020-05-01_2020-05-31"]').type('1')
+    cy.get('input[name="2020-08-01_2020-08-31"]').type('1')
+    cy.get('input[name="2020-10-01_2020-10-31"]').type('1')
+    cy.get('input[name="2020-12-01_2020-12-31"]').type('1')
+    cy.get('form>.govuk-button').click()
+
+    // --> Your current meter details
+    cy.get('input[name="manufacturer"]').type('Test Water Meter')
+    cy.get('input[name="serialNumber"]').type('Test serial number')
+    cy.get('#isMultiplier').check()
+    cy.get('form>.govuk-button').click()
+
+    // Confirm and submit the details
+    cy.get('h2.govuk-heading-l').should('contain.text', 'Confirm your return')
+    // Check the calculated total
+    cy.get(':nth-child(3) > strong').should('contain.text', '0.036')
+    cy.get('form>.govuk-button').click()
+
+    // Confirm Return submitted
+    cy.get('.panel__title').should('contain.text', 'Return submitted')
+  })
+})

--- a/cypress/e2e/external/returns/volumes-litres-return.cy.js
+++ b/cypress/e2e/external/returns/volumes-litres-return.cy.js
@@ -1,0 +1,96 @@
+'use strict'
+
+describe('Submit volumes in litres return (external)', () => {
+  before(() => {
+    cy.tearDown()
+    cy.setUp('barebones')
+    cy.fixture('users.json').its('external').as('userEmail')
+  })
+
+  it('login as an existing user and submit returns', () => {
+    cy.visit(Cypress.env('externalUrl'))
+
+    // tap the sign in button on the welcome page
+    cy.get('a[href*="/signin"]').click()
+
+    //  Enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    //  Click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    // Select a licence to submit returns for
+    cy.contains('AT/CURR/MONTHLY/02').click()
+    cy.get('#tab_returns').click()
+    cy.get('#returns').should('be.visible')
+
+    // Start the return journey - return reference 9999991
+    cy.get(':nth-child(2) > [scope="row"] > a').click()
+
+    // --> Have you extracted water in this period?
+    // Click 'Yes' and continue
+    cy.get('input[value="false"]').check()
+    cy.get('form>.govuk-button').click()
+
+    // --> How are you reporting your figures?
+    // Click 'Volumes from one or more meters' and continue
+    cy.get('input[value="abstractionVolumes,measured"]').check()
+    cy.get('form>.govuk-button').click()
+
+    // --> Which units are you using?
+    // Click 'Litres' and continue
+    cy.get('input[value="l"]').check()
+    cy.get('form>.govuk-button').click()
+
+    // --> Your abstraction volumes
+    // Check validation - enter negative numbers
+    cy.get('input[name="2020-01-01_2020-01-31"]').type('-1000')
+    cy.get('input[name="2020-02-01_2020-02-29"]').type('-1000')
+    cy.get('input[name="2020-03-01_2020-03-31"]').type('-1000')
+    cy.get('input[name="2020-04-01_2020-04-30"]').type('-1000')
+    cy.get('input[name="2020-05-01_2020-05-31"]').type('-1000')
+    cy.get('input[name="2020-06-01_2020-06-30"]').type('-1000')
+    cy.get('input[name="2020-07-01_2020-07-31"]').type('-1000')
+    cy.get('input[name="2020-08-01_2020-08-31"]').type('-1000')
+    cy.get('input[name="2020-09-01_2020-09-30"]').type('-1000')
+    cy.get('input[name="2020-10-01_2020-10-31"]').type('-1000')
+    cy.get('input[name="2020-11-01_2020-11-30"]').type('-1000')
+    cy.get('input[name="2020-12-01_2020-12-31"]').type('-1000')
+    cy.get('form>.govuk-button').click()
+    cy.get('#error-summary-title').should('contain.text', 'There is a problem')
+    cy.get('.govuk-error-summary__list').children().should('have.length', '12')
+    cy.get('.govuk-error-summary__list').children(0).should('contain.text', 'Enter an amount of 0 or above')
+    // Enter valid volumes and continue
+    cy.get('input[name="2020-01-01_2020-01-31"]').clear().type('1000')
+    cy.get('input[name="2020-02-01_2020-02-29"]').clear().type('1000')
+    cy.get('input[name="2020-03-01_2020-03-31"]').clear().type('1000')
+    cy.get('input[name="2020-04-01_2020-04-30"]').clear().type('1000')
+    cy.get('input[name="2020-05-01_2020-05-31"]').clear().type('1000')
+    cy.get('input[name="2020-06-01_2020-06-30"]').clear().type('1000')
+    cy.get('input[name="2020-07-01_2020-07-31"]').clear().type('1000')
+    cy.get('input[name="2020-08-01_2020-08-31"]').clear().type('1000')
+    cy.get('input[name="2020-09-01_2020-09-30"]').clear().type('1000')
+    cy.get('input[name="2020-10-01_2020-10-31"]').clear().type('1000')
+    cy.get('input[name="2020-11-01_2020-11-30"]').clear().type('1000')
+    cy.get('input[name="2020-12-01_2020-12-31"]').clear().type('1000')
+    cy.get('form>.govuk-button').click()
+
+    // --> Your current meter details
+    cy.get('input[name="manufacturer"]').type('Test Water Meter')
+    cy.get('input[name="serialNumber"]').type('Test serial number')
+    cy.get('#isMultiplier').check()
+    cy.get('form>.govuk-button').click()
+
+    // Confirm and submit the details
+    cy.get('h2.govuk-heading-l').should('contain.text', 'Confirm your return')
+    // Check the calculated total
+    cy.get(':nth-child(3) > strong').should('contain.text', '12')
+    cy.get('form>.govuk-button').click()
+
+    // Confirm Return submitted
+    cy.get('.panel__title').should('contain.text', 'Return submitted')
+  })
+})

--- a/cypress/e2e/external/returns/volumes-megalitres-return.cy.js
+++ b/cypress/e2e/external/returns/volumes-megalitres-return.cy.js
@@ -1,0 +1,75 @@
+'use strict'
+
+describe('Submit volumes in megalitres return (external)', () => {
+  before(() => {
+    cy.tearDown()
+    cy.setUp('barebones')
+    cy.fixture('users.json').its('external').as('userEmail')
+  })
+
+  it('login as an existing user and submit returns', () => {
+    cy.visit(Cypress.env('externalUrl'))
+
+    // tap the sign in button on the welcome page
+    cy.get('a[href*="/signin"]').click()
+
+    //  Enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    //  Click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    // Select a licence to submit returns for
+    cy.contains('AT/CURR/MONTHLY/02').click()
+    cy.get('#tab_returns').click()
+    cy.get('#returns').should('be.visible')
+
+    // Start the return journey - return reference 9999991
+    cy.get(':nth-child(2) > [scope="row"] > a').click()
+
+    // --> Have you extracted water in this period?
+    // Click 'Yes' and continue
+    cy.get('input[value="false"]').check()
+    cy.get('form>.govuk-button').click()
+
+    // --> How are you reporting your figures?
+    // Click 'Volumes from one or more meters' and continue
+    cy.get('input[value="abstractionVolumes,measured"]').check()
+    cy.get('form>.govuk-button').click()
+
+    // --> Which units are you using?
+    // Click 'Megalitres' and continue
+    cy.get('[value="Ml"]').check()
+    cy.get('form>.govuk-button').click()
+
+    // --> Your abstraction volumes
+    // Enter valid volumes with some gaps and continue
+    cy.get('input[name="2020-01-01_2020-01-31"]').type('1')
+    cy.get('input[name="2020-02-01_2020-02-29"]').type('1')
+    cy.get('input[name="2020-03-01_2020-03-31"]').type('1')
+    cy.get('input[name="2020-04-01_2020-04-30"]').type('1')
+    cy.get('input[name="2020-05-01_2020-05-31"]').type('1')
+    cy.get('input[name="2020-08-01_2020-08-31"]').type('1')
+    cy.get('input[name="2020-10-01_2020-10-31"]').type('1')
+    cy.get('input[name="2020-12-01_2020-12-31"]').type('1')
+    cy.get('form>.govuk-button').click()
+
+    // --> Your current meter details
+    cy.get('input[name="manufacturer"]').type('Test Water Meter')
+    cy.get('input[name="serialNumber"]').type('Test serial number')
+    cy.get('#isMultiplier').check()
+    cy.get('form>.govuk-button').click()
+
+    // Confirm and submit the details
+    cy.get('h2.govuk-heading-l').should('contain.text', 'Confirm your return')
+    // Check the calculated total
+    cy.get(':nth-child(3) > strong').should('contain.text', '8,000')
+    cy.get('form>.govuk-button').click()
+
+    // Confirm Return submitted
+    cy.get('.panel__title').should('contain.text', 'Return submitted')
+  })
+})


### PR DESCRIPTION
This migrates [user-submitting-returns.spec.js](https://github.com/DEFRA/water-abstraction-ui/blob/main/cypress/integration/external/user-submitting-returns.spec.js) in the old repo.

When we checked the existing spec we found it contained 5 tests!

- submit a return metered readings return
- submit a null return
- submit a return by volumes
- submit returns measured in gallons
- submit returns measured in megalitres

To make that clearer we've split them as part of the migration.