### PR TITLE
Fix latest failing tests

### DIFF
--- a/cypress/e2e/internal/billing/annual/remove-licence.cy.js
+++ b/cypress/e2e/internal/billing/annual/remove-licence.cy.js
@@ -69,11 +69,8 @@ describe('Remove bill from annual bill run (internal)', () => {
     cy.get('form > .govuk-button').contains('Remove this bill').click()
 
     // Test Region Annual bill run
-    // spinner page displayed whilst the bill run is 'building'. Confirm we're on it
-    cy.get('#main-content > div:nth-child(2) > div > p.govuk-body-l')
-      .should('contain.text', 'The bill run is being created. This may take a few minutes.')
-    cy.get('#main-content > div:nth-child(7) > div > p')
-      .should('contain.text', 'Gathering transactions for current charge scheme')
+    // spinner page displayed whilst the bill run is 'building'. We don't confirm we are on it because in some
+    // environments the process is to quick to for the page to have a chance to appear
 
     // Test Region annual bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that

--- a/cypress/e2e/internal/charge-information/presroc/licence-transfer.cy.js
+++ b/cypress/e2e/internal/charge-information/presroc/licence-transfer.cy.js
@@ -103,7 +103,7 @@ describe('PRESROC licence transfer (internal)', () => {
 
     // Use abstraction data to set up the element?
     // choose Yes and continue
-    cy.get('input#useAbstractionData').click()
+    cy.get('input#useAbstractionData-4').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check charge information
@@ -125,7 +125,7 @@ describe('PRESROC licence transfer (internal)', () => {
       // abstraction period
       cy.get('div:nth-child(3) > dd.govuk-summary-list__value').should('contain.text', '1 April to 31 March')
       // annual quantities
-      cy.get('div:nth-child(4) > dd.govuk-summary-list__value').should('contain.text', '1.554ML authorised')
+      cy.get('div:nth-child(4) > dd.govuk-summary-list__value').should('contain.text', '15.54ML authorised')
       // time limit
       cy.get('div:nth-child(5) > dd.govuk-summary-list__value').should('contain.text', 'No')
       // source


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4336

In the latest runs of the acceptance tests, a few are either failing or flaky. It's not that the service is broken. Just that instability we find with the tests we've inherited.

This changes fixes the latest issues so we can get back to 100% pass rate.

- `cypress/e2e/internal/billing/annual/remove-licence.cy.js`: some of the team reported the final spinner page was not displayed long enough for the assertions to complete. We don't need to check this page is completed. We are more interested in checking the bill run summary page that appears when the process is complete. So, we remove the 'flaky' assertions
- `cypress/e2e/internal/charge-information/presroc/licence-transfer.cy.js`: we realised that the test was selecting an option that meant uncontrolled data was used. This meant the test may or may not pass depending on whose machine it was run on. We've tweaked the test to create the new charge version based on the existing test charge version record so that the data is consistent across our machines