### PR TITLE
Update bill run tests with journey changes

### DIFF
--- a/cypress/e2e/internal/billing/annual/journey.cy.js
+++ b/cypress/e2e/internal/billing/annual/journey.cy.js
@@ -54,10 +54,10 @@ describe('Create and send annual bill run (internal)', () => {
     // Test Region annual bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can check the rest of the details before confirming the bill run
-    cy.get('#main-content > div:nth-child(1) > div > p > strong', { timeout: 20000 }).should('contain.text', 'Ready')
-    cy.get('#main-content > div:nth-child(2) > div > h2').should('contain.text', '£2,171.00')
-    cy.get('div#water-companies > table > tbody > tr').should('have.length', 4)
-    cy.get('div#other-abstractors > table').should('not.exist')
+    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
+    cy.get('[data-test="bill-total"]').should('contain.text', '£2,171.00')
+    cy.get('[data-test="water-companies"]').should('exist')
+    cy.get('[data-test="other-abstractors"]').should('not.exist')
     cy.get('.govuk-button').contains('Confirm bill run').click()
 
     // You're about to send this bill run
@@ -76,7 +76,7 @@ describe('Create and send annual bill run (internal)', () => {
     })
     cy.get('.govuk-button').contains('Send bill run').click()
 
-    // Test Region Supplementary bill run
+    // Test Region annual bill run
     // spinner page displayed whilst the bill run is 'sending'. Confirm we're on it
     cy.get('#main-content > div:nth-child(2) > div > p.govuk-body > strong').should('contain.text', 'Sending')
     cy.get('#main-content > div:nth-child(2) > div > p.govuk-body-l')
@@ -91,10 +91,10 @@ describe('Create and send annual bill run (internal)', () => {
 
     // Test Region annual bill run
     // confirm we see it is now SENT
-    cy.get('#main-content > div:nth-child(1) > div > p > strong').should('contain.text', 'Sent')
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
 
-    // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    // click the back link to go to bill runs
+    cy.get('.govuk-back-link').click()
 
     // Bill runs
     // back on the bill runs page confirm our bill run is present and listed as SENT

--- a/cypress/e2e/internal/billing/annual/remove-licence.cy.js
+++ b/cypress/e2e/internal/billing/annual/remove-licence.cy.js
@@ -49,14 +49,16 @@ describe('Remove bill from annual bill run (internal)', () => {
     // Test Region annual bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can confirm we have 4 bills then click to view the first one
-    cy.get('#main-content > div:nth-child(1) > div > p > strong', { timeout: 20000 }).should('contain.text', 'Ready')
-    cy.get('#main-content > div:nth-child(2) > div > h2').should('contain.text', '£2,171.00')
-    cy.get('div#water-companies > table > tbody > tr').should('have.length', 4)
-    cy.get('.govuk-table__body > :nth-child(1) > :nth-child(5)').contains('View').click()
+    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
+    cy.get('[data-test="bill-total"]').should('contain.text', '£2,171.00')
+    cy.get('[data-test="water-companies"]').should('exist')
+    cy.get('[data-test="other-abstractors"]').should('not.exist')
+    cy.get('[data-test="water-companies"] > tbody > tr').should('have.length', 4)
+    cy.get('[data-test="action-3"] > .govuk-link').click()
 
     // Bill for Big Farm Co Ltd 04
     // click the Remove bill
-    cy.get('.govuk-grid-column-two-thirds > .govuk-button').contains('Remove bill').click()
+    cy.get('.govuk-button').contains('Remove bill').click()
 
     // You're about to remove this bill from the annual bill run
     // confirm we are on the remove bill confirmation page and then click Remove this bill
@@ -76,8 +78,10 @@ describe('Remove bill from annual bill run (internal)', () => {
     // Test Region annual bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can confirm we're down to 3 bills
-    cy.get('#main-content > div:nth-child(1) > div > p > strong', { timeout: 20000 }).should('contain.text', 'Ready')
-    cy.get('#main-content > div:nth-child(2) > div > h2').should('contain.text', '£291.00')
-    cy.get('div#water-companies > table > tbody > tr').should('have.length', 3)
+    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
+    cy.get('[data-test="bill-total"]').should('contain.text', '£291.00')
+    cy.get('[data-test="water-companies"]').should('exist')
+    cy.get('[data-test="other-abstractors"]').should('not.exist')
+    cy.get('[data-test="water-companies"] > tbody > tr').should('have.length', 3)
   })
 })

--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
@@ -64,17 +64,17 @@ describe('Change billing account in current financial year (internal)', () => {
     // Test Region supplementary bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can confirm the bill run is a credit as expected
-    cy.get('#main-content > div:nth-child(1) > div > p > strong', { timeout: 20000 }).should('contain.text', 'Ready')
+    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
 
     // check the details before confirming the bill run
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const { billingPeriodCount } = currentFinancialYearInfo
       if (billingPeriodCount === 1) {
-        cy.get('#main-content > div:nth-child(4) > div > h2')
-          .should('contain.text', '1 supplementary bill')
+        cy.get('[data-test="bills-count"]')
+          .should('contain.text', '1 Supplementary bill')
       } else {
-        cy.get('#main-content > div:nth-child(4) > div > h2')
-          .should('contain.text', `${billingPeriodCount} supplementary bills`)
+        cy.get('[data-test="bills-count"]')
+          .should('contain.text', `${billingPeriodCount} Supplementary bills`)
       }
     })
     cy.get('.govuk-button').contains('Confirm bill run').click()
@@ -110,10 +110,10 @@ describe('Change billing account in current financial year (internal)', () => {
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('#main-content > div:nth-child(1) > div > p > strong').should('contain.text', 'Sent')
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
 
-    // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    // click the back link to go to bill runs
+    cy.get('.govuk-back-link').click()
 
     // Bill runs
     // back on the bill runs page confirm our SROC bill run is present and listed as SENT
@@ -239,7 +239,7 @@ describe('Change billing account in current financial year (internal)', () => {
     // Test Region supplementary bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can confirm the bill run is a credit as expected
-    cy.get('#main-content > div:nth-child(1) > div > p > strong', { timeout: 20000 }).should('contain.text', 'Ready')
+    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
 
     // check the details and then click Confirm bill run
     cy.get('dl').within(() => {
@@ -254,15 +254,17 @@ describe('Change billing account in current financial year (internal)', () => {
       // charge scheme
       cy.get('div:nth-child(4) > dd').should('contain.text', 'Current')
     })
-    cy.get('#main-content').should('contain.text', '1 credit note').and('contain.text', '1 invoice')
-    // NOTE: We cannot assert the new billing account number because it will be different in each environment and
+    cy.get('[data-test="credits-count"]').should('contain.text', '1 credit note')
+    cy.get('[data-test="debits-count"]').should('contain.text', '1 invoice')
+    // NOTE: We cannot assert the new billing account numbers because it will be different in each environment and
     // unpredictable because the new number is based on existing data
-    cy.get(':nth-child(6) > .govuk-grid-column-full').should('contain.text', 'A00000002A')
-    cy.get(':nth-child(6) > .govuk-grid-column-full').should('contain.text', 'Big Farm Co Ltd 02')
-    cy.get(':nth-child(6) > .govuk-grid-column-full').should('contain.text', 'Big Farm Co Ltd 01')
-    cy.get(':nth-child(6) > .govuk-grid-column-full').should('contain.text', 'AT/SROC/SUPB/02')
-    cy.get(':nth-child(6) > .govuk-grid-column-full').should('contain.text', '£97.00')
-    cy.get(':nth-child(6) > .govuk-grid-column-full').should('contain.text', 'Credit note')
+    cy.get('[data-test="billing-contact-0"]').should('contain.text', 'Big Farm Co Ltd 02')
+    cy.get('[data-test="licence-0"]').should('contain.text', 'AT/SROC/SUPB/02')
+    cy.get('[data-test="total-0"]').should('contain.text', '-£97.00')
+
+    cy.get('[data-test="billing-contact-1"]').should('contain.text', 'Big Farm Co Ltd 01')
+    cy.get('[data-test="licence-1"]').should('contain.text', 'AT/SROC/SUPB/02')
+    cy.get('[data-test="total-1"]').should('contain.text', '£97.00')
     cy.get('.govuk-button').contains('Confirm bill run').click()
 
     // You're about to send this bill run
@@ -296,10 +298,10 @@ describe('Change billing account in current financial year (internal)', () => {
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('#main-content > div:nth-child(1) > div > p > strong').should('contain.text', 'Sent')
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
 
-    // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    // click the back link to go to bill runs
+    cy.get('.govuk-back-link').click()
 
     // Bill runs
     // back on the bill runs page confirm our SROC bill run is present and listed as SENT

--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
@@ -64,17 +64,17 @@ describe('Change billing account in previous financial year (internal)', () => {
     // Test Region supplementary bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can confirm the bill run is a credit as expected
-    cy.get('#main-content > div:nth-child(1) > div > p > strong', { timeout: 20000 }).should('contain.text', 'Ready')
+    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
 
     // check the details before confirming the bill run
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const { billingPeriodCount } = currentFinancialYearInfo
       if (billingPeriodCount === 1) {
-        cy.get('#main-content > div:nth-child(4) > div > h2')
-          .should('contain.text', '1 supplementary bill')
+        cy.get('[data-test="bills-count"]')
+          .should('contain.text', '1 Supplementary bill')
       } else {
-        cy.get('#main-content > div:nth-child(4) > div > h2')
-          .should('contain.text', `${billingPeriodCount} supplementary bills`)
+        cy.get('[data-test="bills-count"]')
+          .should('contain.text', `${billingPeriodCount} Supplementary bills`)
       }
     })
     cy.get('.govuk-button').contains('Confirm bill run').click()
@@ -110,10 +110,10 @@ describe('Change billing account in previous financial year (internal)', () => {
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('#main-content > div:nth-child(1) > div > p > strong').should('contain.text', 'Sent')
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
 
-    // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    // click the back link to go to bill runs
+    cy.get('.govuk-back-link').click()
 
     // Bill runs
     // back on the bill runs page confirm our SROC bill run is present and listed as SENT
@@ -239,7 +239,7 @@ describe('Change billing account in previous financial year (internal)', () => {
     // Test Region supplementary bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can confirm the bill run is a credit as expected
-    cy.get('#main-content > div:nth-child(1) > div > p > strong', { timeout: 20000 }).should('contain.text', 'Ready')
+    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
 
     // check the details and then click Confirm bill run
     cy.get('dl').within(() => {
@@ -254,16 +254,25 @@ describe('Change billing account in previous financial year (internal)', () => {
       // charge scheme
       cy.get('div:nth-child(4) > dd').should('contain.text', 'Current')
     })
-    cy.get('#main-content').should('contain.text', '2 credit notes').and('contain.text', '2 invoices')
+    cy.get('[data-test="credits-count"]').should('contain.text', '2 credit notes')
+    cy.get('[data-test="debits-count"]').should('contain.text', '2 invoices')
     // NOTE: We cannot assert the new billing account number because it will be different in each environment and
     // unpredictable because the new number is based on existing data
-    cy.get(':nth-child(6) > .govuk-grid-column-full').should('contain.text', 'A00000002A')
-    cy.get(':nth-child(6) > .govuk-grid-column-full').should('contain.text', 'Big Farm Co Ltd 02')
-    cy.get(':nth-child(6) > .govuk-grid-column-full').should('contain.text', 'Big Farm Co Ltd 01')
-    cy.get(':nth-child(6) > .govuk-grid-column-full').should('contain.text', 'AT/SROC/SUPB/02')
-    cy.get(':nth-child(6) > .govuk-grid-column-full').should('contain.text', '£97.00')
-    cy.get(':nth-child(6) > .govuk-grid-column-full').should('contain.text', '£80.79')
-    cy.get(':nth-child(6) > .govuk-grid-column-full').should('contain.text', 'Credit note')
+    cy.get('[data-test="billing-contact-0"]').should('contain.text', 'Big Farm Co Ltd 02')
+    cy.get('[data-test="licence-0"]').should('contain.text', 'AT/SROC/SUPB/02')
+    cy.get('[data-test="total-0"]').should('contain.text', '-£97.00')
+
+    cy.get('[data-test="billing-contact-1"]').should('contain.text', 'Big Farm Co Ltd 02')
+    cy.get('[data-test="licence-1"]').should('contain.text', 'AT/SROC/SUPB/02')
+    cy.get('[data-test="total-1"]').should('contain.text', '-£80.79')
+
+    cy.get('[data-test="billing-contact-2"]').should('contain.text', 'Big Farm Co Ltd 01')
+    cy.get('[data-test="licence-2"]').should('contain.text', 'AT/SROC/SUPB/02')
+    cy.get('[data-test="total-2"]').should('contain.text', '£97.00')
+
+    cy.get('[data-test="billing-contact-3"]').should('contain.text', 'Big Farm Co Ltd 01')
+    cy.get('[data-test="licence-3"]').should('contain.text', 'AT/SROC/SUPB/02')
+    cy.get('[data-test="total-3"]').should('contain.text', '£80.79')
     cy.get('.govuk-button').contains('Confirm bill run').click()
 
     // You're about to send this bill run
@@ -297,10 +306,10 @@ describe('Change billing account in previous financial year (internal)', () => {
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('#main-content > div:nth-child(1) > div > p > strong').should('contain.text', 'Sent')
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
 
-    // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    // click the back link to go to bill runs
+    cy.get('.govuk-back-link').click()
 
     // Bill runs
     // back on the bill runs page confirm our SROC bill run is present and listed as SENT

--- a/cypress/e2e/internal/billing/supplementary/journey.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/journey.cy.js
@@ -67,9 +67,9 @@ describe('Create and send supplementary bill runs (internal)', () => {
     // Test Region supplementary bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can check the rest of the details before confirming the bill run
-    cy.get('#main-content > div:nth-child(1) > div > p > strong', { timeout: 20000 }).should('contain.text', 'Ready')
-    cy.get('#main-content > div:nth-child(2) > div > h2').should('contain.text', '£582.11')
-    cy.get('#main-content > div:nth-child(4) > div > h2').should('contain.text', '4 supplementary bills')
+    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
+    cy.get('[data-test="bill-total"]').should('contain.text', '£582.11')
+    cy.get('[data-test="bills-count"]').should('contain.text', '4 Supplementary bills')
     cy.get('.govuk-button').contains('Confirm bill run').click()
 
     // You're about to send this bill run
@@ -103,10 +103,10 @@ describe('Create and send supplementary bill runs (internal)', () => {
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('#main-content > div:nth-child(1) > div > p > strong').should('contain.text', 'Sent')
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
 
-    // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    // click the back link to go to bill runs
+    cy.get('.govuk-back-link').click()
 
     // Bill runs
     // back on the bill runs page confirm our PRESROC bill run is present and listed as SENT
@@ -128,15 +128,15 @@ describe('Create and send supplementary bill runs (internal)', () => {
 
     // Test Region supplementary bill run
     // check the details before confirming the bill run
-    cy.get('#main-content > div:nth-child(1) > div > p > strong').should('contain.text', 'Ready')
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const { billingPeriodCount } = currentFinancialYearInfo
       if (billingPeriodCount === 1) {
-        cy.get('#main-content > div:nth-child(4) > div > h2')
-          .should('contain.text', '1 supplementary bill')
+        cy.get('[data-test="bills-count"]')
+          .should('contain.text', '1 Supplementary bill')
       } else {
-        cy.get('#main-content > div:nth-child(4) > div > h2')
-          .should('contain.text', `${billingPeriodCount} supplementary bills`)
+        cy.get('[data-test="bills-count"]')
+          .should('contain.text', `${billingPeriodCount} Supplementary bills`)
       }
     })
     cy.get('.govuk-button').contains('Confirm bill run').click()
@@ -172,10 +172,10 @@ describe('Create and send supplementary bill runs (internal)', () => {
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('#main-content > div:nth-child(1) > div > p > strong').should('contain.text', 'Sent')
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
 
-    // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    // click the back link to go to bill runs
+    cy.get('.govuk-back-link').click()
 
     // Bill runs
     // back on the bill runs page confirm our SROC bill run is present and listed as SENT

--- a/cypress/e2e/internal/billing/supplementary/non-charge-licence-credit.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/non-charge-licence-credit.cy.js
@@ -58,7 +58,7 @@ describe('Make licence non-chargeable then see credit in next bill run (internal
     // Test Region supplementary bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can confirm the bill run
-    cy.get('#main-content > div:nth-child(1) > div > p > strong', { timeout: 20000 }).should('contain.text', 'Ready')
+    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
     cy.get('.govuk-button').contains('Confirm bill run').click()
 
     // You're about to send this bill run
@@ -172,7 +172,8 @@ describe('Make licence non-chargeable then see credit in next bill run (internal
     // Test Region supplementary bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can confirm the bill run is a credit as expected
-    cy.get('#main-content > div:nth-child(1) > div > p > strong', { timeout: 20000 }).should('contain.text', 'Ready')
-    cy.get('#main-content').should('contain.text', '1 credit note').and('contain.text', '0 invoices')
+    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
+    cy.get('[data-test="credits-count"]').should('contain.text', '1 credit note')
+    cy.get('[data-test="debits-count"]').should('contain.text', '0 invoices')
   })
 })

--- a/cypress/e2e/internal/billing/supplementary/reissue-presroc.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/reissue-presroc.cy.js
@@ -52,7 +52,7 @@ describe('Reissue PRESROC bill in supplementary bill run (internal)', () => {
     // Test Region supplementary bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we confirm the bill run
-    cy.get('#main-content > div:nth-child(1) > div > p > strong', { timeout: 20000 }).should('contain.text', 'Ready')
+    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
     cy.get('.govuk-button').contains('Confirm bill run').click()
 
     // You're about to send this bill run
@@ -77,13 +77,13 @@ describe('Reissue PRESROC bill in supplementary bill run (internal)', () => {
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT then click view for the first bill
-    cy.get('#main-content > div:nth-child(1) > div > p > strong').should('contain.text', 'Sent')
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
     cy.get(':nth-child(1) > :nth-child(6) > .govuk-link').click()
 
     // Bill for Big Farm Co Ltd 02
     // expand the billing account details section and then click to view the billing account
     cy.get('div > details > summary > span').click()
-    cy.get('div > details > div > p > a').click()
+    cy.get('div > details > div > p > span > a').click()
 
     // Billing account for Big Farm Co Ltd 02
     // confirm we can see the bill runs we just sent and then click Reissue a bill
@@ -146,9 +146,9 @@ describe('Reissue PRESROC bill in supplementary bill run (internal)', () => {
     // Test Region supplementary bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can check the rest of the details before confirming the bill run
-    cy.get('#main-content > div:nth-child(1) > div > p > strong', { timeout: 20000 }).should('contain.text', 'Ready')
-    cy.get('#main-content > div:nth-child(2) > div > h2').should('contain.text', '£0.00')
-    cy.get('.govuk-heading-l').should('contain.text', '2 supplementary bills')
+    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
+    cy.get('[data-test="bill-total"]').should('contain.text', '£0.00')
+    cy.get('[data-test="bills-count"]').should('contain.text', '2 Supplementary bills')
     cy.get('.govuk-button').contains('Confirm bill run').click()
 
     // You're about to send this bill run
@@ -182,14 +182,7 @@ describe('Reissue PRESROC bill in supplementary bill run (internal)', () => {
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT then click view for the first bill
-    cy.get('#main-content > div:nth-child(1) > div > p > strong').should('contain.text', 'Sent')
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
     cy.get(':nth-child(1) > :nth-child(6) > .govuk-link').click()
-
-    // -------------------------------------------------------------------------
-    cy.log('Confirm link to previous bill is displayed')
-
-    // Bill for Big Farm Co Ltd 02
-    // confirm we see the reissue section when viewing the bill
-    cy.get('.govuk-inset-text > .govuk-heading-m').should('contain.text', 'This bill is linked to a reissue')
   })
 })

--- a/cypress/e2e/internal/billing/supplementary/reissue-sroc.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/reissue-sroc.cy.js
@@ -64,17 +64,17 @@ describe('Reissue SROC bill in supplementary bill run (internal)', () => {
     // Test Region supplementary bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can confirm the bill run is a credit as expected
-    cy.get('#main-content > div:nth-child(1) > div > p > strong', { timeout: 20000 }).should('contain.text', 'Ready')
+    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
 
     // check the details before confirming the bill run
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const { billingPeriodCount } = currentFinancialYearInfo
       if (billingPeriodCount === 1) {
-        cy.get('#main-content > div:nth-child(4) > div > h2')
-          .should('contain.text', '1 supplementary bill')
+        cy.get('[data-test="bills-count"]')
+          .should('contain.text', '1 Supplementary bill')
       } else {
-        cy.get('#main-content > div:nth-child(4) > div > h2')
-          .should('contain.text', `${billingPeriodCount} supplementary bills`)
+        cy.get('[data-test="bills-count"]')
+          .should('contain.text', `${billingPeriodCount} Supplementary bills`)
       }
     })
     cy.get('.govuk-button').contains('Confirm bill run').click()
@@ -110,10 +110,10 @@ describe('Reissue SROC bill in supplementary bill run (internal)', () => {
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('#main-content > div:nth-child(1) > div > p > strong').should('contain.text', 'Sent')
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
 
-    // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    // click the back link to go to bill runs
+    cy.get('.govuk-back-link').click()
 
     // Bill runs
     // back on the bill runs page confirm our SROC bill run is present and listed as SENT
@@ -203,7 +203,7 @@ describe('Reissue SROC bill in supplementary bill run (internal)', () => {
     // Bill runs
     // The sroc bill run we created should be the top result. Once it has finished building its status will be `Ready`
     // so we reload until the text is present.
-    cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > strong', 'Ready', 10)
+    cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > strong', 'Ready', 10, 2000)
 
     // We verify the row contains the expected data then click to continue.
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
@@ -219,9 +219,9 @@ describe('Reissue SROC bill in supplementary bill run (internal)', () => {
     // Test Region supplementary bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can check the rest of the details before confirming the bill run
-    cy.get('#main-content > div:nth-child(1) > div > p > strong').should('contain.text', 'Ready')
-    cy.get('#main-content > div:nth-child(2) > div > h2').should('contain.text', '£0.00')
-    cy.get('.govuk-heading-l').should('contain.text', '2 supplementary bills')
+    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
+    cy.get('[data-test="bill-total"]').should('contain.text', '£0.00')
+    cy.get('[data-test="bills-count"]').should('contain.text', '2 Supplementary bills')
     cy.get('.govuk-button').contains('Confirm bill run').click()
 
     // You're about to send this bill run
@@ -255,14 +255,7 @@ describe('Reissue SROC bill in supplementary bill run (internal)', () => {
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT then click view for the first bill
-    cy.get('#main-content > div:nth-child(1) > div > p > strong').should('contain.text', 'Sent')
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
     cy.get(':nth-child(1) > :nth-child(6) > .govuk-link').click()
-
-    // -------------------------------------------------------------------------
-    cy.log('Confirm link to previous bill is displayed')
-
-    // Bill for Big Farm Co Ltd 02
-    // confirm we see the reissue section when viewing the bill
-    cy.get('.govuk-inset-text > .govuk-heading-m').should('contain.text', 'This bill is linked to a reissue')
   })
 })

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
@@ -140,17 +140,17 @@ describe('Replace charge version in the 2023 financial year with no changes (int
     // Test Region supplementary bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can confirm the bill run is a credit as expected
-    cy.get('#main-content > div:nth-child(1) > div > p > strong', { timeout: 20000 }).should('contain.text', 'Ready')
+    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
 
     // check the details before confirming the bill run
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const { billingPeriodCount } = currentFinancialYearInfo
       if (billingPeriodCount === 1) {
-        cy.get('#main-content > div:nth-child(4) > div > h2')
-          .should('contain.text', '1 supplementary bill')
+        cy.get('[data-test="bills-count"]')
+          .should('contain.text', '1 Supplementary bill')
       } else {
-        cy.get('#main-content > div:nth-child(4) > div > h2')
-          .should('contain.text', `${billingPeriodCount} supplementary bills`)
+        cy.get('[data-test="bills-count"]')
+          .should('contain.text', `${billingPeriodCount} Supplementary bills`)
       }
     })
     cy.get('.govuk-button').contains('Confirm bill run').click()
@@ -186,10 +186,10 @@ describe('Replace charge version in the 2023 financial year with no changes (int
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('#main-content > div:nth-child(1) > div > p > strong').should('contain.text', 'Sent')
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
 
-    // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    // click the back link to go to bill runs
+    cy.get('.govuk-back-link').click()
 
     // Bill runs
     // back on the bill runs page confirm our SROC bill run is present and listed as SENT
@@ -294,7 +294,7 @@ describe('Replace charge version in the 2023 financial year with no changes (int
     // Test Region supplementary bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can confirm the bill run is as expected
-    cy.get('#main-content > div:nth-child(1) > div > p > strong', { timeout: 20000 }).should('contain.text', 'Ready')
+    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
 
     // check the details and then click Confirm bill run
     cy.get('dl').within(() => {
@@ -309,8 +309,8 @@ describe('Replace charge version in the 2023 financial year with no changes (int
       // charge scheme
       cy.get('div:nth-child(4) > dd').should('contain.text', 'Current')
     })
-    cy.get(':nth-child(2) > .govuk-grid-column-two-thirds').should('contain.text', '£0.00')
-    cy.get('.govuk-heading-l').should('contain.text', '1 supplementary bill')
+    cy.get('[data-test="bill-total"]').should('contain.text', '£0.00')
+    cy.get('[data-test="bills-count"]').should('contain.text', '0 Supplementary bills and 1 zero value bill')
     // NOTE: We cannot assert the new billing account number because it will be different in each environment and
     // unpredictable because the new number is based on existing data
     cy.get('.govuk-table__body > .govuk-table__row > :nth-child(2)').should('contain.text', 'Big Farm Co Ltd 02')
@@ -350,10 +350,10 @@ describe('Replace charge version in the 2023 financial year with no changes (int
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('#main-content > div:nth-child(1) > div > p > strong').should('contain.text', 'Sent')
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
 
-    // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    // click the back link to go to bill runs
+    cy.get('.govuk-back-link').click()
 
     // Bill runs
     // back on the bill runs page confirm our zero value SROC bill run is present and listed as SENT

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
@@ -313,10 +313,10 @@ describe('Replace charge version in the 2023 financial year with no changes (int
     cy.get('[data-test="bills-count"]').should('contain.text', '0 Supplementary bills and 1 zero value bill')
     // NOTE: We cannot assert the new billing account number because it will be different in each environment and
     // unpredictable because the new number is based on existing data
-    cy.get('.govuk-table__body > .govuk-table__row > :nth-child(2)').should('contain.text', 'Big Farm Co Ltd 02')
-    cy.get('.govuk-table__body > .govuk-table__row > :nth-child(3)').should('contain.text', 'AT/SROC/SUPB/02')
-    cy.get('.govuk-table__body > .govuk-table__row > :nth-child(4)').should('contain.text', '2023')
-    cy.get('.govuk-table__body > .govuk-table__row > :nth-child(5)').should('contain.text', '£0.00')
+    cy.get('[data-test="billing-contact-0"]').should('contain.text', 'Big Farm Co Ltd 02')
+    cy.get('[data-test="licence-0"]').should('contain.text', 'AT/SROC/SUPB/02')
+    cy.get('[data-test="financial-year-0"]').should('contain.text', '2023')
+    cy.get('[data-test="total-0"]').should('contain.text', '£0.00')
     cy.get('.govuk-button').contains('Confirm bill run').click()
 
     // You're about to send this bill run

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
@@ -140,17 +140,17 @@ describe('Replace charge version in current financial year change the charge ref
     // Test Region supplementary bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can confirm the bill run is a credit as expected
-    cy.get('#main-content > div:nth-child(1) > div > p > strong', { timeout: 20000 }).should('contain.text', 'Ready')
+    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
 
     // check the details before confirming the bill run
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const { billingPeriodCount } = currentFinancialYearInfo
       if (billingPeriodCount === 1) {
-        cy.get('#main-content > div:nth-child(4) > div > h2')
-          .should('contain.text', '1 supplementary bill')
+        cy.get('[data-test="bills-count"]')
+          .should('contain.text', '1 Supplementary bill')
       } else {
-        cy.get('#main-content > div:nth-child(4) > div > h2')
-          .should('contain.text', `${billingPeriodCount} supplementary bills`)
+        cy.get('[data-test="bills-count"]')
+          .should('contain.text', `${billingPeriodCount} Supplementary bills`)
       }
     })
     cy.get('.govuk-button').contains('Confirm bill run').click()
@@ -186,10 +186,10 @@ describe('Replace charge version in current financial year change the charge ref
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('#main-content > div:nth-child(1) > div > p > strong').should('contain.text', 'Sent')
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
 
-    // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    // click the back link to go to bill runs
+    cy.get('.govuk-back-link').click()
 
     // Bill runs
     // back on the bill runs page confirm our SROC bill run is present and listed as SENT
@@ -343,7 +343,7 @@ describe('Replace charge version in current financial year change the charge ref
     // Test Region supplementary bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can confirm the bill run is as expected
-    cy.get('#main-content > div:nth-child(1) > div > p > strong', { timeout: 20000 }).should('contain.text', 'Ready')
+    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
 
     // check the details and then click Confirm bill run
     cy.get('dl').within(() => {
@@ -358,16 +358,16 @@ describe('Replace charge version in current financial year change the charge ref
       // charge scheme
       cy.get('div:nth-child(4) > dd').should('contain.text', 'Current')
     })
-    cy.get(':nth-child(2) > .govuk-grid-column-two-thirds').should('contain.text', '£3,574.73')
-    cy.get('.govuk-heading-l').should('contain.text', '1 supplementary bill')
+    cy.get('[data-test="bill-total"]').should('contain.text', '£3,574.73')
+    cy.get('[data-test="bills-count"]').should('contain.text', '1 Supplementary bill')
     // NOTE: We cannot assert the new billing account number because it will be different in each environment and
     // unpredictable because the new number is based on existing data
-    cy.get('.govuk-table__body > .govuk-table__row > :nth-child(2)').should('contain.text', 'Big Farm Co Ltd 02')
-    cy.get('.govuk-table__body > .govuk-table__row > :nth-child(3)').should('contain.text', 'AT/SROC/SUPB/02')
+    cy.get('[data-test="billing-contact-0"]').should('contain.text', 'Big Farm Co Ltd 02')
+    cy.get('[data-test="licence-0"]').should('contain.text', 'AT/SROC/SUPB/02')
     cy.currentFinancialYearDate().then((result) => {
-      cy.get('.govuk-table__body > .govuk-table__row > :nth-child(4)').should('contain.text', result.year)
+      cy.get('[data-test="financial-year-0"]').should('contain.text', result.year)
     })
-    cy.get('.govuk-table__body > .govuk-table__row > :nth-child(5)').should('contain.text', '£3,574.73')
+    cy.get('[data-test="total-0"]').should('contain.text', '£3,574.73')
     cy.get('.govuk-button').contains('Confirm bill run').click()
 
     // You're about to send this bill run
@@ -401,10 +401,10 @@ describe('Replace charge version in current financial year change the charge ref
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('#main-content > div:nth-child(1) > div > p > strong').should('contain.text', 'Sent')
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
 
-    // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    // click the back link to go to bill runs
+    cy.get('.govuk-back-link').click()
 
     // Bill runs
     // back on the bill runs page confirm our SROC bill run is present and listed as SENT
@@ -417,7 +417,7 @@ describe('Replace charge version in current financial year change the charge ref
     cy.get('.govuk-table__body > :nth-child(1) > :nth-child(5)').should('contain.text', '£3,574.73')
     cy.get('.govuk-table__body > :nth-child(1) > :nth-child(6)').should('contain.text', 'Sent')
 
-    // select the bill run to check the adjustments and addional charges have been applied
+    // select the bill run to check the adjustments and additional charges have been applied
     cy.get(':nth-child(1) > :nth-child(1) > .govuk-link').click()
 
     // Test Region supplementary bill run
@@ -425,25 +425,23 @@ describe('Replace charge version in current financial year change the charge ref
     cy.get(':nth-child(6) > .govuk-link').click()
 
     // Bill for Big Farm Co Ltd 02
-    // check the debits, credits, adjustments and addional charges have been applied
-    cy.get('.govuk-template__body')
-      .should('contain.text', '£3,574.73')
-      .and('contain.text', '£97.00')
-      .and('contain.text', '£3,671.73')
-    cy.get(':nth-child(4) > .govuk-grid-column-full')
-      .should('contain.text', '213/366')
-      .and('contain.text', '153/366')
-      .and('contain.text', '366/366')
-      .and('contain.text', '1000ML')
-      .and('contain.text', '100ML')
-      .and('contain.text', '£3,631.18')
-      .and('contain.text', '£40.55')
-      .and('contain.text', '£97.00')
-      .and('contain.text', '£3,671.73')
-      .and('contain.text', '£3,574.73')
-      .and('contain.text', 'Additional charges:')
-      .and('contain.text', 'Supported source Earl Soham - Deben (£10,696.00)')
-      .and('contain.text', 'Adjustments:')
-      .and('contain.text', 'Winter discount (0.5)')
+    // check the debits, credits, adjustments and additional charges have been applied
+    cy.get('[data-test="credits-total"]').should('contain.text', '£97.00')
+    cy.get('[data-test="debits-total"]').should('contain.text', '£3,671.73')
+    cy.get('[data-test="bill-total"]').should('contain.text', '£3,574.73')
+    cy.get('[data-test="additional-charges-0"]').should('contain.text', 'Supported source Earl Soham - Deben (£106.96)')
+    cy.get('[data-test="adjustments-0"]').should('contain.text', 'Winter discount (0.5)')
+
+    cy.get('[data-test="billable-days-0"]').should('contain.text', '213/366')
+    cy.get('[data-test="quantity-0"]').should('contain.text', '1000ML')
+    cy.get('[data-test="debit-0"]').should('contain.text', '£3,631.18')
+
+    cy.get('[data-test="billable-days-1"]').should('contain.text', '366/366')
+    cy.get('[data-test="quantity-1"]').should('contain.text', '100ML')
+    cy.get('[data-test="credit-1"]').should('contain.text', '£97.00')
+
+    cy.get('[data-test="billable-days-2"]').should('contain.text', '153/366')
+    cy.get('[data-test="quantity-2"]').should('contain.text', '100ML')
+    cy.get('[data-test="debit-2"]').should('contain.text', '£40.55')
   })
 })

--- a/cypress/e2e/internal/billing/two-part-tariff/journey.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/journey.cy.js
@@ -113,9 +113,9 @@ describe('Create and send PRESROC two-part tariff bill run (internal)', () => {
     // Test Region two-part tariff bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can check the rest of the details before confirming the bill run
-    cy.get('#main-content > div:nth-child(1) > div > p > strong', { timeout: 20000 }).should('contain.text', 'Ready')
-    cy.get('#main-content > div:nth-child(2) > div > h2').should('contain.text', '£660.24')
-    cy.get('#main-content > div:nth-child(4) > div > h2').should('contain.text', '1 two-part tariff bill')
+    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
+    cy.get('[data-test="bill-total"]').should('contain.text', '£660.24')
+    cy.get('[data-test="bills-count"]').should('contain.text', '1 Two-part tariff winter and all year bill')
     cy.get('.govuk-button').contains('Confirm bill run').click()
 
     // You're about to send this bill run
@@ -148,10 +148,10 @@ describe('Create and send PRESROC two-part tariff bill run (internal)', () => {
 
     // Test Region two-part tariff bill run
     // confirm we see it is now SENT
-    cy.get('#main-content > div:nth-child(1) > div > p > strong').should('contain.text', 'Sent')
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
 
-    // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    // click the back link to go to bill runs
+    cy.get('.govuk-back-link').click()
 
     // Bill runs
     // back on the bill runs page confirm our PRESROC bill run is present and listed as SENT


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4131

In WATER-4070 we logged that the Billing & Data team were struggling because they could not access the larger bill runs. The service would appear to be busy for a while and then eventually error.

We were able to figure out it was simply that the service was not able to return all the data needed using the current design, which listed out all the transactions in a bill run. We also knew the data could be collected in a more performant way.

So, we ended up rebuilding the whole journey of viewing a bill run, the bills in it and the transaction details.

Because the journey has changed, this has broken those tests that rely on the old journey. This change updates the tests to use the new journey.