### PR TITLE
Handle no bill runs

### DIFF
--- a/cypress/e2e/internal/billing/annual/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/annual/cancel-existing.cy.js
@@ -102,7 +102,18 @@ describe('Cancel an existing annual bill run (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our cancelled bill run is not present
-    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-      .should('not.contain.text', 'Test Region')
+    cy.get('#main-content')
+      .then((mainContent) => {
+        if (mainContent.find('tr').length) {
+          return '#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)'
+        }
+
+        return '#main-content'
+      })
+      .then((selector) => {
+        cy.get(selector)
+          .should('not.contain.text', 'Test Region')
+          .and('not.contain.text', 'Annual')
+      })
   })
 })

--- a/cypress/e2e/internal/billing/annual/cancel-in-progress.cy.js
+++ b/cypress/e2e/internal/billing/annual/cancel-in-progress.cy.js
@@ -71,8 +71,18 @@ describe.skip('Cancel an in progress annual bill run (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our cancelled bill run is not present
-    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-      .should('not.contain.text', 'Southern (Test replica)')
-      .and('not.contain.text', 'Annual')
+    cy.get('#main-content')
+      .then((mainContent) => {
+        if (mainContent.find('tr').length) {
+          return '#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)'
+        }
+
+        return '#main-content'
+      })
+      .then((selector) => {
+        cy.get(selector)
+          .should('not.contain.text', 'Southern (Test replica)')
+          .and('not.contain.text', 'Annual')
+      })
   })
 })

--- a/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
@@ -131,7 +131,18 @@ describe('Cancel existing supplementary bill runs (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our cancelled bill run is not present
-    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-      .should('not.contain.text', 'Test Region')
+    cy.get('#main-content')
+      .then((mainContent) => {
+        if (mainContent.find('tr').length) {
+          return '#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)'
+        }
+
+        return '#main-content'
+      })
+      .then((selector) => {
+        cy.get(selector)
+          .should('not.contain.text', 'Test Region')
+          .and('not.contain.text', 'Supplementary')
+      })
   })
 })

--- a/cypress/e2e/internal/billing/supplementary/cancel-in-progress.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/cancel-in-progress.cy.js
@@ -71,9 +71,19 @@ describe.skip('Cancel an in progress supplementary bill run (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our cancelled bill run is not present
-    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-      .should('not.contain.text', 'Old charge scheme')
-      .and('not.contain.text', 'Southern (Test replica)')
-      .and('not.contain.text', 'Supplementary')
+    cy.get('#main-content')
+      .then((mainContent) => {
+        if (mainContent.find('tr').length) {
+          return '#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)'
+        }
+
+        return '#main-content'
+      })
+      .then((selector) => {
+        cy.get(selector)
+          .should('not.contain.text', 'Old charge scheme')
+          .and('not.contain.text', 'Southern (Test replica)')
+          .and('not.contain.text', 'Supplementary')
+      })
   })
 })

--- a/cypress/e2e/internal/billing/two-part-tariff/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/cancel-existing.cy.js
@@ -107,7 +107,18 @@ describe('Cancel an existing two-part tariff bill run (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our cancelled bill run is not present
-    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-      .should('not.contain.text', 'Test Region')
+    cy.get('#main-content')
+      .then((mainContent) => {
+        if (mainContent.find('tr').length) {
+          return '#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)'
+        }
+
+        return '#main-content'
+      })
+      .then((selector) => {
+        cy.get(selector)
+          .should('not.contain.text', 'Test Region')
+          .and('not.contain.text', 'Two-part tariff')
+      })
   })
 })

--- a/cypress/e2e/internal/billing/two-part-tariff/cancel-in-progress.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/cancel-in-progress.cy.js
@@ -78,9 +78,19 @@ describe.skip('Cancel an in progress Two-part tariff bill run (internal)', () =>
 
     // Bill runs
     // back on the bill runs page confirm our cancelled bill run is not present
-    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-      .should('not.contain.text', 'Old charge scheme')
-      .and('not.contain.text', 'Test Region')
-      .and('not.contain.text', 'Two-part tariff')
+    cy.get('#main-content')
+      .then((mainContent) => {
+        if (mainContent.find('tr').length) {
+          return '#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)'
+        }
+
+        return '#main-content'
+      })
+      .then((selector) => {
+        cy.get(selector)
+          .should('not.contain.text', 'Old charge scheme')
+          .and('not.contain.text', 'Test Region')
+          .and('not.contain.text', 'Two-part tariff')
+      })
   })
 })


### PR DESCRIPTION
Another issue we've encountered getting the tests to run on everyone's machine is those folks who like to click the 'Delete all bills and charge information` button 😮😁

When they then run tests all the ones that test cancelling a bill run fail. This is because they have assertions to confirm the bill run doesn't exist in the results table. The problem is, if you've deleted all bill runs there is no results table!

Rather than force folks to have at least one bill run always present this change updates the tests affected to be able to handle both scenarios.

We use [conditional testing](https://docs.cypress.io/guides/core-concepts/conditional-testing) to achieve this. We are aware this is not considered a best practice as it means the test is no longer deterministic. But until we have a better test data seeding solution and are comfortable starting with a clean slate of a DB it's a compromise we have to accept.