### PR TITLE
Migrate licence agreement tests

### DIFF
--- a/cypress/e2e/internal/licence-agreements/delete-licence-agreement.cy.js
+++ b/cypress/e2e/internal/licence-agreements/delete-licence-agreement.cy.js
@@ -1,0 +1,74 @@
+'use strict'
+
+describe('Delete licence agreement journey (internal)', () => {
+  beforeEach(() => {
+    cy.tearDown()
+    cy.setUp('barebones')
+    cy.fixture('users.json').its('billingAndData').as('userEmail')
+  })
+
+  it('sets up a new agreement for a license and then deletes it', () => {
+    cy.visit('/')
+
+    //  Enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    //  Click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    //  Assert the user signed in and we're on the search page
+    cy.contains('Search')
+
+    // Search for the licence and select it from the results
+    cy.get('#query').type('AT/CURR/DAILY/01')
+    cy.get('.search__button').click()
+    cy.contains('Licences')
+    cy.get('.govuk-table__row').contains('AT/CURR/DAILY/01').click()
+
+    // Creating a new licence agreement is also covered with assertions in
+    // cypress/e2e/internal/licence-agreements/new-licence-agreement.cy.js. But for this test we have to use the UI to
+    // create a record to then delete it. So, the following also creates a new licence agreement but we strip out the
+    // checks and assertions for brevity
+    cy.get('#tab_charge').click()
+    cy.get('#charge').contains('Set up a new agreement').click()
+    cy.get('#financialAgreementCode-3').check()
+    cy.get('form > .govuk-button').click()
+    cy.get('#isDateSignedKnown-2').check()
+    cy.get('form > .govuk-button').click()
+    cy.get('input#isCustomStartDate').check()
+    cy.get('#startDate-day').type('01')
+    cy.get('#startDate-month').type('01')
+    cy.get('#startDate-year').type('2018')
+    cy.get('form > .govuk-button').click()
+    cy.get('form > .govuk-button').click()
+
+    // Charge information
+    // back on the Charge Information tab select to delete the licence
+    cy.get('#charge').should('be.visible')
+    cy.get('#charge > table:nth-child(8) > tbody > tr > td:nth-child(5) > a:nth-child(1)').click()
+
+    // You're about to delete this agreement
+    // confirm we are on the right page and it is showing the right agreement then delete it
+    cy.get('.govuk-heading-l').contains("You're about to delete this agreement")
+
+    cy.get('#main-content > table > tbody > tr').within(() => {
+      // agreement
+      cy.get('td:nth-child(1)').should('contain.text', 'Canal and Rivers Trust, unsupported source (S130U)')
+      // date signed
+      cy.get('td:nth-child(2)').should('contain.text', ' ')
+      // start date
+      cy.get('td:nth-child(3)').should('contain.text', '1 January 2018')
+      // end date
+      cy.get('td:nth-child(4)').should('contain.text', ' ')
+    })
+    cy.get('form > .govuk-button').contains('Delete agreement').click()
+
+    // Charge information
+    // confirm we are back on the Charge Information tab and our licence agreement is no longer present
+    cy.get('#charge').should('be.visible')
+    cy.get('#charge > p').should('contain.text', 'No agreements for this licence.')
+  })
+})

--- a/cypress/e2e/internal/licence-agreements/end-licence-agreement.cy.js
+++ b/cypress/e2e/internal/licence-agreements/end-licence-agreement.cy.js
@@ -1,0 +1,99 @@
+'use strict'
+
+describe('End licence agreement journey (internal)', () => {
+  beforeEach(() => {
+    cy.tearDown()
+    cy.setUp('barebones')
+    cy.fixture('users.json').its('billingAndData').as('userEmail')
+  })
+
+  it('sets up a new agreement for a license and then ends it using a valid date', () => {
+    cy.visit('/')
+
+    //  Enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    //  Click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    //  Assert the user signed in and we're on the search page
+    cy.contains('Search')
+
+    // Search for the licence and select it from the results
+    cy.get('#query').type('AT/CURR/DAILY/01')
+    cy.get('.search__button').click()
+    cy.contains('Licences')
+    cy.get('.govuk-table__row').contains('AT/CURR/DAILY/01').click()
+
+    // Creating a new licence agreement is also covered with assertions in
+    // cypress/e2e/internal/licence-agreements/new-licence-agreement.cy.js. But for this test we have to use the UI to
+    // create a record to then end it. So, the following also creates a new licence agreement but we strip out the
+    // checks and assertions for brevity
+    cy.get('#tab_charge').click()
+    cy.get('#charge').contains('Set up a new agreement').click()
+    cy.get('#financialAgreementCode-3').check()
+    cy.get('form > .govuk-button').click()
+    cy.get('#isDateSignedKnown-2').check()
+    cy.get('form > .govuk-button').click()
+    cy.get('input#isCustomStartDate').check()
+    cy.get('#startDate-day').type('01')
+    cy.get('#startDate-month').type('01')
+    cy.get('#startDate-year').type('2018')
+    cy.get('form > .govuk-button').click()
+    cy.get('form > .govuk-button').click()
+
+    // Charge information
+    // back on the Charge Information tab select to end the licence
+    cy.get('#charge').should('be.visible')
+    cy.get('#charge > table:nth-child(8) > tbody > tr > td:nth-child(5) > a:nth-child(2)').click()
+
+    // Set agreement end date
+    // first check the validation for invalid dates is working
+    cy.get('#endDate-day').type('01')
+    cy.get('#endDate-month').type('01')
+    cy.get('#endDate-year').type('2021')
+    cy.get('form > .govuk-button').click()
+    cy.get('.govuk-error-summary').contains('You must enter an end date that matches some existing charge information or is 31 March.You cannot use a date that is before the agreement start date.').should('be.visible')
+
+    // then repeat using a valid date
+    cy.get('#endDate-day').clear().type('31')
+    cy.get('#endDate-month').clear().type('03')
+    cy.get('#endDate-year').clear().type('2022')
+    cy.get('form > .govuk-button').click()
+
+    // You're about to end this agreement
+    // confirm the details match what was entered and continue
+    cy.get('#main-content > table > tbody > tr').within(() => {
+      // agreement
+      cy.get('td:nth-child(1)').should('contain.text', 'Canal and Rivers Trust, unsupported source (S130U)')
+      // date signed
+      cy.get('td:nth-child(2)').should('contain.text', ' ')
+      // start date
+      cy.get('td:nth-child(3)').should('contain.text', '1 January 2018')
+      // end date
+      cy.get('td:nth-child(4)').should('contain.text', '31 March 2022')
+    })
+    cy.get('form > .govuk-button').contains('End agreement').click()
+
+    // Charge information
+    // confirm we are back on the Charge Information tab and our licence agreement is present with an end date and only
+    // the delete action available
+    cy.get('#charge').should('be.visible')
+    cy.get('#charge > table:nth-child(8) > tbody > tr').within(() => {
+      // start date
+      cy.get('td:nth-child(1)').should('contain.text', '1 January 2018')
+      // end date
+      cy.get('td:nth-child(2)').should('contain.text', '31 March 2022')
+      // agreement
+      cy.get('td:nth-child(3)').should('contain.text', 'Canal and Rivers Trust, unsupported source (S130U)')
+      // date signed
+      cy.get('td:nth-child(4)').should('contain.text', ' ')
+      // actions
+      cy.get('td:nth-child(5) > a:nth-child(1)').should('contain.text', 'Delete')
+      cy.get('td:nth-child(5) > a:nth-child(2)').should('not.exist')
+    })
+  })
+})

--- a/cypress/e2e/internal/licence-agreements/new-licence-agreement.cy.js
+++ b/cypress/e2e/internal/licence-agreements/new-licence-agreement.cy.js
@@ -1,0 +1,81 @@
+'use strict'
+
+describe('New licence agreement journey (internal)', () => {
+  beforeEach(() => {
+    cy.tearDown()
+    cy.setUp('barebones')
+    cy.fixture('users.json').its('billingAndData').as('userEmail')
+  })
+
+  it('setup a new agreement for a license and then view it', () => {
+    cy.visit('/')
+
+    //  Enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    //  Click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    //  Assert the user signed in and we're on the search page
+    cy.contains('Search')
+
+    // Search for the licence and select it from the results
+    cy.get('#query').type('AT/CURR/DAILY/01')
+    cy.get('.search__button').click()
+    cy.contains('Licences')
+    cy.get('.govuk-table__row').contains('AT/CURR/DAILY/01').click()
+
+    // Confirm we are on the licence page and select charge information tab
+    cy.contains('AT/CURR/DAILY/01')
+    cy.get('#tab_charge').click()
+
+    // Confirm we are on the tab page and then click Set up a new charge
+    cy.get('#charge > .govuk-heading-l').contains('Charge information')
+    cy.get('#charge').contains('Set up a new agreement').click()
+
+    // Select reason for new charge information
+    // select Canal and Rivers Trust, unsupported source (S130U) then continue
+    cy.get('#financialAgreementCode-3').check()
+    cy.get('form > .govuk-button').click()
+
+    // Do you know the date the agreement was signed?
+    // select No and continue
+    cy.get('#isDateSignedKnown-2').check()
+    cy.get('form > .govuk-button').click()
+
+    // Check agreement start date
+    // select Yes to set a different agreement start date. A section appears allowing the user to enter the custom
+    // date then continue
+    cy.get('input#isCustomStartDate').check()
+    cy.get('#startDate-day').type('01')
+    cy.get('#startDate-month').type('01')
+    cy.get('#startDate-year').type('2018')
+    cy.get('form > .govuk-button').click()
+
+    // Check agreement details
+    // confirm the details match what was entered and continue
+    cy.get('.govuk-heading-l').contains('Check agreement details').should('be.visible')
+    cy.get('.govuk-summary-list__value').contains('Canal and Rivers Trust, unsupported source (S130U)').should('be.visible')
+    cy.get('form > .govuk-button').click()
+
+    // Charge information
+    // confirm we are back on the Charge Information tab and our licence agreement is present
+    cy.get('#charge').should('be.visible')
+    cy.get('#charge > table:nth-child(8) > tbody > tr').within(() => {
+      // start date
+      cy.get('td:nth-child(1)').should('contain.text', '1 January 2018')
+      // end date
+      cy.get('td:nth-child(2)').should('contain.text', ' ')
+      // agreement
+      cy.get('td:nth-child(3)').should('contain.text', 'Canal and Rivers Trust, unsupported source (S130U)')
+      // date signed
+      cy.get('td:nth-child(4)').should('contain.text', ' ')
+      // actions
+      cy.get('td:nth-child(5) > a:nth-child(1)').should('contain.text', 'Delete')
+      cy.get('td:nth-child(5) > a:nth-child(2)').should('contain.text', 'End')
+    })
+  })
+})


### PR DESCRIPTION
When looking to migrate the tests in `internal/chargeinformation/` we found `create-view-edit-delete-licence-agreements.spec.js`.

Managing licence agreements is done from the charge information tab in a licence. But we felt it is a feature in its own right and as such should be in a separate folder.

On top of that, there are 3 functions of a licence agreement being tested in one file. We understand why; the test data does not include a licence agreement so one has to be created through the UI. But these are relatively quick tests to run so when migrating we choose to split it into 3 distinct tests

- delete-licence-agreement.cy.js
- end-licence-agreement.cy.js
- new-licence-agreement.cy.js

We just need to get through all the migrations and then we can start being a bit cleverer with the set up data!