### PR TITLE
Update tests for new bill runs page

### DIFF
--- a/cypress/e2e/internal/billing/annual/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/annual/cancel-existing.cy.js
@@ -35,7 +35,7 @@ describe('Cancel an existing annual bill run (internal)', () => {
 
     // Bill runs
     // click the Create a bill run button
-    cy.get('#main-content > a.govuk-button').contains('Create a bill run').click()
+    cy.get('.govuk-button').contains('Create a bill run').click()
 
     // Which kind of bill run do you want to create?
     // choose Annual and continue
@@ -52,14 +52,13 @@ describe('Cancel an existing annual bill run (internal)', () => {
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status EMPTY, and
     // if not found reload the page and try again. We then select it using the link on the date created
-    cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > .govuk-tag', 'Empty')
+    cy.reloadUntilTextFound('[data-test="bill-run-status-0"] > .govuk-tag', 'empty')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Annual')
+      cy.get('[data-test="date-created-0"]').should('contain.text', formattedCurrentDate)
     })
-    cy.get('tr:nth-child(1) > td:nth-child(1) > a').click()
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Annual')
+    cy.get('[data-test="date-created-0"] > .govuk-link').click()
 
     // Test Region annual bill run
     // quick test that the display is as expected and then click Cancel bill run
@@ -84,6 +83,6 @@ describe('Cancel an existing annual bill run (internal)', () => {
 
     // Bill runs
     // confirm we are back on the bill runs page
-    cy.get('h1.govuk-heading-l').should('contain.text', 'Bill runs')
+    cy.get('.govuk-heading-xl').should('contain.text', 'Bill runs')
   })
 })

--- a/cypress/e2e/internal/billing/annual/journey.cy.js
+++ b/cypress/e2e/internal/billing/annual/journey.cy.js
@@ -32,7 +32,7 @@ describe('Create and send annual bill run (internal)', () => {
 
     // Bill runs
     // click the Create a bill run button
-    cy.get('#main-content > a.govuk-button').contains('Create a bill run').click()
+    cy.get('.govuk-button').contains('Create a bill run').click()
 
     // Which kind of bill run do you want to create?
     // choose Annual and continue
@@ -49,14 +49,13 @@ describe('Create and send annual bill run (internal)', () => {
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status READY, and
     // if not found reload the page and try again. We then select it using the link on the date created
-    cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > .govuk-tag', 'Ready')
+    cy.reloadUntilTextFound('[data-test="bill-run-status-0"] > .govuk-tag', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Annual')
+      cy.get('[data-test="date-created-0"]').should('contain.text', formattedCurrentDate)
     })
-    cy.get('tr:nth-child(1) > td:nth-child(1) > a').click()
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Annual')
+    cy.get('[data-test="date-created-0"] > .govuk-link').click()
 
     // Test Region annual bill run
     // quick test that the display is as expected and then click Send bill run
@@ -96,12 +95,11 @@ describe('Create and send annual bill run (internal)', () => {
     // Bill runs
     // back on the bill runs page confirm our bill run is present and listed as SENT
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Annual')
-        .and('contain.text', '2,171.00')
-        .and('contain.text', 'Sent')
+      cy.get('[data-test="date-created-0"] > .govuk-link').should('contain.text', formattedCurrentDate)
     })
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Annual')
+    cy.get('[data-test="number-of-bills-0"]').should('contain.text', '4')
+    cy.get('[data-test="bill-run-status-0"] > .govuk-tag').should('contain.text', 'sent')
   })
 })

--- a/cypress/e2e/internal/billing/annual/remove-licence.cy.js
+++ b/cypress/e2e/internal/billing/annual/remove-licence.cy.js
@@ -32,7 +32,7 @@ describe('Remove bill from annual bill run (internal)', () => {
 
     // Bill runs
     // click the Create a bill run button
-    cy.get('#main-content > a.govuk-button').contains('Create a bill run').click()
+    cy.get('.govuk-button').contains('Create a bill run').click()
 
     // Which kind of bill run do you want to create?
     // choose Annual and continue
@@ -49,14 +49,13 @@ describe('Remove bill from annual bill run (internal)', () => {
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status READY, and
     // if not found reload the page and try again. We then select it using the link on the date created
-    cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > .govuk-tag', 'Ready')
+    cy.reloadUntilTextFound('[data-test="bill-run-status-0"] > .govuk-tag', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Annual')
+      cy.get('[data-test="date-created-0"]').should('contain.text', formattedCurrentDate)
     })
-    cy.get('tr:nth-child(1) > td:nth-child(1) > a').click()
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Annual')
+    cy.get('[data-test="date-created-0"] > .govuk-link').click()
 
     // Test Region annual bill run
     // quick test that the display is as expected and then click view bill link

--- a/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
@@ -35,7 +35,7 @@ describe('Cancel existing supplementary bill runs (internal)', () => {
 
     // Bill runs
     // click the Create a bill run button
-    cy.get('#main-content > a.govuk-button').contains('Create a bill run').click()
+    cy.get('.govuk-button').contains('Create a bill run').click()
 
     // Which kind of bill run do you want to create?
     // choose Supplementary and continue
@@ -55,15 +55,13 @@ describe('Cancel existing supplementary bill runs (internal)', () => {
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status READY, and
     // if not found reload the page and try again. We then select it using the link on the date created
-    cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > .govuk-tag', 'Ready')
+    cy.reloadUntilTextFound('[data-test="bill-run-status-0"] > .govuk-tag', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Old charge scheme')
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Supplementary')
+      cy.get('[data-test="date-created-0"]').should('contain.text', formattedCurrentDate).and('contain.text', 'Old charge scheme')
     })
-    cy.get('tr:nth-child(1) > td:nth-child(1) > a').click()
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Supplementary')
+    cy.get('[data-test="date-created-0"] > .govuk-link').click()
 
     // Test Region supplementary bill run
     // quick test that the display is as expected and then click Cancel bill run
@@ -87,21 +85,18 @@ describe('Cancel existing supplementary bill runs (internal)', () => {
 
     // Bill runs
     // confirm we are back on the bill runs page
-    cy.get('h1.govuk-heading-l').should('contain.text', 'Bill runs')
+    cy.get('.govuk-heading-xl').should('contain.text', 'Bill runs')
 
     // -------------------------------------------------------------------------
     cy.log('Deleting the SROC supplementary bill run')
 
-    // select the SROC bill run
-    // On fast machines you might not see the cancelling entry in the bill runs screen. So, we have a conditional
-    // to determine which row to click. If 'Cancelling' is seen click the next row down, else click the current row.
-    cy.get(':nth-child(1) > :nth-child(6) > .govuk-tag').then((topRowStatus) => {
-      if (topRowStatus.text().includes('Cancelling')) {
-        cy.get('tr:nth-child(2) > td:nth-child(1) > a').click()
-      } else {
-        cy.get('tr:nth-child(1) > td:nth-child(1) > a').click()
-      }
-    })
+    // Bill runs
+    //
+    // The bill run we created will be the top result. We expect it's status to be CANCELLING. Cancelling might take a
+    // few seconds though so to avoid the test failing we use our custom Cypress command to look for the status READY,
+    // and if not found reload the page and try again. We then select it using the link on the date created
+    cy.reloadUntilTextFound('[data-test="bill-run-status-0"] > .govuk-tag', 'ready')
+    cy.get('[data-test="date-created-0"] > .govuk-link').click()
 
     // Test Region supplementary bill run
     // quick test that the display is as expected and then click Cancel bill run
@@ -125,6 +120,6 @@ describe('Cancel existing supplementary bill runs (internal)', () => {
 
     // Bill runs
     // confirm we are back on the bill runs page
-    cy.get('h1.govuk-heading-l').should('contain.text', 'Bill runs')
+    cy.get('.govuk-heading-xl').should('contain.text', 'Bill runs')
   })
 })

--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
@@ -42,7 +42,7 @@ describe('Change billing account in current financial year (internal)', () => {
 
     // Bill runs
     // click the Create a bill run button
-    cy.get('#main-content > a.govuk-button').contains('Create a bill run').click()
+    cy.get('.govuk-button').contains('Create a bill run').click()
 
     // Which kind of bill run do you want to create?
     // choose Supplementary and continue
@@ -59,14 +59,13 @@ describe('Change billing account in current financial year (internal)', () => {
     // The bill run we created will be the second from top result. We expect it's status to be BUILDING. Building might
     // take a few seconds though so to avoid the test failing we use our custom Cypress command to look for the status
     // READY, and if not found reload the page and try again. We then select it using the link on the date created
-    cy.reloadUntilTextFound('tr:nth-child(2) > td:nth-child(6) > .govuk-tag', 'Ready')
+    cy.reloadUntilTextFound('[data-test="bill-run-status-1"] > .govuk-tag', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Supplementary')
+      cy.get('[data-test="date-created-1"]').should('contain.text', formattedCurrentDate)
     })
-    cy.get('tr:nth-child(2) > td:nth-child(1) > a').click()
+    cy.get('[data-test="region-1"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-1"]').should('contain.text', 'Supplementary')
+    cy.get('[data-test="date-created-1"] > .govuk-link').click()
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
@@ -112,25 +111,18 @@ describe('Change billing account in current financial year (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our SROC bill run is present and listed as SENT
-    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(2)').within(() => {
-      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-        cy.get('td:nth-child(1)').should('contain.text', formattedCurrentDate)
-      })
-
-      cy.get('td:nth-child(2)').should('contain.text', 'Test Region')
-      cy.get('td:nth-child(3)').should('contain.text', 'Supplementary')
-
-      cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
-        cy.get('td:nth-child(4)').should('contain.text', currentFinancialYearInfo.billingPeriodCount)
-      })
-
-      cy.get('td:nth-child(6)').should('contain.text', 'Sent')
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+      cy.get('[data-test="date-created-1"] > .govuk-link').should('contain.text', formattedCurrentDate)
     })
+    cy.get('[data-test="region-1"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-1"]').should('contain.text', 'Supplementary')
+    cy.get('[data-test="number-of-bills-1"]').should('contain.text', '3')
+    cy.get('[data-test="bill-run-status-1"] > .govuk-tag').should('contain.text', 'sent')
 
     // -------------------------------------------------------------------------
 
     // click the Search menu link
-    cy.get('#navbar-view').click()
+    cy.get('#nav-search').click()
 
     // Search
     // search for a licence and select it
@@ -208,7 +200,7 @@ describe('Change billing account in current financial year (internal)', () => {
 
     // Bill runs
     // click the Create a bill run button
-    cy.get('#main-content > a.govuk-button').contains('Create a bill run').click()
+    cy.get('.govuk-button').contains('Create a bill run').click()
 
     // Which kind of bill run do you want to create?
     // choose Supplementary and continue
@@ -220,9 +212,6 @@ describe('Change billing account in current financial year (internal)', () => {
     cy.get('label.govuk-radios__label').contains('Test Region').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
-    // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
-
     // -------------------------------------------------------------------------
     cy.log('Confirming and sending the SROC supplementary bill run')
 
@@ -231,14 +220,13 @@ describe('Change billing account in current financial year (internal)', () => {
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status READY, and
     // if not found reload the page and try again. We then select it using the link on the date created
-    cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > .govuk-tag', 'Ready')
+    cy.reloadUntilTextFound('[data-test="bill-run-status-0"] > .govuk-tag', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Supplementary')
+      cy.get('[data-test="date-created-0"]').should('contain.text', formattedCurrentDate)
     })
-    cy.get('tr:nth-child(1) > td:nth-child(1) > a').click()
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Supplementary')
+    cy.get('[data-test="date-created-0"] > .govuk-link').click()
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
@@ -293,13 +281,12 @@ describe('Change billing account in current financial year (internal)', () => {
     // Bill runs
     // back on the bill runs page confirm our SROC bill run is present and listed as SENT
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Supplementary')
-        .and('contain.text', '2')
-        .and('contain.text', '£0.00')
-        .and('contain.text', 'Sent')
+      cy.get('[data-test="date-created-0"] > .govuk-link').should('contain.text', formattedCurrentDate)
     })
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Supplementary')
+    cy.get('[data-test="number-of-bills-0"]').should('contain.text', '2')
+    cy.get('[data-test="bill-run-total-0"]').should('contain.text', '£0.00')
+    cy.get('[data-test="bill-run-status-0"] > .govuk-tag').should('contain.text', 'sent')
   })
 })

--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
@@ -42,7 +42,7 @@ describe('Change billing account in previous financial year (internal)', () => {
 
     // Bill runs
     // click the Create a bill run button
-    cy.get('#main-content > a.govuk-button').contains('Create a bill run').click()
+    cy.get('.govuk-button').contains('Create a bill run').click()
 
     // Which kind of bill run do you want to create?
     // choose Supplementary and continue
@@ -59,14 +59,13 @@ describe('Change billing account in previous financial year (internal)', () => {
     // The bill run we created will be the second from top result. We expect it's status to be BUILDING. Building might
     // take a few seconds though so to avoid the test failing we use our custom Cypress command to look for the status
     // READY, and if not found reload the page and try again. We then select it using the link on the date created
-    cy.reloadUntilTextFound('tr:nth-child(2) > td:nth-child(6) > .govuk-tag', 'Ready')
+    cy.reloadUntilTextFound('[data-test="bill-run-status-1"] > .govuk-tag', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Supplementary')
+      cy.get('[data-test="date-created-1"] > .govuk-link').should('contain.text', formattedCurrentDate)
     })
-    cy.get('tr:nth-child(2) > td:nth-child(1) > a').click()
+    cy.get('[data-test="region-1"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-1"]').should('contain.text', 'Supplementary')
+    cy.get('[data-test="date-created-1"] > .govuk-link').click()
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
@@ -112,25 +111,20 @@ describe('Change billing account in previous financial year (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our SROC bill run is present and listed as SENT
-    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(2)').within(() => {
-      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-        cy.get('td:nth-child(1)').should('contain.text', formattedCurrentDate)
-      })
-
-      cy.get('td:nth-child(2)').should('contain.text', 'Test Region')
-      cy.get('td:nth-child(3)').should('contain.text', 'Supplementary')
-
-      cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
-        cy.get('td:nth-child(4)').should('contain.text', currentFinancialYearInfo.billingPeriodCount)
-      })
-
-      cy.get('td:nth-child(6)').should('contain.text', 'Sent')
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+      cy.get('[data-test="date-created-1"] > .govuk-link').should('contain.text', formattedCurrentDate)
     })
+    cy.get('[data-test="region-1"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-1"]').should('contain.text', 'Supplementary')
+    cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
+      cy.get('[data-test="number-of-bills-1"]').should('contain.text', currentFinancialYearInfo.billingPeriodCount)
+    })
+    cy.get('[data-test="bill-run-status-1"] > .govuk-tag').should('contain.text', 'sent')
 
     // -------------------------------------------------------------------------
 
     // click the Search menu link
-    cy.get('#navbar-view').click()
+    cy.get('#nav-search').click()
 
     // Search
     // search for a licence and select it
@@ -208,7 +202,7 @@ describe('Change billing account in previous financial year (internal)', () => {
 
     // Bill runs
     // click the Create a bill run button
-    cy.get('#main-content > a.govuk-button').contains('Create a bill run').click()
+    cy.get('.govuk-button').contains('Create a bill run').click()
 
     // Which kind of bill run do you want to create?
     // choose Supplementary and continue
@@ -220,9 +214,6 @@ describe('Change billing account in previous financial year (internal)', () => {
     cy.get('label.govuk-radios__label').contains('Test Region').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
-    // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
-
     // -------------------------------------------------------------------------
     cy.log('Confirming and sending the SROC supplementary bill run')
 
@@ -231,14 +222,13 @@ describe('Change billing account in previous financial year (internal)', () => {
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status READY, and
     // if not found reload the page and try again. We then select it using the link on the date created
-    cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > .govuk-tag', 'Ready')
+    cy.reloadUntilTextFound('[data-test="bill-run-status-0"] > .govuk-tag', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Supplementary')
+      cy.get('[data-test="date-created-0"]').should('contain.text', formattedCurrentDate)
     })
-    cy.get('tr:nth-child(1) > td:nth-child(1) > a').click()
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Supplementary')
+    cy.get('[data-test="date-created-0"] > .govuk-link').click()
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
@@ -302,13 +292,12 @@ describe('Change billing account in previous financial year (internal)', () => {
     // Bill runs
     // back on the bill runs page confirm our SROC bill run is present and listed as SENT
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Supplementary')
-        .and('contain.text', '4')
-        .and('contain.text', '£0.00')
-        .and('contain.text', 'Sent')
+      cy.get('[data-test="date-created-0"]').should('contain.text', formattedCurrentDate)
     })
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Supplementary')
+    cy.get('[data-test="number-of-bills-0"]').should('contain.text', '4')
+    cy.get('[data-test="bill-run-total-0"]').should('contain.text', '£0.00')
+    cy.get('[data-test="bill-run-status-0"] > .govuk-tag').should('contain.text', 'sent')
   })
 })

--- a/cypress/e2e/internal/billing/supplementary/journey.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/journey.cy.js
@@ -42,7 +42,7 @@ describe('Create and send supplementary bill runs (internal)', () => {
 
     // Bill runs
     // click the Create a bill run button
-    cy.get('#main-content > a.govuk-button').contains('Create a bill run').click()
+    cy.get('.govuk-button').contains('Create a bill run').click()
 
     // Which kind of bill run do you want to create?
     // choose Supplementary and continue
@@ -59,14 +59,13 @@ describe('Create and send supplementary bill runs (internal)', () => {
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status READY, and
     // if not found reload the page and try again. We then select it using the link on the date created
-    cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > .govuk-tag', 'Ready')
+    cy.reloadUntilTextFound('[data-test="bill-run-status-0"] > .govuk-tag', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Supplementary')
+      cy.get('[data-test="date-created-0"]').should('contain.text', formattedCurrentDate)
     })
-    cy.get('tr:nth-child(1) > td:nth-child(1) > a').click()
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Supplementary')
+    cy.get('[data-test="date-created-0"] > .govuk-link').click()
 
     // -------------------------------------------------------------------------
     cy.log('Confirming and sending the PRESROC supplementary bill run')
@@ -108,20 +107,18 @@ describe('Create and send supplementary bill runs (internal)', () => {
     // Bill runs
     // back on the bill runs page confirm our PRESROC bill run is present and listed as SENT
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Old charge scheme')
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Supplementary')
-        .and('contain.text', '£537.90')
-        .and('contain.text', 'Sent')
+      cy.get('[data-test="date-created-0"]').should('contain.text', formattedCurrentDate).and('contain.text', 'Old charge scheme')
     })
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Supplementary')
+    cy.get('[data-test="number-of-bills-0"]').should('contain.text', '3')
+    cy.get('[data-test="bill-run-status-0"] > .govuk-tag').should('contain.text', 'sent')
 
     // -------------------------------------------------------------------------
     cy.log('Confirming and sending the SROC supplementary bill run')
 
     // select the SROC bill run
-    cy.get('tr:nth-child(2) > td:nth-child(1) > a').click()
+    cy.get('[data-test="date-created-1"] > .govuk-link').click()
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
@@ -167,19 +164,14 @@ describe('Create and send supplementary bill runs (internal)', () => {
 
     // Bill runs
     // back on the bill runs page confirm our SROC bill run is present and listed as SENT
-    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(2)').within(() => {
-      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-        cy.get('td:nth-child(1)').should('contain.text', formattedCurrentDate)
-      })
-
-      cy.get('td:nth-child(2)').should('contain.text', 'Test Region')
-      cy.get('td:nth-child(3)').should('contain.text', 'Supplementary')
-
-      cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
-        cy.get('td:nth-child(4)').should('contain.text', currentFinancialYearInfo.billingPeriodCount)
-      })
-
-      cy.get('td:nth-child(6)').should('contain.text', 'Sent')
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+      cy.get('[data-test="date-created-1"] > .govuk-link').should('contain.text', formattedCurrentDate)
     })
+    cy.get('[data-test="region-1"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-1"]').should('contain.text', 'Supplementary')
+    cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
+      cy.get('[data-test="number-of-bills-1"]').should('contain.text', currentFinancialYearInfo.billingPeriodCount)
+    })
+    cy.get('[data-test="bill-run-status-1"] > .govuk-tag').should('contain.text', 'sent')
   })
 })

--- a/cypress/e2e/internal/billing/supplementary/no-annual-in-current-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/no-annual-in-current-year.cy.js
@@ -45,7 +45,7 @@ describe('Create and send supplementary bill runs (internal)', () => {
 
     // Bill runs
     // click the Create a bill run button
-    cy.get('#main-content > a.govuk-button').contains('Create a bill run').click()
+    cy.get('.govuk-button').contains('Create a bill run').click()
 
     // Which kind of bill run do you want to create?
     // choose Supplementary and continue
@@ -62,14 +62,13 @@ describe('Create and send supplementary bill runs (internal)', () => {
     // The bill run we created will be the second from top result. We expect it's status to be BUILDING. Building might
     // take a few seconds though so to avoid the test failing we use our custom Cypress command to look for the status
     // READY, and if not found reload the page and try again. We then select it using the link on the date created
-    cy.reloadUntilTextFound('tr:nth-child(2) > td:nth-child(6) > .govuk-tag', 'Ready')
+    cy.reloadUntilTextFound('[data-test="bill-run-status-1"] > .govuk-tag', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Supplementary')
+      cy.get('[data-test="date-created-1"]').should('contain.text', formattedCurrentDate)
     })
-    cy.get('tr:nth-child(2) > td:nth-child(1) > a').click()
+    cy.get('[data-test="region-1"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-1"]').should('contain.text', 'Supplementary')
+    cy.get('[data-test="date-created-1"] > .govuk-link').click()
 
     // Test Region supplementary bill run
     // check the the financial end year is not the current year

--- a/cypress/e2e/internal/billing/supplementary/non-charge-licence-credit.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/non-charge-licence-credit.cy.js
@@ -35,7 +35,7 @@ describe('Make licence non-chargeable then see credit in next bill run (internal
 
     // Bill runs
     // click the Create a bill run button
-    cy.get('#main-content > a.govuk-button').contains('Create a bill run').click()
+    cy.get('.govuk-button').contains('Create a bill run').click()
 
     // Which kind of bill run do you want to create?
     // choose Supplementary and continue
@@ -52,14 +52,13 @@ describe('Make licence non-chargeable then see credit in next bill run (internal
     // The bill run we created will be the second from top result. We expect it's status to be BUILDING. Building might
     // take a few seconds though so to avoid the test failing we use our custom Cypress command to look for the status
     // READY, and if not found reload the page and try again. We then select it using the link on the date created
-    cy.reloadUntilTextFound('tr:nth-child(2) > td:nth-child(6) > .govuk-tag', 'Ready')
+    cy.reloadUntilTextFound('[data-test="bill-run-status-1"] > .govuk-tag', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Supplementary')
+      cy.get('[data-test="date-created-1"]').should('contain.text', formattedCurrentDate)
     })
-    cy.get('tr:nth-child(2) > td:nth-child(1) > a').click()
+    cy.get('[data-test="region-1"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-1"]').should('contain.text', 'Supplementary')
+    cy.get('[data-test="date-created-1"] > .govuk-link').click()
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
@@ -161,7 +160,7 @@ describe('Make licence non-chargeable then see credit in next bill run (internal
 
     // Bill runs
     // click the Create a bill run button
-    cy.get('#main-content > a.govuk-button').contains('Create a bill run').click()
+    cy.get('.govuk-button').contains('Create a bill run').click()
 
     // Which kind of bill run do you want to create?
     // choose Supplementary and continue
@@ -178,14 +177,13 @@ describe('Make licence non-chargeable then see credit in next bill run (internal
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status READY, and
     // if not found reload the page and try again. We then select it using the link on the date created
-    cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > .govuk-tag', 'Ready')
+    cy.reloadUntilTextFound('[data-test="bill-run-status-0"] > .govuk-tag', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Supplementary')
+      cy.get('[data-test="date-created-0"]').should('contain.text', formattedCurrentDate)
     })
-    cy.get('tr:nth-child(1) > td:nth-child(1) > a').click()
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Supplementary')
+    cy.get('[data-test="date-created-0"] > .govuk-link').click()
 
     // Test Region supplementary bill run
     // check the details before sending the bill run

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
@@ -118,7 +118,7 @@ describe('Replace charge version in the 2023 financial year with no changes (int
 
     // Bill runs
     // click the Create a bill run button
-    cy.get('#main-content > a.govuk-button').contains('Create a bill run').click()
+    cy.get('.govuk-button').contains('Create a bill run').click()
 
     // Which kind of bill run do you want to create?
     // choose Supplementary and continue
@@ -135,14 +135,13 @@ describe('Replace charge version in the 2023 financial year with no changes (int
     // The bill run we created will be the second from top result. We expect it's status to be BUILDING. Building might
     // take a few seconds though so to avoid the test failing we use our custom Cypress command to look for the status
     // READY, and if not found reload the page and try again. We then select it using the link on the date created
-    cy.reloadUntilTextFound('tr:nth-child(2) > td:nth-child(6) > .govuk-tag', 'Ready')
+    cy.reloadUntilTextFound('[data-test="bill-run-status-1"] > .govuk-tag', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Supplementary')
+      cy.get('[data-test="date-created-1"]').should('contain.text', formattedCurrentDate)
     })
-    cy.get('tr:nth-child(2) > td:nth-child(1) > a').click()
+    cy.get('[data-test="region-1"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-1"]').should('contain.text', 'Supplementary')
+    cy.get('[data-test="date-created-1"] > .govuk-link').click()
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
@@ -188,26 +187,21 @@ describe('Replace charge version in the 2023 financial year with no changes (int
 
     // Bill runs
     // back on the bill runs page confirm our SROC bill run is present and listed as SENT
-    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(2)').within(() => {
-      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-        cy.get('td:nth-child(1)').should('contain.text', formattedCurrentDate)
-      })
-
-      cy.get('td:nth-child(2)').should('contain.text', 'Test Region')
-      cy.get('td:nth-child(3)').should('contain.text', 'Supplementary')
-
-      cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
-        cy.get('td:nth-child(4)').should('contain.text', currentFinancialYearInfo.billingPeriodCount)
-      })
-
-      cy.get('td:nth-child(6)').should('contain.text', 'Sent')
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+      cy.get('[data-test="date-created-1"]').should('contain.text', formattedCurrentDate)
     })
+    cy.get('[data-test="region-1"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-1"]').should('contain.text', 'Supplementary')
+    cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
+      cy.get('[data-test="number-of-bills-1"]').should('contain.text', currentFinancialYearInfo.billingPeriodCount)
+    })
+    cy.get('[data-test="bill-run-status-1"] > .govuk-tag').should('contain.text', 'sent')
 
     // -------------------------------------------------------------------------
     cy.log('Setting up a new charge in 2023 Financial Year with no changes, then creating a supplementary bill run')
 
     // click the Search menu link
-    cy.get('#navbar-view').click()
+    cy.get('#nav-search').click()
 
     // Search
     // search for a licence and select it
@@ -263,7 +257,7 @@ describe('Replace charge version in the 2023 financial year with no changes (int
 
     // Bill runs
     // click the Create a bill run button
-    cy.get('#main-content > a.govuk-button').contains('Create a bill run').click()
+    cy.get('.govuk-button').contains('Create a bill run').click()
 
     // Which kind of bill run do you want to create?
     // choose Supplementary and continue
@@ -283,14 +277,13 @@ describe('Replace charge version in the 2023 financial year with no changes (int
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status READY, and
     // if not found reload the page and try again. We then select it using the link on the date created
-    cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > .govuk-tag', 'Ready')
+    cy.reloadUntilTextFound('[data-test="bill-run-status-0"] > .govuk-tag', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Supplementary')
+      cy.get('[data-test="date-created-0"]').should('contain.text', formattedCurrentDate)
     })
-    cy.get('tr:nth-child(1) > td:nth-child(1) > a').click()
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Supplementary')
+    cy.get('[data-test="date-created-0"] > .govuk-link').click()
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
@@ -341,12 +334,12 @@ describe('Replace charge version in the 2023 financial year with no changes (int
     // Bill runs
     // back on the bill runs page confirm our zero value SROC bill run is present and listed as SENT
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('.govuk-table__body > :nth-child(1) > :nth-child(1)').should('contain.text', formattedCurrentDate)
+      cy.get('[data-test="date-created-0"] > .govuk-link').should('contain.text', formattedCurrentDate)
     })
-    cy.get('.govuk-table__body > :nth-child(1) > :nth-child(2)').should('contain.text', 'Test Region')
-    cy.get('.govuk-table__body > :nth-child(1) > :nth-child(3)').should('contain.text', 'Supplementary')
-    cy.get('.govuk-table__body > :nth-child(1) > :nth-child(4)').should('contain.text', '0')
-    cy.get('.govuk-table__body > :nth-child(1) > :nth-child(5)').should('contain.text', '£0.00')
-    cy.get('.govuk-table__body > :nth-child(1) > :nth-child(6)').should('contain.text', 'Sent')
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Supplementary')
+    cy.get('[data-test="number-of-bills-0"]').should('contain.text', '0')
+    cy.get('[data-test="bill-run-total-0"]').should('contain.text', '£0.00')
+    cy.get('[data-test="bill-run-status-0"] > .govuk-tag').should('contain.text', 'sent')
   })
 })

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
@@ -118,7 +118,7 @@ describe('Replace charge version in current financial year change the charge ref
 
     // Bill runs
     // click the Create a bill run button
-    cy.get('#main-content > a.govuk-button').contains('Create a bill run').click()
+    cy.get('.govuk-button').contains('Create a bill run').click()
 
     // Which kind of bill run do you want to create?
     // choose Supplementary and continue
@@ -135,14 +135,13 @@ describe('Replace charge version in current financial year change the charge ref
     // The bill run we created will be the second from top result. We expect it's status to be BUILDING. Building might
     // take a few seconds though so to avoid the test failing we use our custom Cypress command to look for the status
     // READY, and if not found reload the page and try again. We then select it using the link on the date created
-    cy.reloadUntilTextFound('tr:nth-child(2) > td:nth-child(6) > .govuk-tag', 'Ready')
+    cy.reloadUntilTextFound('[data-test="bill-run-status-1"] > .govuk-tag', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Supplementary')
+      cy.get('[data-test="date-created-1"]').should('contain.text', formattedCurrentDate)
     })
-    cy.get('tr:nth-child(2) > td:nth-child(1) > a').click()
+    cy.get('[data-test="region-1"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-1"]').should('contain.text', 'Supplementary')
+    cy.get('[data-test="date-created-1"] > .govuk-link').click()
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
@@ -188,26 +187,21 @@ describe('Replace charge version in current financial year change the charge ref
 
     // Bill runs
     // back on the bill runs page confirm our SROC bill run is present and listed as SENT
-    cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(2)').within(() => {
-      cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-        cy.get('td:nth-child(1)').should('contain.text', formattedCurrentDate)
-      })
-
-      cy.get('td:nth-child(2)').should('contain.text', 'Test Region')
-      cy.get('td:nth-child(3)').should('contain.text', 'Supplementary')
-
-      cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
-        cy.get('td:nth-child(4)').should('contain.text', currentFinancialYearInfo.billingPeriodCount)
-      })
-
-      cy.get('td:nth-child(6)').should('contain.text', 'Sent')
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+      cy.get('[data-test="date-created-1"] > .govuk-link').should('contain.text', formattedCurrentDate)
     })
+    cy.get('[data-test="region-1"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-1"]').should('contain.text', 'Supplementary')
+    cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
+      cy.get('[data-test="number-of-bills-1"]').should('contain.text', currentFinancialYearInfo.billingPeriodCount)
+    })
+    cy.get('[data-test="bill-run-status-1"] > .govuk-tag').should('contain.text', 'sent')
 
     // -------------------------------------------------------------------------
     cy.log('Setting up a new charge changing the charge volume and adding adjustments and additional charges then creating a supplementary bill run')
 
     // click the Search menu link
-    cy.get('#navbar-view').click()
+    cy.get('#nav-search').click()
 
     // Search
     // search for a licence and select it
@@ -312,7 +306,7 @@ describe('Replace charge version in current financial year change the charge ref
 
     // Bill runs
     // click the Create a bill run button
-    cy.get('#main-content > a.govuk-button').contains('Create a bill run').click()
+    cy.get('.govuk-button').contains('Create a bill run').click()
 
     // Which kind of bill run do you want to create?
     // choose Supplementary and continue
@@ -332,14 +326,13 @@ describe('Replace charge version in current financial year change the charge ref
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status READY, and
     // if not found reload the page and try again. We then select it using the link on the date created
-    cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > .govuk-tag', 'Ready')
+    cy.reloadUntilTextFound('[data-test="bill-run-status-0"] > .govuk-tag', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Supplementary')
+      cy.get('[data-test="date-created-0"] > .govuk-link').should('contain.text', formattedCurrentDate)
     })
-    cy.get('tr:nth-child(1) > td:nth-child(1) > a').click()
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Supplementary')
+    cy.get('[data-test="date-created-0"] > .govuk-link').click()
 
     // Test Region supplementary bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
@@ -397,16 +390,15 @@ describe('Replace charge version in current financial year change the charge ref
     // Bill runs
     // back on the bill runs page confirm our SROC bill run is present and listed as SENT
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('.govuk-table__body > :nth-child(1) > :nth-child(1)').should('contain.text', formattedCurrentDate)
+      cy.get('[data-test="date-created-0"] > .govuk-link').should('contain.text', formattedCurrentDate)
     })
-    cy.get('.govuk-table__body > :nth-child(1) > :nth-child(2)').should('contain.text', 'Test Region')
-    cy.get('.govuk-table__body > :nth-child(1) > :nth-child(3)').should('contain.text', 'Supplementary')
-    cy.get('.govuk-table__body > :nth-child(1) > :nth-child(4)').should('contain.text', '1')
-    cy.get('.govuk-table__body > :nth-child(1) > :nth-child(5)').should('contain.text', '£3,567.70')
-    cy.get('.govuk-table__body > :nth-child(1) > :nth-child(6)').should('contain.text', 'Sent')
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Supplementary')
+    cy.get('[data-test="number-of-bills-0"]').should('contain.text', '1')
+    cy.get('[data-test="bill-run-status-0"] > .govuk-tag').should('contain.text', 'sent')
 
     // select the bill run to check the adjustments and additional charges have been applied
-    cy.get(':nth-child(1) > :nth-child(1) > .govuk-link').click()
+    cy.get('[data-test="date-created-0"] > .govuk-link').click()
 
     // Test Region supplementary bill run
     // click the View link

--- a/cypress/e2e/internal/billing/two-part-tariff/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/cancel-existing.cy.js
@@ -32,7 +32,7 @@ describe('Cancel an existing two-part tariff bill run (internal)', () => {
 
     // Bill runs
     // click the Create a bill run button
-    cy.get('#main-content > a.govuk-button').contains('Create a bill run').click()
+    cy.get('.govuk-button').contains('Create a bill run').click()
 
     // Which kind of bill run do you want to create?
     // choose Two-part tariff then continue
@@ -59,14 +59,13 @@ describe('Cancel an existing two-part tariff bill run (internal)', () => {
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status EMPTY, and
     // if not found reload the page and try again. We then select it using the link on the date created
-    cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > .govuk-tag', 'Empty')
+    cy.reloadUntilTextFound('[data-test="bill-run-status-0"] > .govuk-tag', 'empty')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Two-part tariff')
+      cy.get('[data-test="date-created-0"]').should('contain.text', formattedCurrentDate)
     })
-    cy.get('tr:nth-child(1) > td:nth-child(1) > a').click()
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Two-part tariff')
+    cy.get('[data-test="date-created-0"] > .govuk-link').click()
 
     // Test Region two-part tariff bill run
     // check the details before cancelling the bill run
@@ -90,6 +89,6 @@ describe('Cancel an existing two-part tariff bill run (internal)', () => {
 
     // Bill runs
     // confirm we are back on the bill runs page
-    cy.get('h1.govuk-heading-l').should('contain.text', 'Bill runs')
+    cy.get('.govuk-heading-xl').should('contain.text', 'Bill runs')
   })
 })

--- a/cypress/e2e/internal/billing/two-part-tariff/journey.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/journey.cy.js
@@ -32,7 +32,7 @@ describe('Create and send PRESROC two-part tariff bill run (internal)', () => {
 
     // Bill runs
     // click the Create a bill run button
-    cy.get('#main-content > a.govuk-button').contains('Create a bill run').click()
+    cy.get('.govuk-button').contains('Create a bill run').click()
 
     // Which kind of bill run do you want to create?
     // choose Two-part tariff then continue
@@ -59,14 +59,13 @@ describe('Create and send PRESROC two-part tariff bill run (internal)', () => {
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status REVIEW, and
     // if not found reload the page and try again. We then select it using the link on the date created
-    cy.reloadUntilTextFound('tr:nth-child(1) > td:nth-child(6) > .govuk-tag', 'Review')
+    cy.reloadUntilTextFound('[data-test="bill-run-status-0"] > .govuk-tag', 'review')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Two-part tariff')
+      cy.get('[data-test="date-created-0"]').should('contain.text', formattedCurrentDate)
     })
-    cy.get('tr:nth-child(1) > td:nth-child(1) > a').click()
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Two-part tariff winter and all year')
+    cy.get('[data-test="date-created-0"] > .govuk-link').click()
 
     // Review data issues
     // check the rest of the details before completing the review
@@ -158,13 +157,11 @@ describe('Create and send PRESROC two-part tariff bill run (internal)', () => {
     // Bill runs
     // back on the bill runs page confirm our PRESROC bill run is present and listed as SENT
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
-      cy.get('#main-content > div:nth-child(5) > div > table > tbody > tr:nth-child(1)')
-        .should('contain.text', formattedCurrentDate)
-        .and('contain.text', 'Old charge scheme')
-        .and('contain.text', 'Test Region')
-        .and('contain.text', 'Two-part tariff')
-        .and('contain.text', '£660.24')
-        .and('contain.text', 'Sent')
+      cy.get('[data-test="date-created-0"]').should('contain.text', formattedCurrentDate).and('contain.text', 'Old charge scheme')
     })
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Two-part tariff winter and all year')
+    cy.get('[data-test="number-of-bills-0"]').should('contain.text', '1')
+    cy.get('[data-test="bill-run-status-0"] > .govuk-tag').should('contain.text', 'sent')
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4445

In [Migrate view bill runs page from legacy UI](https://github.com/DEFRA/water-abstraction-system/pull/925) we were able to implement a new version of the bill runs page!

But that means we need to update any tests that interact with it to use the new selectors we have made available.