### PR TITLE
Update tests due to supplementary year bump

### DIFF
--- a/cypress/e2e/internal/billing/annual/journey.cy.js
+++ b/cypress/e2e/internal/billing/annual/journey.cy.js
@@ -3,7 +3,7 @@
 describe('Create and send annual bill run (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-billing-data')
+    cy.setUp('sroc-annual')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023

--- a/cypress/e2e/internal/billing/annual/journey.cy.js
+++ b/cypress/e2e/internal/billing/annual/journey.cy.js
@@ -3,7 +3,7 @@
 describe('Create and send annual bill run (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-annual')
+    cy.setUp('sroc-billing-previous')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023

--- a/cypress/e2e/internal/billing/annual/remove-licence.cy.js
+++ b/cypress/e2e/internal/billing/annual/remove-licence.cy.js
@@ -3,7 +3,7 @@
 describe('Remove bill from annual bill run (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-billing-data')
+    cy.setUp('sroc-supplementary-current')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023

--- a/cypress/e2e/internal/billing/annual/remove-licence.cy.js
+++ b/cypress/e2e/internal/billing/annual/remove-licence.cy.js
@@ -3,7 +3,7 @@
 describe('Remove bill from annual bill run (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-supplementary-current')
+    cy.setUp('sroc-billing-previous')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023

--- a/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
@@ -6,7 +6,7 @@ describe('Cancel existing supplementary bill runs (internal)', () => {
     // NOTE: Using 2PT test data in this test is intended. The supplementary test data inserts an Annual bill run that
     // confuses this test and its assertion that all bill runs for the test region have been deleted. The 2PT test data
     // doesn't add any bill runs so the test works
-    cy.setUp('sroc-supplementary-current')
+    cy.setUp('sroc-billing-current')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023

--- a/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
@@ -6,7 +6,7 @@ describe('Cancel existing supplementary bill runs (internal)', () => {
     // NOTE: Using 2PT test data in this test is intended. The supplementary test data inserts an Annual bill run that
     // confuses this test and its assertion that all bill runs for the test region have been deleted. The 2PT test data
     // doesn't add any bill runs so the test works
-    cy.setUp('two-part-tariff-billing-data')
+    cy.setUp('sroc-billing-data')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023
@@ -53,9 +53,9 @@ describe('Cancel existing supplementary bill runs (internal)', () => {
     // Bill runs
     //
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
-    // seconds though so to avoid the test failing we use our custom Cypress command to look for the status EMPTY, and
+    // seconds though so to avoid the test failing we use our custom Cypress command to look for the status READY, and
     // if not found reload the page and try again. We then select it using the link on the date created
-    cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > .govuk-tag', 'Empty')
+    cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > .govuk-tag', 'Ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('tr:nth-child(1)')
         .should('contain.text', formattedCurrentDate)

--- a/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
@@ -6,7 +6,7 @@ describe('Cancel existing supplementary bill runs (internal)', () => {
     // NOTE: Using 2PT test data in this test is intended. The supplementary test data inserts an Annual bill run that
     // confuses this test and its assertion that all bill runs for the test region have been deleted. The 2PT test data
     // doesn't add any bill runs so the test works
-    cy.setUp('sroc-billing-data')
+    cy.setUp('sroc-supplementary-current')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023

--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
@@ -3,7 +3,7 @@
 describe('Change billing account in current financial year (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-billing-data')
+    cy.setUp('sroc-supplementary-current')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023

--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
@@ -243,16 +243,7 @@ describe('Change billing account in current financial year (internal)', () => {
     // Test Region supplementary bill run
     // check the details before sending the bill run
     cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
-    cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
-      const { billingPeriodCount } = currentFinancialYearInfo
-      if (billingPeriodCount === 1) {
-        cy.get('[data-test="bills-count"]')
-          .should('contain.text', '1 Supplementary bill')
-      } else {
-        cy.get('[data-test="bills-count"]')
-          .should('contain.text', `${billingPeriodCount} Supplementary bills`)
-      }
-    })
+    cy.get('[data-test="bills-count"]').should('contain.text', '2 Supplementary bills')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('[data-test="meta-data-created"]').should('contain.text', formattedCurrentDate)
     })

--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
@@ -3,7 +3,7 @@
 describe('Change billing account in current financial year (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-supplementary-current')
+    cy.setUp('sroc-billing-current')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023

--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
@@ -3,7 +3,7 @@
 describe('Change billing account in previous financial year (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-billing-data')
+    cy.setUp('sroc-supplementary-current')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023

--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
@@ -3,7 +3,7 @@
 describe('Change billing account in previous financial year (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-supplementary-current')
+    cy.setUp('sroc-billing-current')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023

--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
@@ -253,21 +253,23 @@ describe('Change billing account in previous financial year (internal)', () => {
     cy.get('[data-test="debits-count"]').should('contain.text', '2 invoices')
     // NOTE: We cannot assert the new billing account number because it will be different in each environment and
     // unpredictable because the new number is based on existing data
+    // We also can assert exactly what the total will be because it can differ year to year depending on whether we have
+    // a leap year or not.
     cy.get('[data-test="billing-contact-0"]').should('contain.text', 'Big Farm Co Ltd 02')
     cy.get('[data-test="licence-0"]').should('contain.text', 'AT/SROC/SUPB/02')
-    cy.get('[data-test="total-0"]').should('contain.text', '-£97.00')
+    cy.get('[data-test="total-0"]').should('contain.text', '-£97')
 
     cy.get('[data-test="billing-contact-1"]').should('contain.text', 'Big Farm Co Ltd 02')
     cy.get('[data-test="licence-1"]').should('contain.text', 'AT/SROC/SUPB/02')
-    cy.get('[data-test="total-1"]').should('contain.text', '-£80.79')
+    cy.get('[data-test="total-1"]').should('contain.text', '-£80')
 
     cy.get('[data-test="billing-contact-2"]').should('contain.text', 'Big Farm Co Ltd 01')
     cy.get('[data-test="licence-2"]').should('contain.text', 'AT/SROC/SUPB/02')
-    cy.get('[data-test="total-2"]').should('contain.text', '£97.00')
+    cy.get('[data-test="total-2"]').should('contain.text', '£97')
 
     cy.get('[data-test="billing-contact-3"]').should('contain.text', 'Big Farm Co Ltd 01')
     cy.get('[data-test="licence-3"]').should('contain.text', 'AT/SROC/SUPB/02')
-    cy.get('[data-test="total-3"]').should('contain.text', '£80.79')
+    cy.get('[data-test="total-3"]').should('contain.text', '£80')
     cy.get('.govuk-button').contains('Send bill run').click()
 
     // You're about to send this bill run

--- a/cypress/e2e/internal/billing/supplementary/journey.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/journey.cy.js
@@ -3,7 +3,7 @@
 describe('Create and send supplementary bill runs (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-billing-data')
+    cy.setUp('sroc-supplementary-current')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023

--- a/cypress/e2e/internal/billing/supplementary/journey.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/journey.cy.js
@@ -74,8 +74,8 @@ describe('Create and send supplementary bill runs (internal)', () => {
     // Test Region supplementary bill run
     // quick test that the display is as expected and then click Send bill run
     cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
-    cy.get('[data-test="bill-total"]').should('contain.text', '£582.11')
-    cy.get('[data-test="bills-count"]').should('contain.text', '4 Supplementary bills')
+    cy.get('[data-test="bill-total"]').should('contain.text', '£537.90')
+    cy.get('[data-test="bills-count"]').should('contain.text', '3 Supplementary bills')
     cy.get('.govuk-button').contains('Send bill run').click()
 
     // You're about to send this bill run
@@ -113,7 +113,7 @@ describe('Create and send supplementary bill runs (internal)', () => {
         .and('contain.text', 'Old charge scheme')
         .and('contain.text', 'Test Region')
         .and('contain.text', 'Supplementary')
-        .and('contain.text', '£582.11')
+        .and('contain.text', '£537.90')
         .and('contain.text', 'Sent')
     })
 

--- a/cypress/e2e/internal/billing/supplementary/journey.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/journey.cy.js
@@ -3,7 +3,7 @@
 describe('Create and send supplementary bill runs (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-supplementary-current')
+    cy.setUp('sroc-billing-current')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023

--- a/cypress/e2e/internal/billing/supplementary/no-annual-in-current-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/no-annual-in-current-year.cy.js
@@ -1,0 +1,90 @@
+'use strict'
+
+describe('Create and send supplementary bill runs (internal)', () => {
+  beforeEach(() => {
+    cy.tearDown()
+    cy.setUp('sroc-supplementary-previous')
+    cy.fixture('users.json').its('billingAndData').as('userEmail')
+
+    // Get the current date as a string, for example 12 July 2023
+    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
+      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
+    })
+
+    // Work out current financial year info using the current date. So, what the end year will be. As we don't override
+    // day and month we'll get back 20XX-03-31. We then use that date to work out how many SROC billing periods we
+    // expect to be calculated. We then deduct a year because the engine will bump the financial to the year of the last
+    // sent annual bill run. In other tests our SROC test fixture creates an annual bill run in the current year. For
+    // this test we use a fixture that creates it in the previous year. We then combine these results into one value for
+    // use in our tests.
+    cy.currentFinancialYearDate().then((currentFinancialYearInfo) => {
+      cy.numberOfSrocBillingPeriods(currentFinancialYearInfo.year).then((numberOfBillingPeriods) => {
+        currentFinancialYearInfo.billingPeriodCount = numberOfBillingPeriods - 1
+        cy.wrap(currentFinancialYearInfo).as('currentFinancialYearInfo')
+      })
+    })
+  })
+
+  it('creates both the PRESROC and SROC supplementary bill runs in the current year where no annual exists', () => {
+    cy.visit('/')
+
+    //  Enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    //  Click Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    //  Assert the user signed in and we're on the search page
+    cy.contains('Search')
+
+    // click the Bill runs menu link
+    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+
+    // Bill runs
+    // click the Create a bill run button
+    cy.get('#main-content > a.govuk-button').contains('Create a bill run').click()
+
+    // Which kind of bill run do you want to create?
+    // choose Supplementary and continue
+    cy.get('label.govuk-radios__label').contains('Supplementary').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Select the region
+    // choose Test Region and continue
+    cy.get('label.govuk-radios__label').contains('Test Region').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Bill runs
+    //
+    // The bill run we created will be the second from top result. We expect it's status to be BUILDING. Building might
+    // take a few seconds though so to avoid the test failing we use our custom Cypress command to look for the status
+    // READY, and if not found reload the page and try again. We then select it using the link on the date created
+    cy.reloadUntilTextFound('tr:nth-child(2) > td:nth-child(6) > .govuk-tag', 'Ready')
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+      cy.get('tr:nth-child(1)')
+        .should('contain.text', formattedCurrentDate)
+        .and('contain.text', 'Test Region')
+        .and('contain.text', 'Supplementary')
+    })
+    cy.get('tr:nth-child(2) > td:nth-child(1) > a').click()
+
+    // Test Region supplementary bill run
+    // check the the financial end year is not the current year
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
+    cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
+      const { billingPeriodCount } = currentFinancialYearInfo
+      if (billingPeriodCount === 1) {
+        cy.get('[data-test="bills-count"]')
+          .should('contain.text', '1 Supplementary bill')
+      } else {
+        cy.get('[data-test="bills-count"]')
+          .should('contain.text', `${billingPeriodCount} Supplementary bills`)
+      }
+      cy.get('[data-test="meta-data-year"]')
+        .should('contain.text', `${currentFinancialYearInfo.year - 2} to ${currentFinancialYearInfo.year - 1}`)
+    })
+  })
+})

--- a/cypress/e2e/internal/billing/supplementary/no-annual-in-current-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/no-annual-in-current-year.cy.js
@@ -3,7 +3,7 @@
 describe('Create and send supplementary bill runs (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-supplementary-previous')
+    cy.setUp('sroc-billing-previous')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023

--- a/cypress/e2e/internal/billing/supplementary/non-charge-licence-credit.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/non-charge-licence-credit.cy.js
@@ -3,7 +3,7 @@
 describe('Make licence non-chargeable then see credit in next bill run (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-supplementary-current')
+    cy.setUp('sroc-billing-current')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023

--- a/cypress/e2e/internal/billing/supplementary/non-charge-licence-credit.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/non-charge-licence-credit.cy.js
@@ -3,7 +3,7 @@
 describe('Make licence non-chargeable then see credit in next bill run (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-billing-data')
+    cy.setUp('sroc-supplementary-current')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
@@ -3,7 +3,7 @@
 describe('Replace charge version in the 2023 financial year with no changes (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-supplementary-current')
+    cy.setUp('sroc-billing-current')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
@@ -3,7 +3,7 @@
 describe('Replace charge version in the 2023 financial year with no changes (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-billing-data')
+    cy.setUp('sroc-supplementary-current')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
@@ -3,7 +3,7 @@
 describe('Replace charge version in current financial year change the charge reference and add adjustments and additional charges (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-supplementary-current')
+    cy.setUp('sroc-billing-current')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
@@ -3,7 +3,7 @@
 describe('Replace charge version in current financial year change the charge reference and add adjustments and additional charges (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-billing-data')
+    cy.setUp('sroc-supplementary-current')
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
@@ -355,7 +355,7 @@ describe('Replace charge version in current financial year change the charge ref
     cy.get('[data-test="meta-data-region"]').should('contain.text', 'Test Region')
     cy.get('[data-test="meta-data-type"]').should('contain.text', 'Supplementary')
     cy.get('[data-test="meta-data-scheme"]').should('contain.text', 'Current')
-    cy.get('[data-test="bill-total"]').should('contain.text', '£3,574.73')
+    cy.get('[data-test="bill-total"]').should('contain.text', '£3,567.70')
     cy.get('[data-test="bills-count"]').should('contain.text', '1 Supplementary bill')
     // NOTE: We cannot assert the new billing account number because it will be different in each environment and
     // unpredictable because the new number is based on existing data
@@ -364,7 +364,7 @@ describe('Replace charge version in current financial year change the charge ref
     cy.currentFinancialYearDate().then((result) => {
       cy.get('[data-test="financial-year-0"]').should('contain.text', result.year)
     })
-    cy.get('[data-test="total-0"]').should('contain.text', '£3,574.73')
+    cy.get('[data-test="total-0"]').should('contain.text', '£3,567.70')
     cy.get('.govuk-button').contains('Send bill run').click()
 
     // You're about to send this bill run
@@ -402,7 +402,7 @@ describe('Replace charge version in current financial year change the charge ref
     cy.get('.govuk-table__body > :nth-child(1) > :nth-child(2)').should('contain.text', 'Test Region')
     cy.get('.govuk-table__body > :nth-child(1) > :nth-child(3)').should('contain.text', 'Supplementary')
     cy.get('.govuk-table__body > :nth-child(1) > :nth-child(4)').should('contain.text', '1')
-    cy.get('.govuk-table__body > :nth-child(1) > :nth-child(5)').should('contain.text', '£3,574.73')
+    cy.get('.govuk-table__body > :nth-child(1) > :nth-child(5)').should('contain.text', '£3,567.70')
     cy.get('.govuk-table__body > :nth-child(1) > :nth-child(6)').should('contain.text', 'Sent')
 
     // select the bill run to check the adjustments and additional charges have been applied
@@ -415,21 +415,21 @@ describe('Replace charge version in current financial year change the charge ref
     // Bill for Big Farm Co Ltd 02
     // check the debits, credits, adjustments and additional charges have been applied
     cy.get('[data-test="credits-total"]').should('contain.text', '£97.00')
-    cy.get('[data-test="debits-total"]').should('contain.text', '£3,671.73')
-    cy.get('[data-test="bill-total"]').should('contain.text', '£3,574.73')
+    cy.get('[data-test="debits-total"]').should('contain.text', '£3,664.70')
+    cy.get('[data-test="bill-total"]').should('contain.text', '£3,567.70')
     cy.get('[data-test="additional-charges-0"]').should('contain.text', 'Supported source Earl Soham - Deben (£10696.00)')
     cy.get('[data-test="adjustments-0"]').should('contain.text', 'Winter discount (0.5)')
 
-    cy.get('[data-test="billable-days-0"]').should('contain.text', '213/366')
+    cy.get('[data-test="billable-days-0"]').should('contain.text', '212/365')
     cy.get('[data-test="quantity-0"]').should('contain.text', '1000ML')
-    cy.get('[data-test="debit-0"]').should('contain.text', '£3,631.18')
+    cy.get('[data-test="debit-0"]').should('contain.text', '£3,624.04')
 
-    cy.get('[data-test="billable-days-1"]').should('contain.text', '366/366')
+    cy.get('[data-test="billable-days-1"]').should('contain.text', '365/365')
     cy.get('[data-test="quantity-1"]').should('contain.text', '100ML')
     cy.get('[data-test="credit-1"]').should('contain.text', '£97.00')
 
-    cy.get('[data-test="billable-days-2"]').should('contain.text', '153/366')
+    cy.get('[data-test="billable-days-2"]').should('contain.text', '153/365')
     cy.get('[data-test="quantity-2"]').should('contain.text', '100ML')
-    cy.get('[data-test="debit-2"]').should('contain.text', '£40.55')
+    cy.get('[data-test="debit-2"]').should('contain.text', '£40.66')
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4403

In [Bump supplementary end year if no annual bill run](https://github.com/DEFRA/water-abstraction-system/pull/875) we amended our billing engine for supplementary. We made it possible for users to generate supplementary bill runs in years where no annual has yet been created and sent.

Previously, the Billing & Data team would have to put a block on creating bill runs until the annuals were generated. This is because supplementary takes into account previous transactions whereas annual doesn't. Without the change creating a supplementary followed by an annual bill run would result in the customer getting charged twice.

We now determine when the last annual bill run was sent and use its financial end year as the end year for the supplementary bill run. Annual created in this billing period? Then the supplementary will start there and work back 5 years. If the last sent annual was for the previous billing period the supplementary will start _there_ and work back 5 years.

The problem is this means our billing engine is working on the assumption there is _always_ at least one 'sent' annual bill run for a region. This is the case in our live service but not in our test setup.

We've made changes to our [acceptance test fixture setup](https://github.com/DEFRA/water-abstraction-service/pull/2484) to ensure we always create an annual as part of our SROC test fixture. These changes cover any other tweaks needed to get the existing tests working.

---

Notes on the changes

- `cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js`

It was 'cheating' before by using a two-part tariff test fixture that would result in empty bill runs. We have only added the annual bill run entry to our SROC data fixture so we needed to switch it to use that and update the assertions accordingly.

- `internal/billing/supplementary/journey.cy.js

Having moved into 2024-25 we've hit a point where part of the PRESROC charge version is no longer included in the bill run.

It starts on Jan 1 2019. When the billing period was 2023-24 five years before that year it would include the billing period 2018-19. This means there would be 4 supplementary bills with the first just being for 2019-01-01 to 2019-03-31.

Now the billing period is 2024-25 the period 2018-2019 has dropped off. This means 1 less bill which affects the bill run total.

- `internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js`

Moving into a new billing period means the number of billable days being calculated is different which affects the values being asserted.

- `internal/billing/supplementary/change-billing-account-current-year.cy.js`

This corrects a faulty assumption in the test, put there no doubt because of a copy and paste. Once we add the new charge version for the current year and then create the second SRO supplementary, with no other changes we should only see 2 bills; the credit for the previous one and the debit for the new account.

But we were using the number returned from our logic which works out how many bills we expect to see based on the number of billing periods since 2022. It worked when running the tests in 2023-24 because the result was also 2. Now we are in 2024-25 it's exposed the faulty logic.

- Fix broken annual billing

We had overlooked that the annual billing tests were using the `sroc-billing-data` fixture as well. Adding an annual bill run to that fixture caused the annual tests to fail because of the existing bill run.

We realised that we could use the 'previous' fixture we created as part of these changes both for our new supplementary test and the annual tests. This saves a bunch of duplication in the integration sets. It still creates a bill run but it is for the previous year. If anything it's a more robust way of checking that bill runs in previous billing periods shouldn't prevent a new one from being created.

- Add new test for supplementary financial year bump

This new test gives us a means to check that the supplementary end-year bump feature is working. It uses a new SROC fixture that is the same as our normal one only the annual bill run created is for the previous billing period.

This means we can confirm when we create an SROC supplementary that its financial year end is also for the previous billing period.