### PR TITLE
Migrate charge information tests

### DIFF
--- a/cypress/e2e/internal/charge-information/sroc/journey.cy.js
+++ b/cypress/e2e/internal/charge-information/sroc/journey.cy.js
@@ -1,0 +1,217 @@
+'use strict'
+
+describe('SROC charge information journey (internal)', () => {
+  beforeEach(() => {
+    cy.tearDown()
+    cy.setUp('billing-data')
+    cy.fixture('users.json').its('billingAndData').as('userEmail')
+  })
+
+  it('adds a new charge information with a new billing account, note and charge element note then sets up the charge reference including additional charges and adjustments and then approves it', () => {
+    cy.visit('/')
+
+    //  Enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    //  Click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    //  Assert the user signed in and we're on the search page
+    cy.contains('Search')
+
+    // Search for the licence and select it from the results
+    cy.get('#query').type('AT/CURR/DAILY/01')
+    cy.get('.search__button').click()
+    cy.contains('Licences')
+    cy.get('.govuk-table__row').contains('AT/CURR/DAILY/01').click()
+
+    // Confirm we are on the licence page and select charge information tab
+    cy.contains('AT/CURR/DAILY/01')
+    cy.get('#tab_charge').click()
+
+    // Confirm we are on the tab page and then click Set up a new charge
+    cy.get('#charge > .govuk-heading-l').contains('Charge information')
+    cy.get('#charge').contains('Set up a new charge').click()
+
+    // Select reason for new charge information
+    // choose Strategic review of charges (SRoC) and continue
+    cy.get('input#reason-12').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Set charge start date
+    // choose another date and then enter 2022-06-01 and continue
+    cy.get('input#startDate-4').click()
+    cy.get('#customDate-day').type('1')
+    cy.get('#customDate-month').type('6')
+    cy.get('#customDate-year').type('2022')
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Who should the bills go to?
+    // the existing account is automatically selected so just continue
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Select an existing address for Big Farm Co Ltd
+    // choose the existing address and continue
+    cy.get('input#selectedAddress').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Do you need to add an FAO?
+    // choose No and continue
+    cy.get('input#faoRequired-2').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Check billing account details
+    // confirm
+    cy.get('form > .govuk-button').contains('Confirm').click()
+
+    // Use abstraction data to set up the element?
+    // choose Use charge information valid from 1 June 2022 and continue
+    cy.get('input#useAbstractionData-4').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Check charge information
+    // add a note
+    cy.get('section:nth-child(2) > p > a').click()
+
+    // Add a note
+    // enter a note and continue
+    cy.get('#note').type('This is Automation Testing')
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Check charge information
+    // add another element
+    cy.get('button[value="addElement"]').contains('Add another element').click()
+
+    // Select a purpose use
+    // choose the one option available Animal Watering & General Use In Non Farming Situations and continue
+    cy.get('input#purpose').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Add element description
+    // enter a description and continue
+    cy.get('input#description').type('test element description')
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Set abstraction period
+    // enter start and end date and continue
+    cy.get('input#startDate-day').type('1')
+    cy.get('input#startDate-month').type('4')
+    cy.get('input#endDate-day').type('30')
+    cy.get('input#endDate-month').type('9')
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Add annual quantities
+    // enter annual quantity and continue
+    cy.get('input#authorisedAnnualQuantity').type('10')
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Set time limit?
+    // choose no and continue
+    cy.get('input#timeLimitedPeriod-2').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Select loss category
+    // choose medium and continue
+    cy.get('input#loss-2').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Check charge information
+    // set the charge reference
+    cy.get('button[value="addChargeCategory"]').click()
+
+    // Select the elements this charge reference is for
+    // tick both and continue
+    cy.get('input#selectedElementIds').check()
+    cy.get('input#selectedElementIds-2').check()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Enter a description for the charge reference
+    // enter a description and continue
+    cy.get('#description').type('Automation-Test')
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Select the source
+    // choose non-tidal and continue
+    cy.get('input#source-2').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Select the loss category
+    // choose low and continue
+    cy.get('input#loss-3').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Enter the total quantity to use for this charge reference
+    // enter 150 and continue
+    cy.get('#volume').type('150')
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Select the water availability
+    // choose Restricted availability or no availability and continue
+    cy.get('input#isRestrictedSource-2').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Select the water modelling charge
+    // choose Tier 1 and continue
+    cy.get('input#waterModel-2').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Do additional charges apply?
+    // choose Yes and continue
+    cy.get('input#isAdditionalCharges').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Is abstraction from a supported source?
+    // choose Yes and continue
+    cy.get('input#isSupportedSource').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Select the name of the supported source
+    // choose Rhee Groundwater and continue
+    cy.get('input#supportedSourceId-12').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Is abstraction for the supply of public water?
+    // choose Yes and continue
+    cy.get('input#isSupplyPublicWater').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Do adjustments apply?
+    // choose Yes and continue
+    cy.get('input#isAdjustments').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Which adjustments apply?
+    // choose Charge adjustment, enter a Factor and continue
+    cy.get('input#adjustments-2').check()
+    cy.get('#chargeFactor').type('25')
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Check charge information
+    // confirm
+    cy.get('form > .govuk-button').contains('Confirm').click()
+
+    // Charge information complete
+    // confirm the charge information is submitted and then click to view it
+    cy.get('.govuk-panel__title').should('contain', 'Charge information complete')
+    cy.get('a[href*="licences/"]').contains('View charge information').click()
+
+    // Charge information
+    // select to review it
+    cy.get('#charge > table > tbody > tr:nth-child(1) > td:nth-child(5) > a').contains('Review').click()
+
+    // Check charge information
+    // approve the new charge version
+    cy.get('strong.govuk-tag--orange').should('contain.text', 'Review')
+    cy.get('input#reviewOutcome').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Charge information
+    // confirm our new charge information is APPROVED
+    cy.get('#charge > table > tbody > tr:nth-child(1)').within(() => {
+      cy.get('td:nth-child(4) > strong').should('contain.text', 'Approved')
+    })
+  })
+})

--- a/cypress/e2e/internal/charge-information/sroc/validation.cy.js
+++ b/cypress/e2e/internal/charge-information/sroc/validation.cy.js
@@ -1,0 +1,357 @@
+'use strict'
+
+describe('SROC charge information validation (internal)', () => {
+  beforeEach(() => {
+    cy.tearDown()
+    cy.setUp('billing-data')
+    cy.fixture('users.json').its('billingAndData').as('userEmail')
+  })
+
+  it('adds a new charge information with a new billing account and a note, and sets up the charge reference including additional charges and adjustments', () => {
+    cy.visit('/')
+
+    //  Enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    //  Click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    //  Assert the user signed in and we're on the search page
+    cy.contains('Search')
+
+    // Search for the licence and select it from the results
+    cy.get('#query').type('AT/CURR/DAILY/01')
+    cy.get('.search__button').click()
+    cy.contains('Licences')
+    cy.get('.govuk-table__row').contains('AT/CURR/DAILY/01').click()
+
+    // Confirm we are on the licence page and select charge information tab
+    cy.contains('AT/CURR/DAILY/01')
+    cy.get('#tab_charge').click()
+
+    // Confirm we are on the tab page and then click Set up a new charge
+    cy.get('#charge > .govuk-heading-l').contains('Charge information')
+    cy.get('#charge').contains('Set up a new charge').click()
+
+    // Select reason for new charge information
+    // test submitting nothing
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', 'Select a reason for new charge information')
+    cy.get('.govuk-error-message').should('contain.text', 'Select a reason for new charge information')
+    // choose Strategic review of charges (SRoC) and continue
+    cy.get('input#reason-12').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Set charge start date
+    // test submitting nothing
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', 'Select charge information start date')
+    cy.get('.govuk-error-message').should('contain.text', 'Select charge information start date')
+    // choose another date
+    cy.get('input#startDate-4').click()
+    // test date before licence start date
+    cy.get('#customDate-day').type('1')
+    cy.get('#customDate-month').type('6')
+    cy.get('#customDate-year').type('2019')
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', 'Date must be after the start date of the earliest known licence version')
+    cy.get('.govuk-error-message').should('contain.text', 'Date must be after the start date of the earliest known licence version')
+    // test not a real date
+    cy.get('#customDate-day').clear().type('aa')
+    cy.get('#customDate-month').clear().type('6')
+    cy.get('#customDate-year').clear().type('2022')
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', 'Enter a real date for the charge information start date')
+    cy.get('.govuk-error-message').should('contain.text', 'Enter a real date for the charge information start date')
+    // enter 2022-06-01 and continue
+    cy.get('#customDate-day').clear().type('1')
+    cy.get('#customDate-month').clear().type('6')
+    cy.get('#customDate-year').clear().type('2022')
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Who should the bills go to?
+    // the existing account is automatically selected so just continue
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Select an existing address for Big Farm Co Ltd
+    // test submitting nothing
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', 'Select an existing address, or set up a new one.')
+    cy.get('.govuk-error-message').should('contain.text', 'Select an existing address, or set up a new one.')
+    // choose the existing address and continue
+    cy.get('input#selectedAddress').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Do you need to add an FAO?
+    // test submitting nothing
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', 'Select yes if you need to add a person or department as an FAO')
+    cy.get('.govuk-error-message').should('contain.text', 'Select yes if you need to add a person or department as an FAO')
+    // choose No and continue
+    cy.get('input#faoRequired-2').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Check billing account details
+    // check the details are as expected and confirm
+    cy.get('section > dl').within(() => {
+      cy.get('div:nth-child(1) > dd.govuk-summary-list__value').should('contain.text', 'Big Farm Co Ltd')
+      cy.get('div:nth-child(2) > dd.govuk-summary-list__value').should('contain.text', 'TT1 1TT')
+      cy.get('div:nth-child(3) > dd.govuk-summary-list__value').should('contain.text', 'No')
+    })
+    cy.get('form > .govuk-button').contains('Confirm').click()
+
+    // Use abstraction data to set up the element?
+    // test submitting nothing
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', 'Select whether to use abstraction data to set up the element')
+    cy.get('.govuk-error-message').should('contain.text', 'Select whether to use abstraction data to set up the element')
+    // choose Use charge information valid from 1 June 2022 and continue
+    cy.get('input#useAbstractionData-4').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Check charge information
+    // check the charge details and element details are as expected and then select option to add a note
+    cy.get('section:nth-child(1) > dl').within(() => {
+      // reason
+      cy.get('div:nth-child(1) > dd.govuk-summary-list__value').should('contain.text', 'Strategic review of charges (SRoC)')
+      // start date
+      cy.get('div:nth-child(2) > dd.govuk-summary-list__value').should('contain.text', '1 June 2022')
+      // billing account
+      cy.get('div:nth-child(3) > dd.govuk-summary-list__value').should('contain.text', 'Big Farm')
+      // licence holder
+      cy.get('div:nth-child(4) > dd.govuk-summary-list__value').should('contain.text', 'Big Farm Co Ltd')
+    })
+    cy.get('form > section > h2').should('contain.text', 'Element')
+    cy.get('form > section > dl').within(() => {
+      // purpose
+      cy.get('div:nth-child(1) > dd.govuk-summary-list__value').should('contain.text', 'Animal Watering & General Use In Non Farming Situations')
+      // description
+      cy.get('div:nth-child(2) > dd.govuk-summary-list__value').should('contain.text', 'Test Charge Element!')
+      // abstraction period
+      cy.get('div:nth-child(3) > dd.govuk-summary-list__value').should('contain.text', '1 April to 31 March')
+      // annual quantities
+      cy.get('div:nth-child(4) > dd.govuk-summary-list__value').should('contain.text', '15.54ML authorised')
+      // time limit
+      cy.get('div:nth-child(5) > dd.govuk-summary-list__value').should('contain.text', 'No')
+      // medium
+      cy.get('div:nth-child(6) > dd.govuk-summary-list__value').should('contain.text', 'Medium')
+    })
+    cy.get('section:nth-child(2) > p > a').click()
+
+    // Add a note
+    // test submitting nothing
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', 'Enter details.')
+    cy.get('.govuk-error-message').should('contain.text', 'Enter details.')
+    // enter a note and continue
+    cy.get('#note').type('This is Automation Testing')
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Check charge information
+    // back on this page we confirm the note we added is present then set the charge reference
+    cy.get('#main-content > :nth-child(1) > :nth-child(2) > :nth-child(2)').within(() => {
+      cy.get('dt').should('contain.text', 'acceptance-test.internal.billing_and_data@defra.gov.uk')
+      cy.get('dd.govuk-summary-list__value').should('contain.text', 'This is Automation Testing')
+    })
+    cy.get('button:nth-child(3)').click()
+
+    // Enter a description for the charge reference
+    // test submitting nothing
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', 'Enter a description for the charge reference')
+    cy.get('.govuk-error-message').should('contain.text', 'Enter a description for the charge reference')
+    // test submitting invalid characters. We loop through testing each one
+    cy.wrap(['“', '”', '?', '^', '£', '≥', '≤', '—']).each((character) => {
+      cy.get('#description').clear().type(character)
+      cy.get('form > .govuk-button').contains('Continue').click()
+      cy.get('.govuk-error-summary__list').should('contain.text', 'You can not use “ ” ? ^ £ ≥ ≤ — (long dash) in the charge reference description')
+      cy.get('.govuk-error-message').should('contain.text', 'You can not use “ ” ? ^ £ ≥ ≤ — (long dash) in the charge reference description')
+    })
+    // enter a description made up of valid special characters and continue
+    cy.get('#description').clear().type('-\'.,()&* are supported characters')
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Select the source
+    // test submitting nothing
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', 'Select if the source is tidal or non-tidal.')
+    cy.get('.govuk-error-message').should('contain.text', 'Select if the source is tidal or non-tidal.')
+    // select non-tidal and continue
+    cy.get('input#source-2').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Select the loss category
+    // test submitting nothing
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', 'Select if the loss category is high, medium or low.')
+    cy.get('.govuk-error-message').should('contain.text', 'Select if the loss category is high, medium or low.')
+    // select low and continue
+    cy.get('input#loss-3').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Enter the total quantity to use for this charge reference
+    // test submitting nothing
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', 'Enter the volume in ML (megalitres).')
+    cy.get('.govuk-error-message').should('contain.text', 'Enter the volume in ML (megalitres).')
+    // test submitting not a real number
+    cy.get('#volume').type('1a')
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', 'Enter the volume in ML (megalitres).')
+    cy.get('.govuk-error-message').should('contain.text', 'Enter the volume in ML (megalitres).')
+    // test submitting -1
+    cy.get('#volume').clear().type('-1')
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', 'The volume must be greater than 0')
+    cy.get('.govuk-error-message').should('contain.text', 'The volume must be greater than 0')
+    // test submitting 0
+    cy.get('#volume').clear().type('0')
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', 'The volume must be greater than 0')
+    cy.get('.govuk-error-message').should('contain.text', 'The volume must be greater than 0')
+    // enter 0.5 to confirm decimal numbers are allowed and continue
+    cy.get('#volume').clear().type('0.5')
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Select the water availability
+    // test submitting nothing
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', 'Select the water availability.')
+    cy.get('.govuk-error-message').should('contain.text', 'Select the water availability.')
+    // choose Restricted availability or no availability and continue
+    cy.get('input#isRestrictedSource-2').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Select the water modelling charge
+    // test submitting nothing
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', 'Select the water modelling charge.')
+    cy.get('.govuk-error-message').should('contain.text', 'Select the water modelling charge.')
+    // choose Tier 1 and continue
+    cy.get('input#waterModel-2').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Do additional charges apply?
+    // test submitting nothing
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', "Select 'yes' if additional charges apply.")
+    cy.get('.govuk-error-message').should('contain.text', "Select 'yes' if additional charges apply.")
+    // choose Yes and continue
+    cy.get('input#isAdditionalCharges').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Is abstraction from a supported source?
+    // test submitting nothing
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', "Select 'yes' if abstraction is from a supported source.")
+    cy.get('.govuk-error-message').should('contain.text', "Select 'yes' if abstraction is from a supported source.")
+    // choose Yes and continue
+    cy.get('input#isSupportedSource').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Select the name of the supported source
+    // test submitting nothing
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', 'Select the name of the supported source.')
+    cy.get('.govuk-error-message').should('contain.text', 'Select the name of the supported source.')
+    // choose Rhee Groundwater and continue
+    cy.get('input#supportedSourceId-12').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Is abstraction for the supply of public water?
+    // test submitting nothing
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', "Select 'yes' if abstraction is for the supply of public water.")
+    cy.get('.govuk-error-message').should('contain.text', "Select 'yes' if abstraction is for the supply of public water.")
+    // choose Yes and continue
+    cy.get('input#isSupplyPublicWater').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Do adjustments apply?
+    // test submitting nothing
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', "Select 'yes' if adjustments apply.")
+    cy.get('.govuk-error-message').should('contain.text', "Select 'yes' if adjustments apply.")
+    // choose Yes and continue
+    cy.get('input#isAdjustments').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Which adjustments apply?
+    // test submitting nothing
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', 'At least one condition must be selected')
+    cy.get('.govuk-error-message').should('contain.text', 'At least one condition must be selected')
+    // choose Charge Adjustment
+    cy.get('input#adjustments-2').check()
+    // test not submitting a factor
+    cy.get('form > .govuk-button').contains('Continue').click()
+    cy.get('.govuk-error-summary__list').should('contain.text', "The 'Charge adjustment' factor must not have more than 15 decimal places.")
+    cy.get('.govuk-error-message').should('contain.text', "The 'Charge adjustment' factor must not have more than 15 decimal places.")
+    // choose Charge adjustment, enter a Factor and continue
+    cy.get('#chargeFactor').type('25')
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Check charge information
+    // back on the check charge information screen there is now new sections covering the charge reference. We confirm
+    // they exist and the details match what we entered and then confirm
+    cy.get(':nth-child(1) > .govuk-grid-column-full > form').within(() => {
+      cy.get('h2.govuk-heading-l > span').should('contain.text', 'Charge reference 4.4.5')
+      cy.get('h2:nth-child(4)').should('contain.text', 'Charge reference details')
+
+      cy.get('dl:nth-child(5)').within(() => {
+        // applies to
+        cy.get('div:nth-child(1) > dd.govuk-summary-list__value').should('contain.text', 'Test Charge Element!')
+        // description
+        cy.get('div:nth-child(2) > dd.govuk-summary-list__value').should('contain.text', 'are supported characters')
+        // source
+        cy.get('div:nth-child(3) > dd.govuk-summary-list__value').should('contain.text', 'Non-tidal')
+        // loss
+        cy.get('div:nth-child(4) > dd.govuk-summary-list__value').should('contain.text', 'Low')
+        // volume
+        cy.get('div:nth-child(5) > dd.govuk-summary-list__value').should('contain.text', '0.5ML')
+        // water availability
+        cy.get('div:nth-child(6) > dd.govuk-summary-list__value').should('contain.text', 'Restricted availablity')
+        // water model
+        cy.get('div:nth-child(7) > dd.govuk-summary-list__value').should('contain.text', 'Tier 1')
+        // additional charges apply
+        cy.get('div:nth-child(8) > dd.govuk-summary-list__value').should('contain.text', 'Yes')
+        // adjustments apply
+        cy.get('div:nth-child(9) > dd.govuk-summary-list__value').should('contain.text', 'Yes')
+        // eic region
+        cy.get('div:nth-child(10) > dd.govuk-summary-list__value').should('contain.text', 'Southern')
+      })
+
+      cy.get('h2:nth-child(7)').should('contain.text', 'Additional charges')
+      cy.get('dl:nth-child(8)').within(() => {
+        // supported source
+        cy.get('div:nth-child(1) > dd.govuk-summary-list__value').should('contain.text', 'Yes')
+        // supported source name
+        cy.get('div:nth-child(2) > dd.govuk-summary-list__value').should('contain.text', 'Rhee Groundwater')
+        // supply public water
+        cy.get('div:nth-child(3) > dd.govuk-summary-list__value').should('contain.text', 'Yes')
+      })
+
+      cy.get('dl:nth-child(10)').within(() => {
+        cy.get('div:nth-child(1) > dt').should('contain.text', 'Adjustments')
+
+        // adjustment factor
+        cy.get('div:nth-child(2) > dd.govuk-summary-list__value').should('contain.text', '25')
+      })
+    })
+    cy.get('form > .govuk-button').contains('Confirm').click()
+
+    // Charge information complete
+    // confirm the charge information is submitted and then click to view it
+    cy.get('.govuk-panel__title').should('contain', 'Charge information complete')
+    cy.get('a[href*="licences/"]').contains('View charge information').click()
+
+    // Charge information
+    // confirm our new charge information is in REVIEW
+    cy.get('#charge > table > tbody > tr:nth-child(1)').within(() => {
+      cy.get('td:nth-child(4) > strong').should('contain.text', 'Review')
+    })
+  })
+})

--- a/cypress/e2e/internal/licence-agreements/new-licence-agreement.cy.js
+++ b/cypress/e2e/internal/licence-agreements/new-licence-agreement.cy.js
@@ -32,11 +32,11 @@ describe('New licence agreement journey (internal)', () => {
     cy.contains('AT/CURR/DAILY/01')
     cy.get('#tab_charge').click()
 
-    // Confirm we are on the tab page and then click Set up a new charge
+    // Confirm we are on the tab page and then click Set up a new agreement
     cy.get('#charge > .govuk-heading-l').contains('Charge information')
     cy.get('#charge').contains('Set up a new agreement').click()
 
-    // Select reason for new charge information
+    // Select agreement
     // select Canal and Rivers Trust, unsupported source (S130U) then continue
     cy.get('#financialAgreementCode-3').check()
     cy.get('form > .govuk-button').click()

--- a/cypress/e2e/internal/workflow/remove-charge-information.cy.js
+++ b/cypress/e2e/internal/workflow/remove-charge-information.cy.js
@@ -1,0 +1,61 @@
+'use strict'
+
+describe('Remove charge information journey (internal)', () => {
+  beforeEach(() => {
+    cy.tearDown()
+    cy.setUp('charge-version-workflow')
+    cy.fixture('users.json').its('billingAndData').as('userEmail')
+  })
+
+  it('removes a charge information from the workflow', () => {
+    cy.visit('/')
+
+    // enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    // click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    // assert the user signed in and we're on the search page
+    cy.get('#main-content > form > fieldset > legend > h1 > label').should('contain.text', 'Search')
+
+    // navigate to the charge information flow
+    cy.get('#navbar-notifications').click()
+    cy.get('a[href="/charge-information-workflow"]').click()
+
+    // Charge information workflow
+    // confirm the 3 tabs exist
+    cy.get('#tab_toSetUp').should('contain.text', 'To set up')
+    cy.get('#tab_review').should('contain.text', 'Review')
+    cy.get('#tab_changeRequest').should('contain.text', 'Change request')
+
+    // confirm we see our test licence in the 'To set up' workflow and the correct action links
+    cy.get('#toSetUp > div > table > tbody').within(() => {
+      cy.get('.govuk-table__row:nth-child(1)').should('contain.text', 'AT/CURR/DAILY/01')
+      cy.get('.govuk-table__row:nth-child(1)').should('contain.text', 'Big Farm Co Ltd')
+      cy.get('.govuk-table__row:nth-child(1)').should('contain.text', '1 March 2020')
+
+      cy.get('.govuk-table__row:nth-child(1)').should('contain.text', 'Set up')
+      cy.get('.govuk-table__row:nth-child(1)').should('contain.text', 'Remove')
+
+      cy.get('.govuk-table__row:nth-child(1) > td:nth-child(4) > a:nth-child(2)').click()
+    })
+
+    // You're about to remove this licence from the workflow
+    // confirm we are on the right page and seeing the right information then click the Remove button
+    cy.get('.govuk-heading-xl').should('contain.text', "You're about to remove this licence from the workflow")
+    cy.get('.govuk-table__body').within(() => {
+      cy.get('.govuk-table__row:nth-child(1)').should('contain.text', 'AT/CURR/DAILY/01')
+      cy.get('.govuk-table__row:nth-child(1)').should('contain.text', 'Big Farm Co Ltd')
+      cy.get('.govuk-table__row:nth-child(1)').should('contain.text', '1 April 1920')
+    })
+    cy.get('button.govuk-button').click()
+
+    // Charge information workflow
+    // confirm the charge information has been removed
+    cy.get('#toSetUp > div > div').should('contain.text', 'There are no licences that require charge information setup.')
+  })
+})


### PR DESCRIPTION
This covers the migration of what we found in `internal/chargeinformation` in the legacy tests, having dealt with [user permission](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/40) and [licence agreement](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/41) tests.

We migrated `remove-charge-info-workflow.spec.js` into its own `workflow/` folder as it was actually testing the workflow functionality rather than charge information.

The remaining tests were probably the worst we've had to deal with so far. They were

- sroc-charge-version-adjustments-option-no.spec.js
- sroc-charge-version-adjustments-option-yes.spec.js
- sroc-charge-version.spec.js
- sroc-edit-submit-review-view-charge-version.spec.js
- sroc-select-multiple-charge-version.spec.js

5 tests that all repeat the exact same validation checks and have very little to differentiate them. They all go through the same set-up new charge version journey with very, _very_ minor differences. `sroc-charge-version.spec.js`, for example, creates a charge version that adds the same adjustment used in `sroc-charge-version-adjustments-option-yes.spec.js` and 2 others. `sroc-edit-submit-review-view-charge-version.spec.js` is a duplicate of most of them only it goes a few steps further in the journey (and nothing gets edited!)

So, we have condensed them down into 2 tests;

- sroc/journey.cy.js
- sroc/validation.cy.js

`journey.cy.js` includes adding an adjustment and an additional element. It also includes reviewing and approving the charge version. It omits the validation and asserting values appear where they should be as that is covered by `validation.cy.js`. There was no validation checking of the screens used to add a charge element so that part is omitted from the journey. The same goes for the review and approval screens.

We cover everything the legacy tests were doing including additional checking of values shown in the pages. But we remove the duplication which reduces the overall run time and will make it easier to maintain in future.