### PR TITLE
Migrate address entry tests

### DIFF
--- a/cypress/e2e/internal/address-entry/journey.cy.js
+++ b/cypress/e2e/internal/address-entry/journey.cy.js
@@ -1,0 +1,103 @@
+'use strict'
+
+describe('Address lookup journey (internal)', () => {
+  before(() => {
+    cy.tearDown()
+    cy.setUp('bulk-return')
+    cy.fixture('users.json').its('billingAndData').as('userEmail')
+  })
+
+  it('does stuff', () => {
+    cy.visit('/')
+
+    //  Enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    //  Click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    //  Assert the user signed in and we're on the search page
+    cy.contains('Search')
+
+    // Navigate to the paper returns flow. We'll use it's address entry screens to test the address lookup and entry
+    // functionality
+    cy.get('#navbar-notifications').click()
+    cy.get('a[href="/returns-notifications/forms"]').click()
+
+    // Select a licence to generate paper returns for
+    cy.get('#licenceNumbers').type('AT/CURR/MONTHLY/02')
+    cy.get('button.govuk-button').click()
+
+    // MANUAL ADDRESS ENTRY
+    // Select the option to change the address then the option to setup a one-time address - manual address entry
+    cy.get('[href*="/select-address"]').click()
+    cy.get('#selectedRole-3').check()
+    cy.get('button.govuk-button').click()
+
+    // Who should receive the form?
+    cy.get('input[name="fullName"]').type('Manual Address')
+    cy.get('button.govuk-button').click()
+
+    // Enter the UK postcode
+    cy.get('input[name="postcode"]').type('EX1 1QA')
+    cy.get('button.govuk-button').click()
+
+    // Opt to enter the address manually
+    cy.get('a.govuk-link').eq(4).should('contain', 'I cannot find the address in the list').click()
+
+    // Enter the address
+    cy.get('input[name="addressLine1"]').type('Sub-building')
+    cy.get('input[name="addressLine2"]').type('Building number')
+    cy.get('input[name="addressLine3"]').type('Building Name')
+    cy.get('input[name="addressLine4"]').type('Street Name')
+    cy.get('input[name="town"]').type('Test Town')
+    cy.get('input[name="county"]').type('RainingAllTheTimeShire')
+    cy.get('select[name="country"]').select('United Kingdom')
+    cy.get('button.govuk-button').click()
+
+    // ADDRESS LOOKUP
+    // Select the option to change the address then the option to setup a one-time address - address lookup
+    cy.get('[href*="/select-address"]').click()
+    cy.get('#selectedRole-3').check()
+    cy.get('button.govuk-button').click()
+
+    // Who should receive the form?
+    cy.get('input[name="fullName"]').type('Lookup Address')
+    cy.get('button.govuk-button').click()
+
+    // Enter the UK postcode
+    cy.get('input[name="postcode"]').type('BS1 5AH')
+    cy.get('button.govuk-button').click()
+
+    // Select the address
+    cy.get('.govuk-select').select('340116')
+    cy.get('button.govuk-button').click()
+
+    // OUTSIDE UK
+    // Select the option to change the address then the option to setup a one-time address - outside UK
+    cy.get('[href*="/select-address"]').click()
+    cy.get('#selectedRole-3').check()
+    cy.get('button.govuk-button').click()
+
+    // Who should receive the form?
+    cy.get('input[name="fullName"]').type('Outside United')
+    cy.get('button.govuk-button').click()
+
+    // Enter the UK postcode
+    cy.get("a[href*='manual-entry']").click()
+
+    // Enter the address
+    cy.get('input[name="addressLine1"]').type('Sub-building')
+    cy.get('input[name="addressLine2"]').type('Building number')
+    cy.get('input[name="addressLine3"]').type('Building Name')
+    cy.get('input[name="addressLine4"]').type('Street Name')
+    cy.get('input[name="town"]').type('Test Town')
+    cy.get('input[name="county"]').type('RainingAllTheTimeShire')
+    cy.get('input[name="postcode"]').type('RA1 N')
+    cy.get('select[name="country"]').select('Croatia')
+    cy.get('button.govuk-button').click()
+  })
+})


### PR DESCRIPTION
This is the remainder of the migration of the legacy acceptance test `paper-forms-flow.ci.spec`.

Though the test is ostensibly about sending paper return forms for specified licences within it is an exhaustive check of the address entry functionality.

To make things easier to review and maintain in the future we split the test up. [Migrate paper return form tests](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/34) covered the paper return forms. This change migrates all the address entry tests.