### PR TITLE
Switch to using new test tear-down

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -44,14 +44,11 @@ Cypress.Commands.add('tearDown', () => {
   cy.log('Tearing down existing test data')
 
   cy.request({
-    url: '/acceptance-tests/tear-down',
+    url: '/system/data/tear-down',
     log: false,
     method: 'POST',
-    headers: {
-      authorization: `Bearer ${Cypress.env('jwtToken')}`
-    },
     timeout: 60000
-  }).its('status', { log: false }).should('equal', 200)
+  }).its('status', { log: false }).should('equal', 204)
 })
 
 Cypress.Commands.add('lastNotification', (email) => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3982

Using the existing acceptance tests a common issue we face is that we can't clear down the existing test data. Because of the solution previously implemented, it only focuses on data flagged as `is_test === true`. The problem is when using this data for test purposes you will often create related data that is not flagged as `is_test`. This leads to errors in the existing clear-down process that we then have to create and run manual SQL delete scripts to deal with.

On top of that everything is driven through the network calls across the services. We know they haven't been properly isolated as they should have if micro-services was the intent. Knowing that we can improve the performance by just using direct SQL calls to do the teardown.

So we added a [Reliable test data clear down](https://github.com/DEFRA/water-abstraction-system/pull/215) endpoint to the **water-abstraction-system** app.

This change updates the acceptance tests to use it rather than the old mechanism. Timings will vary across machines and environments. But so far our tests all show the new endpoint is quicker leading to a reduced runtime for all tests.