### PR TITLE
Fix any issues found when running the tests

### DIFF
--- a/cypress/e2e/external/bulk-upload.cy.js
+++ b/cypress/e2e/external/bulk-upload.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe.skip('Bulk upload returns (external)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('bulk-return')
     cy.fixture('users.json').its('external').as('userEmail')

--- a/cypress/e2e/external/licence-alias-naming.cy.js
+++ b/cypress/e2e/external/licence-alias-naming.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('View Licences as external user', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
     cy.fixture('users.json').its('external').as('userEmail')

--- a/cypress/e2e/external/login/journey.cy.js
+++ b/cypress/e2e/external/login/journey.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('Login and log out (external)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
     cy.fixture('users.json').its('external').as('userEmail')

--- a/cypress/e2e/external/login/validation.cy.js
+++ b/cypress/e2e/external/login/validation.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('Login validation (external)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.fixture('users.json').its('external').as('userEmail')
   })
 

--- a/cypress/e2e/external/notify-callback.cy.js
+++ b/cypress/e2e/external/notify-callback.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('Notify callback endpoint', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('notify-mock-notification')
     cy.fixture('users.json').its('notifyCallbackTestEmail').as('userEmail')

--- a/cypress/e2e/external/registration/journey.cy.js
+++ b/cypress/e2e/external/registration/journey.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('User registration (external)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
     cy.fixture('users.json').its('externalNew').as('userEmail')

--- a/cypress/e2e/external/registration/validation.cy.js
+++ b/cypress/e2e/external/registration/validation.cy.js
@@ -1,12 +1,9 @@
 'use strict'
 
 describe('User registration validation (external)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
-  })
-
-  beforeEach(() => {
     cy.fixture('users.json').its('externalNew').as('userEmail')
   })
 

--- a/cypress/e2e/external/reset-password/journey.cy.js
+++ b/cypress/e2e/external/reset-password/journey.cy.js
@@ -1,12 +1,9 @@
 'use strict'
 
 describe('Reset password journey (external)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
-  })
-
-  beforeEach(() => {
     cy.fixture('users.json').its('external').as('userEmail')
   })
 

--- a/cypress/e2e/external/returns/metered-readings-return.cy.js
+++ b/cypress/e2e/external/returns/metered-readings-return.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('Submit metered readings return (external)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
     cy.fixture('users.json').its('external').as('userEmail')

--- a/cypress/e2e/external/returns/null-return.cy.js
+++ b/cypress/e2e/external/returns/null-return.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('Submit null return (external)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
     cy.fixture('users.json').its('external').as('userEmail')

--- a/cypress/e2e/external/returns/volumes-gallons-return.cy.js
+++ b/cypress/e2e/external/returns/volumes-gallons-return.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('Submit volumes in gallons return (external)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
     cy.fixture('users.json').its('external').as('userEmail')

--- a/cypress/e2e/external/returns/volumes-litres-return.cy.js
+++ b/cypress/e2e/external/returns/volumes-litres-return.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('Submit volumes in litres return (external)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
     cy.fixture('users.json').its('external').as('userEmail')

--- a/cypress/e2e/external/returns/volumes-megalitres-return.cy.js
+++ b/cypress/e2e/external/returns/volumes-megalitres-return.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('Submit volumes in megalitres return (external)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
     cy.fixture('users.json').its('external').as('userEmail')

--- a/cypress/e2e/external/sharing-access-with-existing-user.cy.js
+++ b/cypress/e2e/external/sharing-access-with-existing-user.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('Sharing license access with another user (external)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
     cy.fixture('users.json').its('external').as('firstUserEmail')

--- a/cypress/e2e/external/sharing-access-with-new-user.cy.js
+++ b/cypress/e2e/external/sharing-access-with-new-user.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('Sharing license access with a new user (external)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
     cy.fixture('users.json').its('external').as('firstUserEmail')

--- a/cypress/e2e/external/view-licences.cy.js
+++ b/cypress/e2e/external/view-licences.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('View returns (external)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
     cy.fixture('users.json').its('external').as('userEmail')

--- a/cypress/e2e/external/view-returns.cy.js
+++ b/cypress/e2e/external/view-returns.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('View returns (external)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
     cy.fixture('users.json').its('external').as('userEmail')

--- a/cypress/e2e/internal/abstraction-alerts/journey.cy.js
+++ b/cypress/e2e/internal/abstraction-alerts/journey.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('mBOD abstraction alert journey (internal)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
     cy.fixture('users.json').its('environmentOfficer').as('userEmail')
@@ -69,7 +69,9 @@ describe('mBOD abstraction alert journey (internal)', () => {
     cy.get('.govuk-radios__input[value="true"]').click()
     cy.get('.govuk-button').contains('Continue').click()
 
-    cy.get('.govuk-button').contains('Confirm and send').click()
+    // spinner page appears here. Because this takes some time we need to amend the timeout in the next command
+    cy.get('h1').contains('Processing notifications')
+    cy.get('.govuk-button').contains('Confirm and send', { timeout: 20000 }).click()
 
     // Return to the monitoring station
     cy.get('.govuk-link').contains('Return to monitoring station').click()

--- a/cypress/e2e/internal/abstraction-alerts/validation.cy.js
+++ b/cypress/e2e/internal/abstraction-alerts/validation.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('mBOD abstraction alert validation (internal)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
     cy.fixture('users.json').its('environmentOfficer').as('userEmail')
@@ -112,6 +112,7 @@ describe('mBOD abstraction alert validation (internal)', () => {
     cy.get('h1').contains('Processing notifications')
 
     // Check the alert for each licence and send
+    // spinner page was the previous page. Because this takes some time we need to amend the timeout in the next command
     cy.get('table > caption', { timeout: 30000 }).contains("You're sending this alert for 1 licence.")
 
     cy.get('.govuk-button').contains('Confirm and send').click()

--- a/cypress/e2e/internal/address-entry/journey.cy.js
+++ b/cypress/e2e/internal/address-entry/journey.cy.js
@@ -1,13 +1,13 @@
 'use strict'
 
 describe('Address lookup journey (internal)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('bulk-return')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
   })
 
-  it('does stuff', () => {
+  it('allows addresses to be entered manually or via the lookup', () => {
     cy.visit('/')
 
     //  Enter the user name and Password
@@ -73,6 +73,10 @@ describe('Address lookup journey (internal)', () => {
     cy.get('button.govuk-button').click()
 
     // Select the address
+    // we have to wait a second. Both the lookup and selecting the address result in a call to the address facade which
+    // has rate monitoring protection. Because we're automating the calls, they happen to quickly so the facade rejects
+    // the second call. Hence we need to wait a second.
+    cy.wait(1000)
     cy.get('.govuk-select').select('340116')
     cy.get('button.govuk-button').click()
 

--- a/cypress/e2e/internal/address-entry/validation.cy.js
+++ b/cypress/e2e/internal/address-entry/validation.cy.js
@@ -1,13 +1,13 @@
 'use strict'
 
 describe('Address lookup validation (internal)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('bulk-return')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
   })
 
-  it('does stuff', () => {
+  it('allows addresses to be entered manually or via the lookup', () => {
     cy.visit('/')
 
     //  Enter the user name and Password
@@ -60,6 +60,10 @@ describe('Address lookup validation (internal)', () => {
     cy.get('button.govuk-button').click()
 
     // Select the address
+    // we have to wait a second. Both the lookup and selecting the address result in a call to the address facade which
+    // has rate monitoring protection. Because we're automating the calls, they happen to quickly so the facade rejects
+    // the second call. Hence we need to wait a second.
+    cy.wait(1000)
     // click continue without selecting an address
     cy.get('button.govuk-button').click()
     cy.get('.govuk-error-summary__title').should('contain', 'There is a problem')
@@ -105,7 +109,7 @@ describe('Address lookup validation (internal)', () => {
     cy.get('button.govuk-button').click()
 
     // Who should receive the form?
-    cy.get('input[name="fullName"]').type('Lookup Address')
+    cy.get('input[name="fullName"]').type('Address Lookup')
     cy.get('button.govuk-button').click()
 
     // Enter the UK postcode
@@ -113,6 +117,10 @@ describe('Address lookup validation (internal)', () => {
     cy.get('button.govuk-button').click()
 
     // Select the address
+    // we have to wait a second. Both the lookup and selecting the address result in a call to the address facade which
+    // has rate monitoring protection. Because we're automating the calls, they happen to quickly so the facade rejects
+    // the second call. Hence we need to wait a second.
+    cy.wait(1000)
     cy.get('.govuk-select').select('340116')
     cy.get('button.govuk-button').click()
 
@@ -151,7 +159,7 @@ describe('Address lookup validation (internal)', () => {
     cy.get('button.govuk-button').click()
 
     // Check returns details
-    cy.get('div.govuk-summary-list__row').eq(2).children(1).contains('Lookup Address')
+    cy.get('div.govuk-summary-list__row').eq(2).children(1).contains('Outside United')
     cy.get('div.govuk-summary-list__row').eq(2).children(1).contains('Sub-building')
     cy.get('div.govuk-summary-list__row').eq(2).children(1).contains('Building number')
     cy.get('div.govuk-summary-list__row').eq(2).children(1).contains('Building Name')

--- a/cypress/e2e/internal/create-user.cy.js
+++ b/cypress/e2e/internal/create-user.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('Creating a user (internal)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
     cy.fixture('users.json').its('super').as('userEmail')

--- a/cypress/e2e/internal/login-logout.cy.js
+++ b/cypress/e2e/internal/login-logout.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('Login and log out (internal)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
     cy.fixture('users.json').its('billingAndData').as('userEmail')

--- a/cypress/e2e/internal/paper-returns/journey.cy.js
+++ b/cypress/e2e/internal/paper-returns/journey.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('Paper returns journey (internal)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('bulk-return')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
@@ -39,6 +39,6 @@ describe('Paper returns journey (internal)', () => {
     cy.get('button.govuk-button').contains('Send paper forms').click()
 
     // Paper return forms sent
-    cy.get('.govuk-panel__title', { timeout: 10000 }).contains('Paper return forms sent')
+    cy.get('.govuk-panel__title', { timeout: 15000 }).contains('Paper return forms sent')
   })
 })

--- a/cypress/e2e/internal/paper-returns/validation.cy.js
+++ b/cypress/e2e/internal/paper-returns/validation.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('Paper returns validation (internal)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('bulk-return')
     cy.fixture('users.json').its('billingAndData').as('userEmail')

--- a/cypress/e2e/internal/reset-password/journey.cy.js
+++ b/cypress/e2e/internal/reset-password/journey.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('Reset password journey (internal)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
     cy.fixture('users.json').its('psc').as('userEmail')

--- a/cypress/e2e/internal/search-for-licence.cy.js
+++ b/cypress/e2e/internal/search-for-licence.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe('Search for a licence (internal)', () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('billing-data')
     cy.fixture('users.json').its('super').as('userEmail')

--- a/cypress/e2e/internal/view-licence-contacts.cy.js
+++ b/cypress/e2e/internal/view-licence-contacts.cy.js
@@ -1,7 +1,7 @@
 'use strict'
 
 describe("View a licence's contacts (internal)", () => {
-  before(() => {
+  beforeEach(() => {
     cy.tearDown()
     cy.setUp('billing-data')
     cy.fixture('users.json').its('super').as('userEmail')


### PR DESCRIPTION
We have recently migrated a series of the legacy tests

- [Migrate abstraction alert tests](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/33)
- [Migrate paper return form tests](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/34)
- [Migrate address entry tests](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/36)

At the time though we were unable to run them. Now we can this change resolves any issues found. We also spotted we were using a `before()` rather than `beforeEach()` in some places. We favour a `beforeEach()` because what is in there does need to be done before each test. One day we hope to only need a `before()` block!