### PR TITLE
Migrate returns tests

### DIFF
--- a/cypress/e2e/internal/returns/send-invite.cy.js
+++ b/cypress/e2e/internal/returns/send-invite.cy.js
@@ -1,0 +1,46 @@
+'use strict'
+
+describe('Send returns invite to customer (internal)', () => {
+  beforeEach(() => {
+    cy.tearDown()
+    cy.setUp('barebones')
+    cy.fixture('users.json').its('billingAndData').as('userEmail')
+  })
+
+  it('invites a customer to submit returns', () => {
+    cy.visit('/')
+
+    // enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    // click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    // assert the user signed in and we're on the search page
+    cy.contains('Search')
+
+    // navigate to the invitations flow
+    cy.get('#navbar-notifications').click()
+    cy.get('a[href="/returns-notifications/invitations"]').click()
+
+    // Send returns invitations
+    // just click continue. The page is for submitting licences to be excluded which this test doesn't cover
+    cy.get('form > .govuk-button').click()
+
+    // Send returns invitations
+    // spinner page appears here. Because this takes some time we need to amend the timeout in the next command
+    cy.get('h1').contains('Send returns invitations')
+    cy.get('.govuk-button').contains('Send', { timeout: 20000 }).click()
+
+    // Return invitations sent
+    cy.get('.govuk-panel__title').should('contain', 'Return invitations sent')
+    cy.get('p > a').contains('View report').should('be.visible').click()
+
+    // Returns: invitation
+    // it can take some time to generate the report hence the extra timeout
+    cy.get('h1').contains('Notification report', { timeout: 20000 })
+  })
+})

--- a/cypress/e2e/internal/returns/send-reminder.cy.js
+++ b/cypress/e2e/internal/returns/send-reminder.cy.js
@@ -1,0 +1,46 @@
+'use strict'
+
+describe('Send returns reminder to customer (internal)', () => {
+  beforeEach(() => {
+    cy.tearDown()
+    cy.setUp('barebones')
+    cy.fixture('users.json').its('billingAndData').as('userEmail')
+  })
+
+  it('reminds a customer to submit returns', () => {
+    cy.visit('/')
+
+    // enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    // click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    // assert the user signed in and we're on the search page
+    cy.contains('Search')
+
+    // navigate to the reminders flow
+    cy.get('#navbar-notifications').click()
+    cy.get('a[href="/returns-notifications/reminders"]').click()
+
+    // Send returns reminders
+    // just click continue. The page is for submitting licences to be excluded which this test doesn't cover
+    cy.get('form > .govuk-button').click()
+
+    // Send returns reminders
+    // spinner page appears here. Because this takes some time we need to amend the timeout in the next command
+    cy.get('h1').contains('Send returns reminders')
+    cy.get('.govuk-button').contains('Send', { timeout: 40000 }).click()
+
+    // Return reminders sent
+    cy.get('.govuk-panel__title').should('contain', 'Return reminders sent')
+    cy.get('p > a').contains('View report').should('be.visible').click()
+
+    // Returns: reminder
+    // it can take some time to generate the report hence the extra timeout
+    cy.get('h1').contains('Notification report', { timeout: 40000 })
+  })
+})

--- a/cypress/e2e/internal/returns/submit.cy.js
+++ b/cypress/e2e/internal/returns/submit.cy.js
@@ -1,0 +1,66 @@
+'use strict'
+
+describe('Submit return (internal)', () => {
+  beforeEach(() => {
+    cy.tearDown()
+    cy.setUp('barebones')
+    cy.fixture('users.json').its('billingAndData').as('userEmail')
+  })
+
+  it('submit an overdue return for a licence from the returns tab', () => {
+    cy.visit('/')
+
+    // enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    // click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    // assert the user signed in and we're on the search page
+    cy.contains('Search')
+
+    // search for a licence
+    cy.get('#query').type('AT/CURR/MONTHLY/02')
+    cy.get('.search__button').click()
+    cy.get('.govuk-table__row').contains('AT/CURR/MONTHLY/02').click()
+
+    // confirm we are on the licence page and select returns tab
+    cy.contains('AT/CURR/MONTHLY/02')
+    cy.get('#tab_returns').click()
+
+    // confirm we are on the tab page
+    cy.get('#returns > .govuk-heading-l').contains('Returns')
+
+    // confirm we see the overdue return
+    cy.get('section#returns > .govuk-table > .govuk-table__body').within(() => {
+      cy.get('.govuk-table__row:nth-child(5)').should('be.visible').and('contain.text', '9999990')
+      cy.get('.govuk-table__row:nth-child(5)').should('be.visible').and('contain.text', 'Overdue')
+
+      cy.get('.govuk-table__row:nth-child(5) a').contains('9999990').click()
+    })
+
+    // What do you want to do with this return?
+    // select record receipt
+    cy.get('#action-2').check()
+    cy.get('form > .govuk-button').click()
+
+    // When was the return received?
+    // leave defaulted current date
+    cy.get('form > .govuk-button').click()
+
+    // Return received
+    cy.get('.panel').contains('Return received Licence number AT/CURR/MONTHLY/02').should('be.visible')
+
+    // View returns for the licence (this is a different view)
+    cy.get('p > a').contains('View returns for AT/CURR/MONTHLY/02').should('be.visible').click()
+
+    // confirm we see the received return
+    cy.get('.govuk-table > .govuk-table__body').within(() => {
+      cy.get('.govuk-table__row:nth-child(5)').should('be.visible').and('contain.text', 'January 2019 to December 2019')
+      cy.get('.govuk-table__row:nth-child(5)').should('be.visible').and('contain.text', 'Received')
+    })
+  })
+})

--- a/cypress/e2e/internal/returns/view-status.cy.js
+++ b/cypress/e2e/internal/returns/view-status.cy.js
@@ -1,0 +1,55 @@
+'use strict'
+
+describe('View returns and their status (internal)', () => {
+  beforeEach(() => {
+    cy.tearDown()
+    cy.setUp('barebones')
+    cy.fixture('users.json').its('billingAndData').as('userEmail')
+  })
+
+  it('lists the returns for a licence and their status', () => {
+    cy.visit('/')
+
+    // enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    // click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    // assert the user signed in and we're on the search page
+    cy.contains('Search')
+
+    // search for a licence
+    cy.get('#query').type('AT/CURR/MONTHLY/02')
+    cy.get('.search__button').click()
+    cy.get('.govuk-table__row').contains('AT/CURR/MONTHLY/02').click()
+
+    // confirm we are on the licence page and select returns tab
+    cy.contains('AT/CURR/MONTHLY/02')
+    cy.get('#tab_returns').click()
+
+    // confirm we are on the tab page
+    cy.get('#returns > .govuk-heading-l').contains('Returns')
+
+    // confirm we see the expected returns and their statuses
+    cy.get('section#returns > .govuk-table > .govuk-table__body').within(() => {
+      cy.get('.govuk-table__row:nth-child(1)').should('be.visible').and('contain.text', '9999992')
+      cy.get('.govuk-table__row:nth-child(1)').should('be.visible').and('contain.text', 'Due')
+
+      cy.get('.govuk-table__row:nth-child(2)').should('be.visible').and('contain.text', '9999993')
+      cy.get('.govuk-table__row:nth-child(2)').should('be.visible').and('contain.text', 'Void')
+
+      cy.get('.govuk-table__row:nth-child(3)').should('be.visible').and('contain.text', '9999991')
+      cy.get('.govuk-table__row:nth-child(3)').should('be.visible').and('contain.text', 'Overdue')
+
+      cy.get('.govuk-table__row:nth-child(4)').should('be.visible').and('contain.text', '9999992')
+      cy.get('.govuk-table__row:nth-child(4)').should('be.visible').and('contain.text', 'Complete')
+
+      cy.get('.govuk-table__row:nth-child(5)').should('be.visible').and('contain.text', '9999990')
+      cy.get('.govuk-table__row:nth-child(5)').should('be.visible').and('contain.text', 'Overdue')
+    })
+  })
+})


### PR DESCRIPTION
This change migrates the legacy returns tests to this project. The legacy tests were

- returns/invite-licence-holders-submit-returns.spec.js
- returns/remind-licence-holders-submit-returns.spec.js
- returns/returns-status-view.spec.js
- returns/update-view-returns-status-of-a-licence.spec.js