### PR TITLE
Migrate legacy Mark licence for supp. billing test

### DIFF
--- a/cypress/e2e/internal/charge-information/sroc/journey.cy.js
+++ b/cypress/e2e/internal/charge-information/sroc/journey.cy.js
@@ -7,7 +7,7 @@ describe('SROC charge information journey (internal)', () => {
     cy.fixture('users.json').its('billingAndData').as('userEmail')
   })
 
-  it('adds a new charge information with a new billing account, note and charge element note then sets up the charge reference including additional charges and adjustments and then approves it', () => {
+  it('adds a new charge information with a new billing account, note and charge element then sets up the charge reference including additional charges and adjustments and then approves it and confirms licence is flagged for supplementary billing', () => {
     cy.visit('/')
 
     //  Enter the user name and Password
@@ -209,9 +209,12 @@ describe('SROC charge information journey (internal)', () => {
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Charge information
-    // confirm our new charge information is APPROVED
+    // confirm our new charge information is APPROVED and that the licence has been flagged for the next supplementary
+    // bill run
     cy.get('#charge > table > tbody > tr:nth-child(1)').within(() => {
       cy.get('td:nth-child(4) > strong').should('contain.text', 'Approved')
     })
+    cy.get('.govuk-notification-banner__content')
+      .should('contain.text', 'This licence has been marked for the next supplementary bill run.')
   })
 })

--- a/cypress/e2e/internal/returns/record-receipt.cy.js
+++ b/cypress/e2e/internal/returns/record-receipt.cy.js
@@ -1,0 +1,66 @@
+'use strict'
+
+describe('Record receipt for return (internal)', () => {
+  beforeEach(() => {
+    cy.tearDown()
+    cy.setUp('barebones')
+    cy.fixture('users.json').its('billingAndData').as('userEmail')
+  })
+
+  it('record the receipt for an overdue return for a licence from its returns tab', () => {
+    cy.visit('/')
+
+    // enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    // click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    // assert the user signed in and we're on the search page
+    cy.contains('Search')
+
+    // search for a licence
+    cy.get('#query').type('AT/CURR/MONTHLY/02')
+    cy.get('.search__button').click()
+    cy.get('.govuk-table__row').contains('AT/CURR/MONTHLY/02').click()
+
+    // confirm we are on the licence page and select returns tab
+    cy.contains('AT/CURR/MONTHLY/02')
+    cy.get('#tab_returns').click()
+
+    // confirm we are on the tab page
+    cy.get('#returns > .govuk-heading-l').contains('Returns')
+
+    // confirm we see the overdue return
+    cy.get('section#returns > .govuk-table > .govuk-table__body').within(() => {
+      cy.get('.govuk-table__row:nth-child(5)').should('be.visible').and('contain.text', '9999990')
+      cy.get('.govuk-table__row:nth-child(5)').should('be.visible').and('contain.text', 'Overdue')
+
+      cy.get('.govuk-table__row:nth-child(5) a').contains('9999990').click()
+    })
+
+    // What do you want to do with this return?
+    // select record receipt
+    cy.get('#action-2').check()
+    cy.get('form > .govuk-button').click()
+
+    // When was the return received?
+    // leave defaulted current date
+    cy.get('form > .govuk-button').click()
+
+    // Return received
+    cy.get('.panel').contains('Return received Licence number AT/CURR/MONTHLY/02').should('be.visible')
+
+    // View returns for the licence (this is a different view)
+    cy.get('p > a').contains('View returns for AT/CURR/MONTHLY/02').should('be.visible').click()
+
+    // confirm we see the received return
+    cy.get('.govuk-table > .govuk-table__body').within(() => {
+      cy.get('.govuk-table__row:nth-child(5)').should('be.visible').and('contain.text', 'January 2019 to December 2019')
+      cy.get('.govuk-table__row:nth-child(5)').should('be.visible').and('contain.text', 'Received')
+    })
+  })
+})

--- a/cypress/e2e/internal/returns/submit.cy.js
+++ b/cypress/e2e/internal/returns/submit.cy.js
@@ -1,13 +1,13 @@
 'use strict'
 
-describe('Submit return (internal)', () => {
+describe('Submit a return (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
   })
 
-  it('submit an overdue return for a licence from the returns tab', () => {
+  it('submit a return for a licence from its returns tab and mark the licence for supplementary billing', () => {
     cy.visit('/')
 
     // enter the user name and Password
@@ -34,33 +34,96 @@ describe('Submit return (internal)', () => {
     // confirm we are on the tab page
     cy.get('#returns > .govuk-heading-l').contains('Returns')
 
-    // confirm we see the overdue return
+    // confirm we see the due return
     cy.get('section#returns > .govuk-table > .govuk-table__body').within(() => {
-      cy.get('.govuk-table__row:nth-child(5)').should('be.visible').and('contain.text', '9999990')
-      cy.get('.govuk-table__row:nth-child(5)').should('be.visible').and('contain.text', 'Overdue')
+      cy.get('.govuk-table__row:nth-child(1)').should('be.visible').and('contain.text', '9999992')
+      cy.get('.govuk-table__row:nth-child(1)').should('be.visible').and('contain.text', 'Due')
 
-      cy.get('.govuk-table__row:nth-child(5) a').contains('9999990').click()
+      cy.get('.govuk-table__row:nth-child(1) a').contains('9999992').click()
     })
 
     // What do you want to do with this return?
-    // select record receipt
-    cy.get('#action-2').check()
+    // choose Enter and submit and continue
+    cy.get('input#action').check()
     cy.get('form > .govuk-button').click()
 
     // When was the return received?
-    // leave defaulted current date
+    // choose Today and continue
+    cy.get('input#receivedDate').check()
     cy.get('form > .govuk-button').click()
 
-    // Return received
-    cy.get('.panel').contains('Return received Licence number AT/CURR/MONTHLY/02').should('be.visible')
+    // Has water been abstracted in this return period?
+    // choose Yes and continue
+    cy.get('input#isNil').check()
+    cy.get('form > .govuk-button').click()
 
-    // View returns for the licence (this is a different view)
-    cy.get('p > a').contains('View returns for AT/CURR/MONTHLY/02').should('be.visible').click()
+    // How was this return reported?
+    // choose Abstraction volumes and continue
+    cy.get('input#method-2').check()
+    cy.get('form > .govuk-button').click()
 
-    // confirm we see the received return
-    cy.get('.govuk-table > .govuk-table__body').within(() => {
-      cy.get('.govuk-table__row:nth-child(5)').should('be.visible').and('contain.text', 'January 2019 to December 2019')
-      cy.get('.govuk-table__row:nth-child(5)').should('be.visible').and('contain.text', 'Received')
+    // Which units were used?
+    // choose Cubic metres and continue
+    cy.get('input#units').check()
+    cy.get('form > .govuk-button').click()
+
+    // Have meter details been provided?
+    // choose No and continue
+    cy.get('input#meterDetailsProvided-2').check()
+    cy.get('form > .govuk-button').click()
+
+    // Did they use a meter or meters?
+    // choose No and continue
+    cy.get('input#meterUsed-2').check()
+    cy.get('form > .govuk-button').click()
+
+    // Is it a single volume?
+    // choose Yes, enter 100 cubic metres and continue
+    cy.get('input#isSingleTotal').check()
+    cy.get('input#total').type('100')
+    cy.get('form > .govuk-button').click()
+
+    // What period was used for this volume?
+    // choose Default abstraction period and continue
+    cy.get('input#totalCustomDates').check()
+    cy.get('form > .govuk-button').click()
+
+    // Volumes
+    // we leave the defaulted values of 50CM, which are 100CM split by the number of months in the abstraction
+    // period (2) and continue
+    cy.get('form > .govuk-button').click()
+
+    // Confirm this return
+    // confirm we are seeing the details we entered then submit
+    cy.get('table > tbody').within(() => {
+      cy.get('tr:nth-child(1) > td:nth-child(1)').should('contain.text', 'January')
+      cy.get('tr:nth-child(1) > td:nth-child(2)').should('contain.text', '50')
+
+      cy.get('tr:nth-child(2) > td:nth-child(1)').should('contain.text', 'February')
+      cy.get('tr:nth-child(2) > td:nth-child(2)').should('contain.text', '50')
+
+      cy.get('tr:nth-child(3) > td:nth-child(1)').should('contain.text', 'Total volume of water abstracted')
+      cy.get('tr:nth-child(3) > td:nth-child(2)').should('contain.text', '100')
     })
+    cy.get('form > .govuk-button').contains('Submit').click()
+
+    // Return submitted
+    // confirm we see the success panel and then click the Mark for supplementary bill run button
+    cy.get('.panel').should('contain.text', 'Return submitted')
+    cy.get('.govuk-grid-column-two-thirds > .govuk-button').contains('Mark for supplementary bill run').click()
+
+    // You're about to mark this licence for the next supplementary bill run
+    // only options is to confirm or go back. We click the confirm button
+    cy.get('form > .govuk-button').contains('Confirm').click()
+
+    // You've marked this licence for the next supplementary bill run
+    // confirm we see the success panel and then click the link to return to the licence
+    cy.get('.govuk-panel').should('contain.text', "You've marked this licence for the next supplementary bill run")
+    cy.get('#main-content > div > div > p:nth-child(4) > a').click()
+
+    // Summary
+    // confirm the licence has been flagged for the next supplementary bill run for the old charge scheme
+    cy.get('.govuk-notification-banner__content')
+      .should('contain.text', 'This licence has been marked for the next supplementary bill run for the old charge scheme.')
   })
 })


### PR DESCRIPTION
We're onto the last folder of legacy tests; `internal/billing`. No surprise there are tests that have little to do with billing and would be better located elsewhere. The first of these is `mark-licence-for-supplementary-billing.spec.js`.

It is in the billing folder and is named as a test to mark a licence for supplementary billing. But having reviewed the test its primary concern is to submit a return against a licence. Marking it for supplementary billing is a small step it tags on the end!

So, we bring this into our `internal/returns` folder. What we also realised was our existing `submit.cy.js` test was actually using the record receipt option in returns. So, a rename frees up 'submit' for the legacy test we're migrating.

Finally, whilst we were doing this we knew that `internal/charge-information/sroc/journey.cy.js` also results in a licence being marked for supplementary billing. So, we tweaked the end of that test to include confirmation this happens.