### PR TITLE
Skip tests which are broken because of bad data

### DIFF
--- a/cypress/e2e/internal/returns/send-invite.cy.js
+++ b/cypress/e2e/internal/returns/send-invite.cy.js
@@ -1,6 +1,7 @@
 'use strict'
 
-describe('Send returns invite to customer (internal)', () => {
+// TODO: remove skip() once the licence NW/072/0417/002/R01\r has been fixed
+describe.skip('Send returns invite to customer (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')
@@ -25,9 +26,6 @@ describe('Send returns invite to customer (internal)', () => {
     // navigate to the invitations flow
     cy.get('#navbar-notifications').click()
     cy.get('a[href="/returns-notifications/invitations"]').click()
-
-    // TODO: remove once the licence NW/072/0417/002/R01\r has been fixed
-    cy.get('textarea#excludeLicences').type('NW/072/0417/002/R01\r')
 
     // Send returns invitations
     // just click continue. The page is for submitting licences to be excluded which this test doesn't cover

--- a/cypress/e2e/internal/returns/send-invite.cy.js
+++ b/cypress/e2e/internal/returns/send-invite.cy.js
@@ -26,6 +26,9 @@ describe('Send returns invite to customer (internal)', () => {
     cy.get('#navbar-notifications').click()
     cy.get('a[href="/returns-notifications/invitations"]').click()
 
+    // TODO: remove once the licence NW/072/0417/002/R01\r has been fixed
+    cy.get('textarea#excludeLicences').type('NW/072/0417/002/R01\r')
+
     // Send returns invitations
     // just click continue. The page is for submitting licences to be excluded which this test doesn't cover
     cy.get('form > .govuk-button').click()

--- a/cypress/e2e/internal/returns/send-reminder.cy.js
+++ b/cypress/e2e/internal/returns/send-reminder.cy.js
@@ -1,6 +1,7 @@
 'use strict'
 
-describe('Send returns reminder to customer (internal)', () => {
+// TODO: remove skip() once the licence NW/072/0417/002/R01\r has been fixed
+describe.skip('Send returns reminder to customer (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
     cy.setUp('barebones')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4182
https://eaflood.atlassian.net/browse/WATER-4180

Whilst trying to sign off a release our acceptance tests kept failing. We finally tracked it down to the `cypress/e2e/internal/returns/send-invite.cy.js` and `cypress/e2e/internal/returns/send-reminder.cy.js` tests.

They are broken because a licence from NALD that includes a carriage return in its reference has managed to get through the import process into the WRLS DB.

Both these functions automatically scoop up all licences that either need a return invitation or a reminder sent out. The field in the journey only allows you to enter those you wish to exclude.

We tried to exclude the problem licence in the tests, but because of the way the legacy code is built, it's still trying to pull the problem licence from the DB as part of the process which is causing its model validators to explode.

And for reasons we don't understand yet, when these tests blow up they bring down every single test that follows.

So, until we can resolve the data issue with `NW/072/0417/002/R01` our on option to get the rest of the tests running and passing is to skip the invitation and reminder tests.