### PR TITLE
Update bill test after decimal point being moved

### DIFF
--- a/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
@@ -429,7 +429,7 @@ describe('Replace charge version in current financial year change the charge ref
     cy.get('[data-test="credits-total"]').should('contain.text', '£97.00')
     cy.get('[data-test="debits-total"]').should('contain.text', '£3,671.73')
     cy.get('[data-test="bill-total"]').should('contain.text', '£3,574.73')
-    cy.get('[data-test="additional-charges-0"]').should('contain.text', 'Supported source Earl Soham - Deben (£106.96)')
+    cy.get('[data-test="additional-charges-0"]').should('contain.text', 'Supported source Earl Soham - Deben (£10696.00)')
     cy.get('[data-test="adjustments-0"]').should('contain.text', 'Winter discount (0.5)')
 
     cy.get('[data-test="billable-days-0"]').should('contain.text', '213/366')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4358

We have just dealt with an issue reported by the billing and data team that the values shown against a transaction for the charge reference and supported source have the decimal in the wrong place.

We've fixed the code but as expected this has broken a test. This change updates it to match what the UI is now displaying.