### PR TITLE
Add new test data loader custom command

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -26,6 +26,20 @@
 
 import 'querystring'
 
+Cypress.Commands.add('load', (body) => {
+  cy.log('Loading test data')
+
+  cy.request({
+    url: '/system/data/load',
+    log: false,
+    method: 'POST',
+    body,
+    timeout: 60000
+  }).then((response) => {
+    return cy.wrap(response.body)
+  })
+})
+
 Cypress.Commands.add('setUp', (testKey) => {
   cy.log(`Setting up ${testKey} test data`)
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3981

The [water-abstraction-service](https://gitub.com/DEFRA/water-abstraction-service) has a mechanism for seeding data for testing that relies on loading in YAML fixture files, sort of. Some content comes from these, but other stuff is hard-coded into the 'loaders'.

This is connected to an endpoint that we currently call to 'setup' test data based on the fixture specified. However, it is slow and prone to failure. It is also horrendous to try and add new 'fixtures' because of its complexity.

So, we have built an alternative [test data loader](https://github.com/DEFRA/water-abstraction-system/pull/1051). This will rely on Cypress fixture files we define in this project.

In this change, we are adding a custom Cypress command we can use to send fixtures we'll create in forthcoming PRs.