### PR TITLE
Fix flaky tests where description keeps changing

### DIFF
--- a/cypress/e2e/internal/charge-information/presroc/licence-transfer.cy.js
+++ b/cypress/e2e/internal/charge-information/presroc/licence-transfer.cy.js
@@ -122,10 +122,6 @@ describe('PRESROC licence transfer (internal)', () => {
     })
     cy.get('form > section > h2').should('contain.text', 'Element')
     cy.get('form > section > dl').within(() => {
-      // purpose
-      cy.get('div:nth-child(1) > dd.govuk-summary-list__value').should('contain.text', 'General Use Relating To Secondary Category (Medium Loss)')
-      // description
-      cy.get('div:nth-child(2) > dd.govuk-summary-list__value').should('contain.text', 'General Use Relating To Secondary Category (Medium Loss)')
       // abstraction period
       cy.get('div:nth-child(3) > dd.govuk-summary-list__value').should('contain.text', '1 April to 31 March')
       // annual quantities

--- a/cypress/e2e/internal/charge-information/sroc/validation.cy.js
+++ b/cypress/e2e/internal/charge-information/sroc/validation.cy.js
@@ -126,8 +126,6 @@ describe('SROC charge information validation (internal)', () => {
     })
     cy.get('form > section > h2').should('contain.text', 'Element')
     cy.get('form > section > dl').within(() => {
-      // purpose
-      cy.get('div:nth-child(1) > dd.govuk-summary-list__value').should('contain.text', 'General Use Relating To Secondary Category (Medium Loss)')
       // description
       cy.get('div:nth-child(2) > dd.govuk-summary-list__value').should('contain.text', 'Test Charge Element!')
       // abstraction period


### PR DESCRIPTION
We have been encountering an issue with our charge information tests. We have assertions that check for a specific description and purpose thinking that as we control the test data the descriptions should not change. But they do. Everything else in the tests is fine. It just appears that when the test data engine is creating the records the `charge_element` is using random purposes which means we cannot guarantee what we are asserting against.

Until we also have rebuilt that test data engine, we can't afford to include these assertions which make the tests flaky. Nothing is lost with their removal, the test of the journey is still valid.