### PR TITLE
Increase defaults for reloadUntilTextFound()

### DIFF
--- a/cypress/e2e/internal/billing/supplementary/reissue-sroc.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/reissue-sroc.cy.js
@@ -203,7 +203,7 @@ describe('Reissue SROC bill in supplementary bill run (internal)', () => {
     // Bill runs
     // The sroc bill run we created should be the top result. Once it has finished building its status will be `Ready`
     // so we reload until the text is present.
-    cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > strong', 'Ready', 10, 2000)
+    cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > strong', 'Ready')
 
     // We verify the row contains the expected data then click to continue.
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -120,7 +120,7 @@ Cypress.Commands.add('dayMonthYearFormattedDate', (date) => {
 
 // Created when we needed to wait until the status of a bill run changed from BUILDING to EMPTY. We have made it generic
 // so it can be used in any other similar scenarios.
-Cypress.Commands.add('reloadUntilTextFound', (selector, textToMatch, retries = 3, retryWait = 1000) => {
+Cypress.Commands.add('reloadUntilTextFound', (selector, textToMatch, retries = 10, retryWait = 2000) => {
   if (retries === 0) {
     throw new Error(`Exhausted retries looking for ${textToMatch} in ${selector}.`)
   }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4131

As part of [Update bill run tests with journey changes](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/78) we needed to increase the number of attempts and the delay between them to get `reissue-sroc.cy.js` to pass locally.

Well, in further test runs, we have found that `cancel-existing.cy.js` will also sometimes fail because it needs more time.

So, rather than keep overriding the defaults we've decided to up the defaults to give the tests a greater chance of succeeding the first time.