### PR TITLE
Update to support wal-dev-environment

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,9 +3,9 @@
   "tasks": [
     {
       "label": "📺 Open (Tests)",
-      "detail": "Open Cypress test runner to manually run the tests",
+      "detail": "Open Cypress test UI to manually run the tests",
       "type": "shell",
-      "command": "npm run cy:open; echo 'All done! 🎉'",
+      "command": "npm run cy:open:${input:environments}; echo 'All done! 🎉'",
       "group": "test",
       "presentation": {
         "echo": true,
@@ -20,7 +20,7 @@
       "label": "📻 Run (Tests)",
       "detail": "Run Cypress tests headless using the runner",
       "type": "shell",
-      "command": "npm run cy:run; echo 'All done! 🎉'",
+      "command": "npm run cy:run:${input:environments}; echo 'All done! 🎉'",
       "group": "test",
       "presentation": {
         "echo": true,
@@ -90,6 +90,19 @@
         "showReuseMessage": false,
         "clear": true
       }
+    }
+  ],
+  "inputs": [
+    {
+      "id": "environments",
+      "description": "Cypress environments",
+      "type": "pickString",
+      "options": [
+        "local",
+        "dev",
+        "tst",
+        "pre"
+      ]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -5,11 +5,11 @@
   "homepage": "https://github.com/DEFRA/water-abstraction-team",
   "main": "index.js",
   "scripts": {
-    "cy:open": "cypress open --e2e --env environment=local",
+    "cy:open:local": "cypress open --e2e --env environment=local",
     "cy:open:dev": "cypress open --e2e --env environment=dev",
     "cy:open:tst": "cypress open --e2e --env environment=tst",
     "cy:open:pre": "cypress open --e2e --env environment=pre",
-    "cy:run": "npm run cy:reports:delete && cypress run --e2e --env environment=local",
+    "cy:run:local": "npm run cy:reports:delete && cypress run --e2e --env environment=local",
     "cy:run:dev": "npm run cy:reports:delete && cypress run --e2e --env environment=dev",
     "cy:run:tst": "npm run cy:reports:delete && cypress run --e2e --env environment=tst",
     "cy:run:pre": "npm run cy:reports:delete && cypress run --e2e --env environment=pre",


### PR DESCRIPTION
**wal-dev-environment** is our repo which builds and maintains our local WRLS environment. This repo is now ready to be added to it but we need to make some tweaks. We're big fans of VSCode tasks and we have tasks in the **wal-dev-environment** we want to add that will trigger actions in this repo.

To do that though we need to tweak the `package.json` so that all environments are consistent; no more special case for `local`. To help with that though we also add in a drop-down list. Now the tasks in this repo (should you wish to use it directly outside **wal-dev-environment**) are more intelligent and allow you to select your chosen environment from a drop-down.