### PR TITLE
Remove spinner checks from replace-cv-2023 test

### DIFF
--- a/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
@@ -171,13 +171,9 @@ describe('Replace charge version in the 2023 financial year with no changes (int
     })
     cy.get('.govuk-button').contains('Send bill run').click()
 
-    // Test Region Supplementary bill run
-    // spinner page displayed whilst the bill run is 'sending'. Confirm we're on it
-    cy.get('#main-content > div:nth-child(2) > div > p.govuk-body > strong').should('contain.text', 'Sending')
-    cy.get('#main-content > div:nth-child(2) > div > p.govuk-body-l')
-      .should('contain.text', 'The bill run is being created. This may take a few minutes.')
-    cy.get('#main-content > div:nth-child(7) > div > p')
-      .should('contain.text', 'Gathering transactions for current charge scheme')
+    // Test Region Supplementary bill run spinner page displayed whilst the bill run is 'sending'. We don't confirm
+    // we're on it because in some environments this step is so fast the test will fail because it doesn't see the
+    // element
 
     // Bill run sent
     // confirm the bill run is sent and then click to go to it
@@ -335,13 +331,9 @@ describe('Replace charge version in the 2023 financial year with no changes (int
     })
     cy.get('.govuk-button').contains('Send bill run').click()
 
-    // Test Region Supplementary bill run
-    // spinner page displayed whilst the bill run is 'sending'. Confirm we're on it
-    cy.get('#main-content > div:nth-child(2) > div > p.govuk-body > strong').should('contain.text', 'Sending')
-    cy.get('#main-content > div:nth-child(2) > div > p.govuk-body-l')
-      .should('contain.text', 'The bill run is being created. This may take a few minutes.')
-    cy.get('#main-content > div:nth-child(7) > div > p')
-      .should('contain.text', 'Gathering transactions for current charge scheme')
+    // Test Region Supplementary bill run spinner page displayed whilst the bill run is 'sending'. We don't confirm
+    // we're on it because in some environments this step is so fast the test will fail because it doesn't see the
+    // element
 
     // Bill run sent
     // confirm the bill run is sent and then click to go to it


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4336

Though running fine for one of the team our QA reported that this test appeared to be 'flaky'. When investigated it seems on the QA's machine there are times that the spinner page doesn't get a chance to appear before the bill run is 'sent'. This causes the test to fail, even though we are fine with that result!

This change removes the assertions for the spinner page in the send bill run process for `internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js`.