### PR TITLE
Fix more flaky tests

### DIFF
--- a/cypress/e2e/internal/billing/annual/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/annual/cancel-existing.cy.js
@@ -102,10 +102,7 @@ describe('Cancel an existing annual bill run (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our cancelled bill run is not present
-    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('not.contain.text', formattedCurrentDate)
-        .and('not.contain.text', 'Test Region')
-    })
+    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
+      .should('not.contain.text', 'Test Region')
   })
 })

--- a/cypress/e2e/internal/billing/annual/cancel-in-progress.cy.js
+++ b/cypress/e2e/internal/billing/annual/cancel-in-progress.cy.js
@@ -71,11 +71,8 @@ describe.skip('Cancel an in progress annual bill run (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our cancelled bill run is not present
-    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('not.contain.text', formattedCurrentDate)
-        .and('not.contain.text', 'Southern (Test replica)')
-        .and('not.contain.text', 'Annual')
-    })
+    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
+      .should('not.contain.text', 'Southern (Test replica)')
+      .and('not.contain.text', 'Annual')
   })
 })

--- a/cypress/e2e/internal/billing/scenarios/non-charge-licence-credit.cy.js
+++ b/cypress/e2e/internal/billing/scenarios/non-charge-licence-credit.cy.js
@@ -53,7 +53,7 @@ describe('Make licence non-chargeable then see credit in next bill run (internal
     // Bill runs
     // we immediately select the SROC bill run. We don't expect it to be ready and to hit the spinner page but it
     // might be super quick and already done. So we do no checks at this point
-    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(2) > td:nth-child(1) > a').click()
+    cy.get(':nth-child(2) > :nth-child(1) > .govuk-link').click()
 
     // Test Region supplementary bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
@@ -167,7 +167,7 @@ describe('Make licence non-chargeable then see credit in next bill run (internal
     // Bill runs
     // we immediately select the SROC bill run. We don't expect it to be ready and to hit the spinner page but it
     // might be super quick and already done. So we do no checks at this point
-    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1) > td:nth-child(1) > a').click()
+    cy.get(':nth-child(1) > :nth-child(1) > .govuk-link').click()
 
     // Test Region supplementary bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that

--- a/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
@@ -131,10 +131,7 @@ describe('Cancel existing supplementary bill runs (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our cancelled bill run is not present
-    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('not.contain.text', formattedCurrentDate)
-        .and('not.contain.text', 'Test Region')
-    })
+    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
+      .should('not.contain.text', 'Test Region')
   })
 })

--- a/cypress/e2e/internal/billing/supplementary/cancel-in-progress.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/cancel-in-progress.cy.js
@@ -71,12 +71,9 @@ describe.skip('Cancel an in progress supplementary bill run (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our cancelled bill run is not present
-    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('not.contain.text', formattedCurrentDate)
-        .and('not.contain.text', 'Old charge scheme')
-        .and('not.contain.text', 'Southern (Test replica)')
-        .and('not.contain.text', 'Supplementary')
-    })
+    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
+      .should('not.contain.text', 'Old charge scheme')
+      .and('not.contain.text', 'Southern (Test replica)')
+      .and('not.contain.text', 'Supplementary')
   })
 })

--- a/cypress/e2e/internal/billing/two-part-tariff/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/cancel-existing.cy.js
@@ -107,10 +107,7 @@ describe('Cancel an existing two-part tariff bill run (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our cancelled bill run is not present
-    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('not.contain.text', formattedCurrentDate)
-        .and('not.contain.text', 'Test Region')
-    })
+    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
+      .should('not.contain.text', 'Test Region')
   })
 })

--- a/cypress/e2e/internal/billing/two-part-tariff/cancel-in-progress.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/cancel-in-progress.cy.js
@@ -78,12 +78,9 @@ describe.skip('Cancel an in progress Two-part tariff bill run (internal)', () =>
 
     // Bill runs
     // back on the bill runs page confirm our cancelled bill run is not present
-    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('not.contain.text', formattedCurrentDate)
-        .and('not.contain.text', 'Old charge scheme')
-        .and('not.contain.text', 'Test Region')
-        .and('not.contain.text', 'Two-part tariff')
-    })
+    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
+      .should('not.contain.text', 'Old charge scheme')
+      .and('not.contain.text', 'Test Region')
+      .and('not.contain.text', 'Two-part tariff')
   })
 })

--- a/cypress/e2e/internal/paper-returns/validation.cy.js
+++ b/cypress/e2e/internal/paper-returns/validation.cy.js
@@ -91,7 +91,6 @@ describe('Paper returns validation (internal)', () => {
 
     // Send the paper form
     cy.get('button.govuk-button').contains('Send paper forms').click()
-    cy.get('.govuk-heading-l').contains('Sending paper return forms')
 
     // Paper return forms sent
     cy.get('.govuk-panel__title', { timeout: 10000 }).contains('Paper return forms sent')


### PR DESCRIPTION
Those with experience in acceptance testing will know they are prone to [works on my machine](https://blog.codinghorror.com/the-works-on-my-machine-certification-program/).

We've started running these on different members' machines and found some fail either because of performance or existing data setup. Assertions on certain text content and whether the spinner page appears long enough to test against are the primary contenders.

We also recently made a change to [Warn the user if a bill run is 'processing'](https://github.com/DEFRA/water-abstraction-ui/pull/2369). This made a structural change to the bill runs page that broke some tests.

These changes deal with those we've found so far. Excluding the new warning, when we've looked at the issue we've found we're asserting against something that doesn't have much value. So, rather than make the tests more complex to cater for all possibilities we can just remove the assertion.