### PR TITLE
Fix broken billing tests

### DIFF
--- a/cypress/e2e/internal/billing/annual/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/annual/cancel-existing.cy.js
@@ -8,6 +8,11 @@ describe('Cancel an existing annual bill run (internal)', () => {
     // doesn't add any bill runs so the test works
     cy.setUp('two-part-tariff-billing-data')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
+
+    // Get the current date as a string, for example 12 July 2023
+    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
+      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
+    })
   })
 
   it('cancels an annual bill run that has already finished building', () => {
@@ -57,9 +62,9 @@ describe('Cancel an existing annual bill run (internal)', () => {
     // used. Building might take a second though so to avoid the test failing we use our custom Cypress command to look
     // for the status EMPTY, and if not found reload the page and try a few more times. We then select it using the link
     cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > strong', 'Empty')
-    cy.dayMonthYearFormattedDate().then((formattedDate) => {
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedDate)
+        .should('contain.text', formattedCurrentDate)
         .and('contain.text', 'Test Region')
         .and('contain.text', 'Annual')
     })
@@ -69,8 +74,8 @@ describe('Cancel an existing annual bill run (internal)', () => {
     // quick test that the display is as expected and then click Cancel bill run
     cy.get('dl').within(() => {
       // date created
-      cy.dayMonthYearFormattedDate().then((formattedDate) => {
-        cy.get('div:nth-child(1) > dd').should('contain.text', formattedDate)
+      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+        cy.get('div:nth-child(1) > dd').should('contain.text', formattedCurrentDate)
       })
       // region
       cy.get('div:nth-child(2) > dd').should('contain.text', 'Test Region')
@@ -85,8 +90,8 @@ describe('Cancel an existing annual bill run (internal)', () => {
     // confirm we are deleting the right bill run and click Cancel bill run
     cy.get('dl').within(() => {
       // date created
-      cy.dayMonthYearFormattedDate().then((formattedDate) => {
-        cy.get('div:nth-child(1) > dd').should('contain.text', formattedDate)
+      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+        cy.get('div:nth-child(1) > dd').should('contain.text', formattedCurrentDate)
       })
       // region
       cy.get('div:nth-child(2) > dd').should('contain.text', 'Test Region')
@@ -97,9 +102,9 @@ describe('Cancel an existing annual bill run (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our cancelled bill run is not present
-    cy.dayMonthYearFormattedDate().then((formattedDate) => {
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('not.contain.text', formattedDate)
+        .should('not.contain.text', formattedCurrentDate)
         .and('not.contain.text', 'Test Region')
     })
   })

--- a/cypress/e2e/internal/billing/annual/cancel-in-progress.cy.js
+++ b/cypress/e2e/internal/billing/annual/cancel-in-progress.cy.js
@@ -8,6 +8,11 @@ describe.skip('Cancel an in progress annual bill run (internal)', () => {
     cy.tearDown()
     cy.setUp('supplementary-billing')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
+
+    // Get the current date as a string, for example 12 July 2023
+    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
+      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
+    })
   })
 
   it("starts an annual bill run and then immediately cancels it from the 'building' page", () => {
@@ -54,8 +59,8 @@ describe.skip('Cancel an in progress annual bill run (internal)', () => {
     // confirm we are deleting the right bill run and click Cancel bill run
     cy.get('dl').within(() => {
       // date created
-      cy.dayMonthYearFormattedDate().then((formattedDate) => {
-        cy.get('div:nth-child(1) > dd').should('contain.text', formattedDate)
+      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+        cy.get('div:nth-child(1) > dd').should('contain.text', formattedCurrentDate)
       })
       // region
       cy.get('div:nth-child(2) > dd').should('contain.text', 'Southern (Test replica)')
@@ -66,9 +71,9 @@ describe.skip('Cancel an in progress annual bill run (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our cancelled bill run is not present
-    cy.dayMonthYearFormattedDate().then((formattedDate) => {
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('not.contain.text', formattedDate)
+        .should('not.contain.text', formattedCurrentDate)
         .and('not.contain.text', 'Southern (Test replica)')
         .and('not.contain.text', 'Annual')
     })

--- a/cypress/e2e/internal/billing/annual/journey.cy.js
+++ b/cypress/e2e/internal/billing/annual/journey.cy.js
@@ -5,6 +5,11 @@ describe('Create and send annual bill run (internal)', () => {
     cy.tearDown()
     cy.setUp('sroc-billing-data')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
+
+    // Get the current date as a string, for example 12 July 2023
+    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
+      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
+    })
   })
 
   it('creates an SROC annual bill run and once built confirms and sends it', () => {
@@ -59,8 +64,8 @@ describe('Create and send annual bill run (internal)', () => {
     // check the details then click Send bill run
     cy.get('dl').within(() => {
       // date created
-      cy.dayMonthYearFormattedDate().then((formattedDate) => {
-        cy.get('div:nth-child(1) > dd').should('contain.text', formattedDate)
+      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+        cy.get('div:nth-child(1) > dd').should('contain.text', formattedCurrentDate)
       })
       // region
       cy.get('div:nth-child(2) > dd').should('contain.text', 'Test Region')
@@ -93,9 +98,9 @@ describe('Create and send annual bill run (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our bill run is present and listed as SENT
-    cy.dayMonthYearFormattedDate().then((formattedDate) => {
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('contain.text', formattedDate)
+        .should('contain.text', formattedCurrentDate)
         .and('contain.text', 'Test Region')
         .and('contain.text', 'Annual')
         .and('contain.text', '2,171.00')

--- a/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
@@ -8,6 +8,11 @@ describe('Cancel existing supplementary bill runs (internal)', () => {
     // doesn't add any bill runs so the test works
     cy.setUp('two-part-tariff-billing-data')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
+
+    // Get the current date as a string, for example 12 July 2023
+    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
+      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
+    })
   })
 
   it('cancels both the PRESROC and SROC supplementary bill runs once they have finished building', () => {
@@ -61,9 +66,9 @@ describe('Cancel existing supplementary bill runs (internal)', () => {
     // for a status of EMPTY, and if not found reload the page and try a few more times. We then select the first one
     // using its link
     cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > strong', 'Empty')
-    cy.dayMonthYearFormattedDate().then((formattedDate) => {
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedDate)
+        .should('contain.text', formattedCurrentDate)
         .and('contain.text', 'Old charge scheme')
         .and('contain.text', 'Test Region')
         .and('contain.text', 'Supplementary')
@@ -74,8 +79,8 @@ describe('Cancel existing supplementary bill runs (internal)', () => {
     // quick test that the display is as expected and then click Cancel bill run
     cy.get('dl').within(() => {
       // date created
-      cy.dayMonthYearFormattedDate().then((formattedDate) => {
-        cy.get('div:nth-child(1) > dd').should('contain.text', formattedDate)
+      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+        cy.get('div:nth-child(1) > dd').should('contain.text', formattedCurrentDate)
       })
       // region
       cy.get('div:nth-child(2) > dd').should('contain.text', 'Test Region')
@@ -96,9 +101,9 @@ describe('Cancel existing supplementary bill runs (internal)', () => {
     // Bill runs
     // Select the SROC bill run (now first in the list using its link
     cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > strong', 'Empty')
-    cy.dayMonthYearFormattedDate().then((formattedDate) => {
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedDate)
+        .should('contain.text', formattedCurrentDate)
         .and('contain.text', 'Test Region')
         .and('contain.text', 'Supplementary')
     })
@@ -108,8 +113,8 @@ describe('Cancel existing supplementary bill runs (internal)', () => {
     // quick test that the display is as expected and then click Cancel bill run
     cy.get('dl').within(() => {
       // date created
-      cy.dayMonthYearFormattedDate().then((formattedDate) => {
-        cy.get('div:nth-child(1) > dd').should('contain.text', formattedDate)
+      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+        cy.get('div:nth-child(1) > dd').should('contain.text', formattedCurrentDate)
       })
       // region
       cy.get('div:nth-child(2) > dd').should('contain.text', 'Test Region')
@@ -126,9 +131,9 @@ describe('Cancel existing supplementary bill runs (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our cancelled bill run is not present
-    cy.dayMonthYearFormattedDate().then((formattedDate) => {
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('not.contain.text', formattedDate)
+        .should('not.contain.text', formattedCurrentDate)
         .and('not.contain.text', 'Test Region')
     })
   })

--- a/cypress/e2e/internal/billing/supplementary/cancel-in-progress.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/cancel-in-progress.cy.js
@@ -8,6 +8,11 @@ describe.skip('Cancel an in progress supplementary bill run (internal)', () => {
     cy.tearDown()
     cy.setUp('supplementary-billing')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
+
+    // Get the current date as a string, for example 12 July 2023
+    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
+      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
+    })
   })
 
   it("starts a supplementary bill run and then immediately cancels the PRESROC one from the 'building' page", () => {
@@ -54,8 +59,8 @@ describe.skip('Cancel an in progress supplementary bill run (internal)', () => {
     // confirm we are deleting the right bill run and click Cancel bill run
     cy.get('dl').within(() => {
       // date created
-      cy.dayMonthYearFormattedDate().then((formattedDate) => {
-        cy.get('div:nth-child(1) > dd').should('contain.text', formattedDate)
+      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+        cy.get('div:nth-child(1) > dd').should('contain.text', formattedCurrentDate)
       })
       // region
       cy.get('div:nth-child(2) > dd').should('contain.text', 'Southern (Test replica)')
@@ -66,9 +71,9 @@ describe.skip('Cancel an in progress supplementary bill run (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our cancelled bill run is not present
-    cy.dayMonthYearFormattedDate().then((formattedDate) => {
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('not.contain.text', formattedDate)
+        .should('not.contain.text', formattedCurrentDate)
         .and('not.contain.text', 'Old charge scheme')
         .and('not.contain.text', 'Southern (Test replica)')
         .and('not.contain.text', 'Supplementary')

--- a/cypress/e2e/internal/billing/supplementary/journey.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/journey.cy.js
@@ -5,6 +5,21 @@ describe('Create and send supplementary bill runs (internal)', () => {
     cy.tearDown()
     cy.setUp('sroc-billing-data')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
+
+    // Get the current date as a string, for example 12 July 2023
+    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
+      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
+    })
+
+    // Work out current financial year info using the current date. So, what the end year will be. As we don't override
+    // day and month we'll get back 20XX-03-31. We then use that date to work out how many SROC billing periods we
+    // expect to be calculated. We combine these results into one value for use in our tests
+    cy.currentFinancialYearDate().then((currentFinancialYearInfo) => {
+      cy.numberOfSrocBillingPeriods(currentFinancialYearInfo.year).then((numberOfBillingPeriods) => {
+        currentFinancialYearInfo.billingPeriodCount = numberOfBillingPeriods
+        cy.wrap(currentFinancialYearInfo).as('currentFinancialYearInfo')
+      })
+    })
   })
 
   it('creates both the PRESROC and SROC supplementary bill runs and once built sends them', () => {
@@ -61,8 +76,8 @@ describe('Create and send supplementary bill runs (internal)', () => {
     // check the details then click Send bill run
     cy.get('dl').within(() => {
       // date created
-      cy.dayMonthYearFormattedDate().then((formattedDate) => {
-        cy.get('div:nth-child(1) > dd').should('contain.text', formattedDate)
+      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+        cy.get('div:nth-child(1) > dd').should('contain.text', formattedCurrentDate)
       })
       // region
       cy.get('div:nth-child(2) > dd').should('contain.text', 'Test Region')
@@ -95,9 +110,9 @@ describe('Create and send supplementary bill runs (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our PRESROC bill run is present and listed as SENT
-    cy.dayMonthYearFormattedDate().then((formattedDate) => {
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('contain.text', formattedDate)
+        .should('contain.text', formattedCurrentDate)
         .and('contain.text', 'Old charge scheme')
         .and('contain.text', 'Test Region')
         .and('contain.text', 'Supplementary')
@@ -114,16 +129,24 @@ describe('Create and send supplementary bill runs (internal)', () => {
     // Test Region supplementary bill run
     // check the details before confirming the bill run
     cy.get('#main-content > div:nth-child(1) > div > p > strong').should('contain.text', 'Ready')
-    cy.get('#main-content > div:nth-child(2) > div > h2').should('contain.text', '£97.00')
-    cy.get('#main-content > div:nth-child(4) > div > h2').should('contain.text', '1 supplementary bill')
+    cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
+      const { billingPeriodCount } = currentFinancialYearInfo
+      if (billingPeriodCount === 1) {
+        cy.get('#main-content > div:nth-child(4) > div > h2')
+          .should('contain.text', '1 supplementary bill')
+      } else {
+        cy.get('#main-content > div:nth-child(4) > div > h2')
+          .should('contain.text', `${billingPeriodCount} supplementary bills`)
+      }
+    })
     cy.get('.govuk-button').contains('Confirm bill run').click()
 
     // You're about to send this bill run
     // check the details then click Send bill run
     cy.get('dl').within(() => {
       // date created
-      cy.dayMonthYearFormattedDate().then((formattedDate) => {
-        cy.get('div:nth-child(1) > dd').should('contain.text', formattedDate)
+      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+        cy.get('div:nth-child(1) > dd').should('contain.text', formattedCurrentDate)
       })
       // region
       cy.get('div:nth-child(2) > dd').should('contain.text', 'Test Region')
@@ -156,13 +179,19 @@ describe('Create and send supplementary bill runs (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our SROC bill run is present and listed as SENT
-    cy.dayMonthYearFormattedDate().then((formattedDate) => {
-      cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(2)')
-        .should('contain.text', formattedDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Supplementary')
-        .and('contain.text', '£97.00')
-        .and('contain.text', 'Sent')
+    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(2)').within(() => {
+      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+        cy.get('td:nth-child(1)').should('contain.text', formattedCurrentDate)
+      })
+
+      cy.get('td:nth-child(2)').should('contain.text', 'Test Region')
+      cy.get('td:nth-child(3)').should('contain.text', 'Supplementary')
+
+      cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
+        cy.get('td:nth-child(4)').should('contain.text', currentFinancialYearInfo.billingPeriodCount)
+      })
+
+      cy.get('td:nth-child(6)').should('contain.text', 'Sent')
     })
   })
 })

--- a/cypress/e2e/internal/billing/two-part-tariff/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/cancel-existing.cy.js
@@ -5,6 +5,11 @@ describe('Cancel an existing two-part tariff bill run (internal)', () => {
     cy.tearDown()
     cy.setUp('two-part-tariff-billing-data')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
+
+    // Get the current date as a string, for example 12 July 2023
+    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
+      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
+    })
   })
 
   it('cancels a PRESROC two-part tariff bill run that has already finished building', () => {
@@ -61,9 +66,9 @@ describe('Cancel an existing two-part tariff bill run (internal)', () => {
     // used. Building might take a second though so to avoid the test failing we use our custom Cypress command to look
     // for the status EMPTY, and if not found reload the page and try a few more times. We then select it using the link
     cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > strong', 'Empty')
-    cy.dayMonthYearFormattedDate().then((formattedDate) => {
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedDate)
+        .should('contain.text', formattedCurrentDate)
         .and('contain.text', 'Old charge scheme')
         .and('contain.text', 'Test Region')
         .and('contain.text', 'Two-part tariff')
@@ -74,8 +79,8 @@ describe('Cancel an existing two-part tariff bill run (internal)', () => {
     // quick test that the display is as expected and then click Cancel bill run
     cy.get('dl').within(() => {
       // date created
-      cy.dayMonthYearFormattedDate().then((formattedDate) => {
-        cy.get('div:nth-child(1) > dd').should('contain.text', formattedDate)
+      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+        cy.get('div:nth-child(1) > dd').should('contain.text', formattedCurrentDate)
       })
       // region
       cy.get('div:nth-child(2) > dd').should('contain.text', 'Test Region')
@@ -90,8 +95,8 @@ describe('Cancel an existing two-part tariff bill run (internal)', () => {
     // confirm we are deleting the right bill run and click Cancel bill run
     cy.get('dl').within(() => {
       // date created
-      cy.dayMonthYearFormattedDate().then((formattedDate) => {
-        cy.get('div:nth-child(1) > dd').should('contain.text', formattedDate)
+      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+        cy.get('div:nth-child(1) > dd').should('contain.text', formattedCurrentDate)
       })
       // region
       cy.get('div:nth-child(2) > dd').should('contain.text', 'Test Region')
@@ -102,9 +107,9 @@ describe('Cancel an existing two-part tariff bill run (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our cancelled bill run is not present
-    cy.dayMonthYearFormattedDate().then((formattedDate) => {
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('not.contain.text', formattedDate)
+        .should('not.contain.text', formattedCurrentDate)
         .and('not.contain.text', 'Test Region')
     })
   })

--- a/cypress/e2e/internal/billing/two-part-tariff/cancel-in-progress.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/cancel-in-progress.cy.js
@@ -8,6 +8,11 @@ describe.skip('Cancel an in progress Two-part tariff bill run (internal)', () =>
     cy.tearDown()
     cy.setUp('two-part-tariff-billing-data')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
+
+    // Get the current date as a string, for example 12 July 2023
+    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
+      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
+    })
   })
 
   it("starts a Two-part tariff bill run and then immediately cancels the PRESROC one from the 'building' page", () => {
@@ -61,8 +66,8 @@ describe.skip('Cancel an in progress Two-part tariff bill run (internal)', () =>
     // confirm we are deleting the right bill run and click Cancel bill run
     cy.get('dl').within(() => {
       // date created
-      cy.dayMonthYearFormattedDate().then((formattedDate) => {
-        cy.get('div:nth-child(1) > dd').should('contain.text', formattedDate)
+      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+        cy.get('div:nth-child(1) > dd').should('contain.text', formattedCurrentDate)
       })
       // region
       cy.get('div:nth-child(2) > dd').should('contain.text', 'Test Region')
@@ -73,9 +78,9 @@ describe.skip('Cancel an in progress Two-part tariff bill run (internal)', () =>
 
     // Bill runs
     // back on the bill runs page confirm our cancelled bill run is not present
-    cy.dayMonthYearFormattedDate().then((formattedDate) => {
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('not.contain.text', formattedDate)
+        .should('not.contain.text', formattedCurrentDate)
         .and('not.contain.text', 'Old charge scheme')
         .and('not.contain.text', 'Test Region')
         .and('not.contain.text', 'Two-part tariff')

--- a/cypress/e2e/internal/billing/two-part-tariff/journey.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/journey.cy.js
@@ -5,6 +5,11 @@ describe('Create and send PRESROC two-part tariff bill run (internal)', () => {
     cy.tearDown()
     cy.setUp('five-year-two-part-tariff-bill-runs')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
+
+    // Get the current date as a string, for example 12 July 2023
+    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
+      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
+    })
   })
 
   it('creates a PRESROC two-part tariff bill run and once built confirms and sends it', () => {
@@ -93,8 +98,8 @@ describe('Create and send PRESROC two-part tariff bill run (internal)', () => {
     // confirm the details and click confirm
     cy.get('dl').within(() => {
       // date created
-      cy.dayMonthYearFormattedDate().then((formattedDate) => {
-        cy.get('div:nth-child(1) > dd').should('contain.text', formattedDate)
+      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+        cy.get('div:nth-child(1) > dd').should('contain.text', formattedCurrentDate)
       })
       // region
       cy.get('div:nth-child(2) > dd').should('contain.text', 'Test Region')
@@ -117,8 +122,8 @@ describe('Create and send PRESROC two-part tariff bill run (internal)', () => {
     // check the details then click Send bill run
     cy.get('dl').within(() => {
       // date created
-      cy.dayMonthYearFormattedDate().then((formattedDate) => {
-        cy.get('div:nth-child(1) > dd').should('contain.text', formattedDate)
+      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+        cy.get('div:nth-child(1) > dd').should('contain.text', formattedCurrentDate)
       })
       // region
       cy.get('div:nth-child(2) > dd').should('contain.text', 'Test Region')
@@ -150,9 +155,9 @@ describe('Create and send PRESROC two-part tariff bill run (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our PRESROC bill run is present and listed as SENT
-    cy.dayMonthYearFormattedDate().then((formattedDate) => {
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('contain.text', formattedDate)
+        .should('contain.text', formattedCurrentDate)
         .and('contain.text', 'Old charge scheme')
         .and('contain.text', 'Test Region')
         .and('contain.text', 'Two-part tariff')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3984

We have updated our SROC supplementary billing engine to handle multiple years. When new charge information is added it will flag the licence for supplementary billing. Our first iteration of the engine only calculated bills for the financial year 2022-2023. But as a service, we support customers making changes as far back as 5 years ago. So, the supplementary billing engine needs to look at a licence's charge information and calculate what the charge would be, starting with the current financial year and working back 5 more.

> The SROC scheme into effect in April 2022, so the 5 years is cut off at that point. The PRESROC engine handles anything prior to this

What this results in is SROC supplementary bill runs will now feature multiple bills for the same invoice account, one for each year. Our tests were written when there would be only one. We need to amend our assertions, not only to account for this but to support the fact this number will keep increasing by one each year until we are 5 years away from 2022.

Fortunately, only one test is affected; `cypress/e2e/internal/billing/supplementary/journey.cy.js`. To fix it we focus on implementing a custom command that can calculate how many billing periods will be covered in a bill run when given a financial year. We then updated the test to focus on checking the number of bill runs rather than a £ value, as this will be more brittle and outside our control.

When implementing the changes we came up with a 'calculate once' pattern for the test. We move all the current calls to custom commands into the `beforeEach()` and then reference the values when needed. This works so well that we apply it to all tests using relevant custom commands.
