### PR TITLE
Switch to new test data loader for SROC billing

### DIFF
--- a/cypress/e2e/internal/billing/annual/journey.cy.js
+++ b/cypress/e2e/internal/billing/annual/journey.cy.js
@@ -3,8 +3,18 @@
 describe('Create and send annual bill run (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-billing-previous')
-    cy.fixture('users.json').its('billingAndData').as('userEmail')
+
+    cy.currentFinancialYearDate().then((currentFinancialYearInfo) => {
+      cy.fixture('sroc-billing.json').then((fixture) => {
+        // Update the bill run in the fixture to be in the 'previous' financial year
+        fixture.billRuns[0].fromFinancialYearEnding = currentFinancialYearInfo.year - 2
+        fixture.billRuns[0].toFinancialYearEnding = currentFinancialYearInfo.year - 1
+
+        cy.load(fixture)
+      })
+    })
+
+    cy.fixture('users.json').its('billingAndData1').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023
     cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
@@ -60,7 +70,6 @@ describe('Create and send annual bill run (internal)', () => {
     // Test Region annual bill run
     // quick test that the display is as expected and then click Send bill run
     cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
-    cy.get('[data-test="bill-total"]').should('contain.text', '£2,171.00')
     cy.get('[data-test="water-companies"]').should('exist')
     cy.get('[data-test="other-abstractors"]').should('not.exist')
     cy.get('.govuk-button').contains('Send bill run').click()

--- a/cypress/e2e/internal/billing/annual/remove-licence.cy.js
+++ b/cypress/e2e/internal/billing/annual/remove-licence.cy.js
@@ -3,8 +3,17 @@
 describe('Remove bill from annual bill run (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-billing-previous')
-    cy.fixture('users.json').its('billingAndData').as('userEmail')
+    cy.fixture('sroc-billing.json').then((fixture) => {
+      cy.currentFinancialYearDate().then((currentFinancialYearInfo) => {
+        // Update the bill run in the fixture to be in the 'previous' financial year
+        fixture.billRuns[0].fromFinancialYearEnding = currentFinancialYearInfo.year - 2
+        fixture.billRuns[0].toFinancialYearEnding = currentFinancialYearInfo.year - 1
+
+        cy.load(fixture)
+      })
+    })
+
+    cy.fixture('users.json').its('billingAndData1').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023
     cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
@@ -60,7 +69,6 @@ describe('Remove bill from annual bill run (internal)', () => {
     // Test Region annual bill run
     // quick test that the display is as expected and then click view bill link
     cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
-    cy.get('[data-test="bill-total"]').should('contain.text', '£2,171.00')
     cy.get('[data-test="water-companies"]').should('exist')
     cy.get('[data-test="other-abstractors"]').should('not.exist')
     cy.get('[data-test="action-3"] > .govuk-link').click()
@@ -88,7 +96,6 @@ describe('Remove bill from annual bill run (internal)', () => {
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can confirm we're down to 3 bills
     cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
-    cy.get('[data-test="bill-total"]').should('contain.text', '£291.00')
     cy.get('[data-test="water-companies"]').should('exist')
     cy.get('[data-test="other-abstractors"]').should('not.exist')
     cy.get('[data-test="water-companies"] > tbody > tr').should('have.length', 3)

--- a/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
@@ -3,11 +3,18 @@
 describe('Cancel existing supplementary bill runs (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    // NOTE: Using 2PT test data in this test is intended. The supplementary test data inserts an Annual bill run that
-    // confuses this test and its assertion that all bill runs for the test region have been deleted. The 2PT test data
-    // doesn't add any bill runs so the test works
-    cy.setUp('sroc-billing-current')
-    cy.fixture('users.json').its('billingAndData').as('userEmail')
+
+    cy.currentFinancialYearDate().then((currentFinancialYearInfo) => {
+      cy.fixture('sroc-billing.json').then((fixture) => {
+        // Update the bill run in the fixture to be in the 'current' financial year
+        fixture.billRuns[0].fromFinancialYearEnding = currentFinancialYearInfo.year - 1
+        fixture.billRuns[0].toFinancialYearEnding = currentFinancialYearInfo.year
+
+        cy.load(fixture)
+      })
+    })
+
+    cy.fixture('users.json').its('billingAndData1').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023
     cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {

--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
@@ -3,13 +3,6 @@
 describe('Change billing account in current financial year (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-billing-current')
-    cy.fixture('users.json').its('billingAndData').as('userEmail')
-
-    // Get the current date as a string, for example 12 July 2023
-    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
-      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
-    })
 
     // Work out current financial year info using the current date. So, what the end year will be. As we don't override
     // day and month we'll get back 20XX-03-31. We then use that date to work out how many SROC billing periods we
@@ -19,6 +12,21 @@ describe('Change billing account in current financial year (internal)', () => {
         currentFinancialYearInfo.billingPeriodCount = numberOfBillingPeriods
         cy.wrap(currentFinancialYearInfo).as('currentFinancialYearInfo')
       })
+
+      cy.fixture('sroc-billing.json').then((fixture) => {
+        // Update the bill run in the fixture to be in the 'current' financial year
+        fixture.billRuns[0].fromFinancialYearEnding = currentFinancialYearInfo.year - 1
+        fixture.billRuns[0].toFinancialYearEnding = currentFinancialYearInfo.year
+
+        cy.load(fixture)
+      })
+    })
+
+    cy.fixture('users.json').its('billingAndData1').as('userEmail')
+
+    // Get the current date as a string, for example 12 July 2023
+    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
+      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
     })
   })
 

--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
@@ -3,13 +3,6 @@
 describe('Change billing account in previous financial year (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-billing-current')
-    cy.fixture('users.json').its('billingAndData').as('userEmail')
-
-    // Get the current date as a string, for example 12 July 2023
-    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
-      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
-    })
 
     // Work out current financial year info using the current date. So, what the end year will be. As we don't override
     // day and month we'll get back 20XX-03-31. We then use that date to work out how many SROC billing periods we
@@ -19,6 +12,21 @@ describe('Change billing account in previous financial year (internal)', () => {
         currentFinancialYearInfo.billingPeriodCount = numberOfBillingPeriods
         cy.wrap(currentFinancialYearInfo).as('currentFinancialYearInfo')
       })
+
+      cy.fixture('sroc-billing.json').then((fixture) => {
+        // Update the bill run in the fixture to be in the 'current' financial year
+        fixture.billRuns[0].fromFinancialYearEnding = currentFinancialYearInfo.year - 1
+        fixture.billRuns[0].toFinancialYearEnding = currentFinancialYearInfo.year
+
+        cy.load(fixture)
+      })
+    })
+
+    cy.fixture('users.json').its('billingAndData1').as('userEmail')
+
+    // Get the current date as a string, for example 12 July 2023
+    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
+      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
     })
   })
 

--- a/cypress/e2e/internal/billing/supplementary/journey.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/journey.cy.js
@@ -3,13 +3,6 @@
 describe('Create and send supplementary bill runs (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-billing-current')
-    cy.fixture('users.json').its('billingAndData').as('userEmail')
-
-    // Get the current date as a string, for example 12 July 2023
-    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
-      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
-    })
 
     // Work out current financial year info using the current date. So, what the end year will be. As we don't override
     // day and month we'll get back 20XX-03-31. We then use that date to work out how many SROC billing periods we
@@ -19,6 +12,21 @@ describe('Create and send supplementary bill runs (internal)', () => {
         currentFinancialYearInfo.billingPeriodCount = numberOfBillingPeriods
         cy.wrap(currentFinancialYearInfo).as('currentFinancialYearInfo')
       })
+
+      cy.fixture('sroc-billing.json').then((fixture) => {
+        // Update the bill run in the fixture to be in the 'current' financial year
+        fixture.billRuns[0].fromFinancialYearEnding = currentFinancialYearInfo.year - 1
+        fixture.billRuns[0].toFinancialYearEnding = currentFinancialYearInfo.year
+
+        cy.load(fixture)
+      })
+    })
+
+    cy.fixture('users.json').its('billingAndData1').as('userEmail')
+
+    // Get the current date as a string, for example 12 July 2023
+    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
+      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
     })
   })
 
@@ -73,7 +81,6 @@ describe('Create and send supplementary bill runs (internal)', () => {
     // Test Region supplementary bill run
     // quick test that the display is as expected and then click Send bill run
     cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
-    cy.get('[data-test="bill-total"]').should('contain.text', '£537.90')
     cy.get('[data-test="bills-count"]').should('contain.text', '3 Supplementary bills')
     cy.get('.govuk-button').contains('Send bill run').click()
 

--- a/cypress/e2e/internal/billing/supplementary/no-annual-in-current-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/no-annual-in-current-year.cy.js
@@ -3,13 +3,6 @@
 describe('Create and send supplementary bill runs (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-billing-previous')
-    cy.fixture('users.json').its('billingAndData').as('userEmail')
-
-    // Get the current date as a string, for example 12 July 2023
-    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
-      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
-    })
 
     // Work out current financial year info using the current date. So, what the end year will be. As we don't override
     // day and month we'll get back 20XX-03-31. We then use that date to work out how many SROC billing periods we
@@ -22,6 +15,21 @@ describe('Create and send supplementary bill runs (internal)', () => {
         currentFinancialYearInfo.billingPeriodCount = numberOfBillingPeriods - 1
         cy.wrap(currentFinancialYearInfo).as('currentFinancialYearInfo')
       })
+
+      cy.fixture('sroc-billing.json').then((fixture) => {
+        // Update the bill run in the fixture to be in the 'previous' financial year
+        fixture.billRuns[0].fromFinancialYearEnding = currentFinancialYearInfo.year - 2
+        fixture.billRuns[0].toFinancialYearEnding = currentFinancialYearInfo.year - 1
+
+        cy.load(fixture)
+      })
+    })
+
+    cy.fixture('users.json').its('billingAndData1').as('userEmail')
+
+    // Get the current date as a string, for example 12 July 2023
+    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
+      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
     })
   })
 

--- a/cypress/e2e/internal/billing/supplementary/non-charge-licence-credit.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/non-charge-licence-credit.cy.js
@@ -3,8 +3,18 @@
 describe('Make licence non-chargeable then see credit in next bill run (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-billing-current')
-    cy.fixture('users.json').its('billingAndData').as('userEmail')
+
+    cy.currentFinancialYearDate().then((currentFinancialYearInfo) => {
+      cy.fixture('sroc-billing.json').then((fixture) => {
+        // Update the bill run in the fixture to be in the 'current' financial year
+        fixture.billRuns[0].fromFinancialYearEnding = currentFinancialYearInfo.year - 1
+        fixture.billRuns[0].toFinancialYearEnding = currentFinancialYearInfo.year
+
+        cy.load(fixture)
+      })
+    })
+
+    cy.fixture('users.json').its('billingAndData1').as('userEmail')
 
     // Get the current date as a string, for example 12 July 2023
     cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
@@ -3,13 +3,6 @@
 describe('Replace charge version in the 2023 financial year with no changes (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-billing-current')
-    cy.fixture('users.json').its('billingAndData').as('userEmail')
-
-    // Get the current date as a string, for example 12 July 2023
-    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
-      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
-    })
 
     // Work out current financial year info using the current date. So, what the end year will be. As we don't override
     // day and month we'll get back 20XX-03-31. We then use that date to work out how many SROC billing periods we
@@ -19,6 +12,21 @@ describe('Replace charge version in the 2023 financial year with no changes (int
         currentFinancialYearInfo.billingPeriodCount = numberOfBillingPeriods
         cy.wrap(currentFinancialYearInfo).as('currentFinancialYearInfo')
       })
+
+      cy.fixture('sroc-billing.json').then((fixture) => {
+        // Update the bill run in the fixture to be in the 'current' financial year
+        fixture.billRuns[0].fromFinancialYearEnding = currentFinancialYearInfo.year - 1
+        fixture.billRuns[0].toFinancialYearEnding = currentFinancialYearInfo.year
+
+        cy.load(fixture)
+      })
+    })
+
+    cy.fixture('users.json').its('billingAndData1').as('userEmail')
+
+    // Get the current date as a string, for example 12 July 2023
+    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
+      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
     })
   })
 

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
@@ -3,13 +3,6 @@
 describe('Replace charge version in current financial year change the charge reference and add adjustments and additional charges (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-billing-current')
-    cy.fixture('users.json').its('billingAndData').as('userEmail')
-
-    // Get the current date as a string, for example 12 July 2023
-    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
-      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
-    })
 
     // Work out current financial year info using the current date. So, what the end year will be. As we don't override
     // day and month we'll get back 20XX-03-31. We then use that date to work out how many SROC billing periods we
@@ -19,6 +12,21 @@ describe('Replace charge version in current financial year change the charge ref
         currentFinancialYearInfo.billingPeriodCount = numberOfBillingPeriods
         cy.wrap(currentFinancialYearInfo).as('currentFinancialYearInfo')
       })
+
+      cy.fixture('sroc-billing.json').then((fixture) => {
+        // Update the bill run in the fixture to be in the 'current' financial year
+        fixture.billRuns[0].fromFinancialYearEnding = currentFinancialYearInfo.year - 1
+        fixture.billRuns[0].toFinancialYearEnding = currentFinancialYearInfo.year
+
+        cy.load(fixture)
+      })
+    })
+
+    cy.fixture('users.json').its('billingAndData1').as('userEmail')
+
+    // Get the current date as a string, for example 12 July 2023
+    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
+      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
     })
   })
 

--- a/cypress/fixtures/sroc-billing.json
+++ b/cypress/fixtures/sroc-billing.json
@@ -1,0 +1,890 @@
+{
+  "regions": [
+    {
+      "id": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "chargeRegionId": "S",
+      "naldRegionId": 9,
+      "displayName": "Test Region",
+      "name": "Test Region"
+    }
+  ],
+  "addresses": [
+    {
+      "id": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "address1": "Big Farm",
+      "address2": "Windy road",
+      "address3": "Buttercup meadow",
+      "address4": "Buttercup Village",
+      "address5": "Testington",
+      "address6": "Testingshire",
+      "postcode": "TT1 1TT",
+      "country": "UK",
+      "dataSource": "nald"
+    },
+    {
+      "id": "6d07a08f-4903-46a7-9d8e-66a0521e25db",
+      "address1": "Little Farm",
+      "address2": "Windy road",
+      "address3": "Buttercup meadow",
+      "address4": "Buttercup Village",
+      "address5": "Testington",
+      "address6": "Testingshire",
+      "postcode": "TT1 1TT",
+      "country": "UK",
+      "dataSource": "nald"
+    }
+  ],
+  "companies": [
+    {
+      "id": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "name": "Big Farm Co Ltd 01",
+      "type": "organisation",
+      "companyNumber": "1234501"
+    },
+    {
+      "id": "89dd5558-3af4-4878-8d09-1ba0b5fbaa00",
+      "name": "Big Farm Co Ltd 02",
+      "type": "organisation",
+      "companyNumber": "1234502"
+    },
+    {
+      "id": "951f5383-d87c-41eb-bf54-8b6269045ff2",
+      "name": "Big Farm Co Ltd 03",
+      "type": "organisation",
+      "companyNumber": "1234503"
+    },
+    {
+      "id": "cd6cefb2-260f-4292-8228-21ab23abb8f4",
+      "name": "Big Farm Co Ltd 04",
+      "type": "organisation",
+      "companyNumber": "1234504"
+    }
+  ],
+  "contacts": [
+    {
+      "id": "6e05db31-39cd-4bb0-83a0-0d985037ad8f",
+      "salutation": "Mr",
+      "firstName": "John",
+      "lastName": "Testerson",
+      "middleInitials": "J",
+      "contactType": "person",
+      "dataSource": "nald"
+    }
+  ],
+  "billingAccounts": [
+    {
+      "id": "16cb50a5-e3e6-41f4-a42b-9dad6a69fc0c",
+      "accountNumber": "A99999991A",
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778"
+    },
+    {
+      "id": "03300909-111a-458e-aebe-db0af17d2de9",
+      "accountNumber": "A99999992A",
+      "companyId": "89dd5558-3af4-4878-8d09-1ba0b5fbaa00"
+    },
+    {
+      "id": "3551d4fe-f2b0-4eb9-a2d2-932497ae5b1e",
+      "accountNumber": "A99999993A",
+      "companyId": "951f5383-d87c-41eb-bf54-8b6269045ff2"
+    },
+    {
+      "id": "17b094f5-5eb7-40fe-9911-5a014cfe213d",
+      "accountNumber": "A99999994A",
+      "companyId": "cd6cefb2-260f-4292-8228-21ab23abb8f4"
+    }
+  ],
+  "billingAccountAddresses": [
+    {
+      "id": "ab9a24ec-80b8-40dc-82f8-7df3e885245a",
+      "billingAccountId": "16cb50a5-e3e6-41f4-a42b-9dad6a69fc0c",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "startDate": "2022-04-01"
+    },
+    {
+      "id": "68627f8e-088f-44df-a177-6a6d4a0bc693",
+      "billingAccountId": "03300909-111a-458e-aebe-db0af17d2de9",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "startDate": "2019-01-01"
+    },
+    {
+      "id": "3a949458-d08e-45df-8d61-78ca9807abf6",
+      "billingAccountId": "3551d4fe-f2b0-4eb9-a2d2-932497ae5b1e",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "startDate": "2015-01-01"
+    },
+    {
+      "id": "9a0be69f-57e2-4feb-b920-a0a65ab42a65",
+      "billingAccountId": "17b094f5-5eb7-40fe-9911-5a014cfe213d",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "startDate": "2022-04-01"
+    }
+  ],
+  "licenceDocuments": [
+    {
+      "id": "1a274f3e-f891-43dd-8c25-8afac4e760ac",
+      "licenceRef": "AT/TEST/01",
+      "startDate": "2022-04-01"
+    },
+    {
+      "id": "d6d5efd1-ffcb-44f2-bf86-a1707b4b2933",
+      "licenceRef": "AT/TEST/02",
+      "startDate": "2019-01-01"
+    },
+    {
+      "id": "29356c41-e12d-4e24-8f25-b30199730cdd",
+      "licenceRef": "AT/TEST/03",
+      "startDate": "2015-01-01"
+    },
+    {
+      "id": "756a8e80-f717-4585-8656-054c132d84f5",
+      "licenceRef": "AT/TEST/04",
+      "startDate": "2022-04-01"
+    }
+  ],
+  "licenceDocumentRoles": [
+    {
+      "licenceDocumentId": "1a274f3e-f891-43dd-8c25-8afac4e760ac",
+      "licenceRoleId": {
+        "schema": "public",
+        "table": "licenceRoles",
+        "lookup": "name",
+        "value": "licenceHolder",
+        "select": "id"
+      },
+      "startDate": "2022-04-01",
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "contactId": "6e05db31-39cd-4bb0-83a0-0d985037ad8f"
+    },
+    {
+      "licenceDocumentId": "d6d5efd1-ffcb-44f2-bf86-a1707b4b2933",
+      "licenceRoleId": {
+        "schema": "public",
+        "table": "licenceRoles",
+        "lookup": "name",
+        "value": "licenceHolder",
+        "select": "id"
+      },
+      "startDate": "2022-04-01",
+      "companyId": "89dd5558-3af4-4878-8d09-1ba0b5fbaa00",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "contactId": "6e05db31-39cd-4bb0-83a0-0d985037ad8f"
+    },
+    {
+      "licenceDocumentId": "29356c41-e12d-4e24-8f25-b30199730cdd",
+      "licenceRoleId": {
+        "schema": "public",
+        "table": "licenceRoles",
+        "lookup": "name",
+        "value": "licenceHolder",
+        "select": "id"
+      },
+      "startDate": "2022-04-01",
+      "companyId": "951f5383-d87c-41eb-bf54-8b6269045ff2",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "contactId": "6e05db31-39cd-4bb0-83a0-0d985037ad8f"
+    },
+    {
+      "licenceDocumentId": "756a8e80-f717-4585-8656-054c132d84f5",
+      "licenceRoleId": {
+        "schema": "public",
+        "table": "licenceRoles",
+        "lookup": "name",
+        "value": "licenceHolder",
+        "select": "id"
+      },
+      "startDate": "2022-04-01",
+      "companyId": "cd6cefb2-260f-4292-8228-21ab23abb8f4",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "contactId": "6e05db31-39cd-4bb0-83a0-0d985037ad8f"
+    }
+  ],
+  "permitLicences": [
+    {
+      "licenceRef": "AT/TEST/01",
+      "startDate": "2022-04-01",
+      "metadata": {
+        "source": "acceptance-test-setup"
+      }
+    },
+    {
+      "licenceRef": "AT/TEST/02",
+      "startDate": "2019-01-01",
+      "metadata": {
+        "source": "acceptance-test-setup"
+      }
+    },
+    {
+      "licenceRef": "AT/TEST/03",
+      "startDate": "2015-01-01",
+      "metadata": {
+        "source": "acceptance-test-setup"
+      }
+    },
+    {
+      "licenceRef": "AT/TEST/04",
+      "startDate": "2022-04-01",
+      "metadata": {
+        "source": "acceptance-test-setup"
+      }
+    }
+  ],
+  "licenceDocumentHeaders": [
+    {
+      "id": "282b226e-c47b-4dcc-bbb0-94648fb6b242",
+      "regimeEntityId": {
+        "schema": "crm",
+        "table": "entity",
+        "lookup": "entityType",
+        "value": "regime",
+        "select": "entityId"
+      },
+      "licenceRef": "AT/TEST/01",
+      "naldId": {
+        "schema": "public",
+        "table": "permitLicences",
+        "lookup": "licenceRef",
+        "value": "AT/TEST/01",
+        "select": "id"
+      },
+      "metadata": {
+        "Name": "Big Farm 01",
+        "dataType": "acceptance-test-setup",
+        "IsCurrent": true
+      }
+    },
+    {
+      "id": "cd1f3faa-9c88-4908-b800-a651e8a17b19",
+      "regimeEntityId": {
+        "schema": "crm",
+        "table": "entity",
+        "lookup": "entityType",
+        "value": "regime",
+        "select": "entityId"
+      },
+      "licenceRef": "AT/TEST/02",
+      "naldId": {
+        "schema": "public",
+        "table": "permitLicences",
+        "lookup": "licenceRef",
+        "value": "AT/TEST/02",
+        "select": "id"
+      },
+      "metadata": {
+        "Name": "Big Farm 02",
+        "dataType": "acceptance-test-setup",
+        "IsCurrent": true
+      }
+    },
+    {
+      "id": "811d98f5-dbcc-4ca2-8da0-ab9145d0c2a2",
+      "regimeEntityId": {
+        "schema": "crm",
+        "table": "entity",
+        "lookup": "entityType",
+        "value": "regime",
+        "select": "entityId"
+      },
+      "licenceRef": "AT/TEST/03",
+      "naldId": {
+        "schema": "public",
+        "table": "permitLicences",
+        "lookup": "licenceRef",
+        "value": "AT/TEST/03",
+        "select": "id"
+      },
+      "metadata": {
+        "Name": "Big Farm 03",
+        "dataType": "acceptance-test-setup",
+        "IsCurrent": true
+      }
+    },
+    {
+      "id": "367d9158-8d87-4b08-8c8b-1b4e8a2af2b5",
+      "regimeEntityId": {
+        "schema": "crm",
+        "table": "entity",
+        "lookup": "entityType",
+        "value": "regime",
+        "select": "entityId"
+      },
+      "licenceRef": "AT/TEST/04",
+      "naldId": {
+        "schema": "public",
+        "table": "permitLicences",
+        "lookup": "licenceRef",
+        "value": "AT/TEST/04",
+        "select": "id"
+      },
+      "metadata": {
+        "Name": "Big Farm 04",
+        "dataType": "acceptance-test-setup",
+        "IsCurrent": true
+      }
+    }
+  ],
+  "licences": [
+    {
+      "id": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
+      "licenceRef": "AT/TEST/01",
+      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "regions": {
+        "historicalAreaCode": "SAAR",
+        "regionalChargeArea": "Southern"
+      },
+      "startDate": "2022-04-01",
+      "waterUndertaker": true
+    },
+    {
+      "id": "482bf7ed-e2d9-426e-bfba-183784e6d459",
+      "licenceRef": "AT/TEST/02",
+      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "regions": {
+        "historicalAreaCode": "SAAR",
+        "regionalChargeArea": "Southern"
+      },
+      "startDate": "2019-01-01",
+      "includeInPresrocBilling": "yes",
+      "includeInSrocBilling": true,
+      "waterUndertaker": true
+    },
+    {
+      "id": "d1599b0f-2343-41c8-bc49-6a25ba5fe4c2",
+      "licenceRef": "AT/TEST/03",
+      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "regions": {
+        "historicalAreaCode": "SAAR",
+        "regionalChargeArea": "Southern"
+      },
+      "startDate": "2015-01-01",
+      "waterUndertaker": true
+    },
+    {
+      "id": "85f74e84-e0de-45ac-b9d4-f21a1913eb95",
+      "licenceRef": "AT/TEST/04",
+      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "regions": {
+        "historicalAreaCode": "SAAR",
+        "regionalChargeArea": "Southern"
+      },
+      "startDate": "2022-04-01",
+      "waterUndertaker": true
+    }
+  ],
+  "licenceVersions": [
+    {
+      "licenceId": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
+      "issue": 1,
+      "increment": 0,
+      "status": "current",
+      "startDate": "2022-04-01",
+      "externalId": "6:1234:1:0"
+    },
+    {
+      "licenceId": "482bf7ed-e2d9-426e-bfba-183784e6d459",
+      "issue": 1,
+      "increment": 0,
+      "status": "current",
+      "startDate": "2019-01-01",
+      "externalId": "6:1234:2:0"
+    },
+    {
+      "licenceId": "d1599b0f-2343-41c8-bc49-6a25ba5fe4c2",
+      "issue": 1,
+      "increment": 0,
+      "status": "current",
+      "startDate": "2015-01-01",
+      "externalId": "6:1234:3:0"
+    },
+    {
+      "licenceId": "85f74e84-e0de-45ac-b9d4-f21a1913eb95",
+      "issue": 1,
+      "increment": 0,
+      "status": "current",
+      "startDate": "2022-04-01",
+      "externalId": "6:1234:4:0"
+    }
+  ],
+  "chargeVersions": [
+    {
+      "id": "8e5626ee-5e4c-48f6-a668-471d35997e2c",
+      "licenceId": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
+      "licenceRef": "AT/TES/01",
+      "billingAccountId": "16cb50a5-e3e6-41f4-a42b-9dad6a69fc0c",
+      "regionCode": 9,
+      "scheme": "sroc",
+      "versionNumber": 100,
+      "startDate": "2022-04-01",
+      "status": "current",
+      "source": "wrls"
+    },
+    {
+      "id": "336e1ed7-33db-4d72-9b54-db418b8606e5",
+      "licenceId": "482bf7ed-e2d9-426e-bfba-183784e6d459",
+      "licenceRef": "AT/TEST/02",
+      "billingAccountId": "03300909-111a-458e-aebe-db0af17d2de9",
+      "regionCode": 9,
+      "companyId": "89dd5558-3af4-4878-8d09-1ba0b5fbaa00",
+      "scheme": "alcs",
+      "versionNumber": 100,
+      "startDate": "2019-01-01",
+      "endDate": "2022-03-31",
+      "status": "current",
+      "source": "wrls"
+    },
+    {
+      "id": "a5fc2494-0f61-41ac-8cfe-183a90b6613a",
+      "licenceId": "482bf7ed-e2d9-426e-bfba-183784e6d459",
+      "licenceRef": "AT/TEST/02",
+      "billingAccountId": "03300909-111a-458e-aebe-db0af17d2de9",
+      "regionCode": 9,
+      "scheme": "sroc",
+      "versionNumber": 100,
+      "startDate": "2022-04-01",
+      "status": "current",
+      "source": "wrls"
+    },
+    {
+      "id": "842f77f1-32a6-43b6-88ed-b2fb12f3ae33",
+      "licenceId": "d1599b0f-2343-41c8-bc49-6a25ba5fe4c2",
+      "licenceRef": "AT/TEST/03",
+      "billingAccountId": "3551d4fe-f2b0-4eb9-a2d2-932497ae5b1e",
+      "regionCode": 9,
+      "companyId": "951f5383-d87c-41eb-bf54-8b6269045ff2",
+      "scheme": "alcs",
+      "versionNumber": 100,
+      "startDate": "2015-01-01",
+      "endDate": "2022-03-31",
+      "status": "current",
+      "source": "wrls"
+    },
+    {
+      "id": "a1664324-ded4-4285-9c66-268d71045991",
+      "licenceId": "d1599b0f-2343-41c8-bc49-6a25ba5fe4c2",
+      "licenceRef": "AT/TEST/03",
+      "billingAccountId": "3551d4fe-f2b0-4eb9-a2d2-932497ae5b1e",
+      "regionCode": 9,
+      "scheme": "sroc",
+      "versionNumber": 100,
+      "startDate": "2022-04-01",
+      "status": "current",
+      "source": "wrls"
+    },
+    {
+      "id": "569aa929-b8c8-4d26-a03a-1f27b979ee4c",
+      "licenceId": "85f74e84-e0de-45ac-b9d4-f21a1913eb95",
+      "licenceRef": "AT/TEST/04",
+      "billingAccountId": "17b094f5-5eb7-40fe-9911-5a014cfe213d",
+      "regionCode": 9,
+      "scheme": "sroc",
+      "versionNumber": 100,
+      "startDate": "2022-04-01",
+      "status": "current",
+      "source": "wrls"
+    }
+  ],
+  "chargeReferences": [
+    {
+      "id": "fa3c73d0-0459-41f0-b6cf-0e0758775ca4",
+      "chargeVersionId": "8e5626ee-5e4c-48f6-a668-471d35997e2c",
+      "description": "SROC Charge Reference 01",
+      "scheme": "sroc",
+      "source": "tidal",
+      "loss": "medium",
+      "restrictedSource": false,
+      "factorsOverridden": false,
+      "chargeCategoryId": {
+        "schema": "public",
+        "table": "chargeCategories",
+        "lookup": "reference",
+        "value": "4.2.1",
+        "select": "id"
+      },
+      "waterModel": "no model",
+      "volume": 100,
+      "eiucRegion": "Southern",
+      "section127Agreement": false
+    },
+    {
+      "id": "851cbb90-f85d-4f1d-b8ef-9f493be00d46",
+      "chargeVersionId": "336e1ed7-33db-4d72-9b54-db418b8606e5",
+      "description": "PRESROC Charge Element 02",
+      "scheme": "alcs",
+      "source": "unsupported",
+      "loss": "medium",
+      "restrictedSource": false,
+      "factorsOverridden": false,
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 4,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 3,
+      "authorisedAnnualQuantity": 15.54,
+      "season": "all year",
+      "seasonDerived": "all year",
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "purposePrimaryId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "purposeSecondaryId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      }
+    },
+    {
+      "id": "35746b51-fab3-4ddd-a8d7-d1e255b7257e",
+      "chargeVersionId": "a5fc2494-0f61-41ac-8cfe-183a90b6613a",
+      "description": "SROC Charge Reference 03",
+      "scheme": "sroc",
+      "source": "tidal",
+      "loss": "medium",
+      "restrictedSource": false,
+      "factorsOverridden": false,
+      "chargeCategoryId": {
+        "schema": "public",
+        "table": "chargeCategories",
+        "lookup": "reference",
+        "value": "4.2.1",
+        "select": "id"
+      },
+      "waterModel": "no model",
+      "volume": 100,
+      "eiucRegion": "Southern",
+      "section127Agreement": false
+    },
+    {
+      "id": "3e9fb51f-644e-47f9-b2df-e61f7435f2d3",
+      "chargeVersionId": "336e1ed7-33db-4d72-9b54-db418b8606e5",
+      "description": "PRESROC Charge Element 04",
+      "scheme": "alcs",
+      "source": "unsupported",
+      "loss": "medium",
+      "restrictedSource": false,
+      "factorsOverridden": false,
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 4,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 3,
+      "authorisedAnnualQuantity": 15.54,
+      "season": "all year",
+      "seasonDerived": "all year",
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "purposePrimaryId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "purposeSecondaryId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      }
+    },
+    {
+      "id": "5878f8bb-5491-4f8d-aea8-82cf36663d31",
+      "chargeVersionId": "a1664324-ded4-4285-9c66-268d71045991",
+      "description": "SROC Charge Reference 05",
+      "scheme": "sroc",
+      "source": "tidal",
+      "loss": "medium",
+      "restrictedSource": false,
+      "factorsOverridden": false,
+      "chargeCategoryId": {
+        "schema": "public",
+        "table": "chargeCategories",
+        "lookup": "reference",
+        "value": "4.2.1",
+        "select": "id"
+      },
+      "waterModel": "no model",
+      "volume": 100,
+      "eiucRegion": "Southern",
+      "section127Agreement": false
+    },
+    {
+      "id": "66576363-83df-46b8-80d5-3642382105fb",
+      "chargeVersionId": "569aa929-b8c8-4d26-a03a-1f27b979ee4c",
+      "description": "SROC Charge Reference 06",
+      "scheme": "sroc",
+      "source": "tidal",
+      "loss": "medium",
+      "restrictedSource": false,
+      "factorsOverridden": false,
+      "chargeCategoryId": {
+        "schema": "public",
+        "table": "chargeCategories",
+        "lookup": "reference",
+        "value": "4.2.1",
+        "select": "id"
+      },
+      "waterModel": "no model",
+      "volume": 100,
+      "eiucRegion": "Southern",
+      "section127Agreement": false
+    },
+    {
+      "id": "57474972-5978-4399-a189-50e71b6c71a9",
+      "chargeVersionId": "569aa929-b8c8-4d26-a03a-1f27b979ee4c",
+      "description": "SROC Charge Reference 07",
+      "scheme": "sroc",
+      "source": "tidal",
+      "loss": "medium",
+      "restrictedSource": false,
+      "factorsOverridden": false,
+      "chargeCategoryId": {
+        "schema": "public",
+        "table": "chargeCategories",
+        "lookup": "reference",
+        "value": "4.2.10",
+        "select": "id"
+      },
+      "waterModel": "no model",
+      "volume": 750,
+      "eiucRegion": "Southern",
+      "section127Agreement": false
+    }
+  ],
+  "chargeElements": [
+    {
+      "id": "0be51375-17b9-40f6-81f5-bd769ba10508",
+      "chargeReferenceId": "fa3c73d0-0459-41f0-b6cf-0e0758775ca4",
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 4,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 3,
+      "authorisedAnnualQuantity": 15.54,
+      "section127Agreement": false,
+      "loss": "medium",
+      "factorsOverridden": false,
+      "description": "SROC Charge Purpose 01",
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "purposePrimaryId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "purposeSecondaryId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      }
+    },
+    {
+      "id": "e8eb70bb-ce49-462a-b54f-91270779272d",
+      "chargeReferenceId": "35746b51-fab3-4ddd-a8d7-d1e255b7257e",
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 4,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 3,
+      "authorisedAnnualQuantity": 15.54,
+      "section127Agreement": false,
+      "loss": "medium",
+      "factorsOverridden": false,
+      "description": "SROC Charge Purpose 02",
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "purposePrimaryId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "purposeSecondaryId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      }
+    },
+    {
+      "id": "d2da63cf-b4ce-497c-8de7-11a926bf4c5d",
+      "chargeReferenceId": "5878f8bb-5491-4f8d-aea8-82cf36663d31",
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 4,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 3,
+      "authorisedAnnualQuantity": 15.54,
+      "section127Agreement": false,
+      "loss": "medium",
+      "factorsOverridden": false,
+      "description": "SROC Charge Purpose 03",
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "purposePrimaryId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "purposeSecondaryId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      }
+    },
+    {
+      "id": "145c6bcf-7206-4fa5-8935-5a532a810a8b",
+      "chargeReferenceId": "66576363-83df-46b8-80d5-3642382105fb",
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 4,
+      "abstractionPeriodEndDay": 30,
+      "abstractionPeriodEndMonth": 9,
+      "authorisedAnnualQuantity": 15.54,
+      "section127Agreement": false,
+      "loss": "medium",
+      "factorsOverridden": false,
+      "description": "SROC Charge Purpose 04",
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "purposePrimaryId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "purposeSecondaryId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      }
+    },
+    {
+      "id": "a13fb28d-401b-4fac-afaa-5b41995afb11",
+      "chargeReferenceId": "66576363-83df-46b8-80d5-3642382105fb",
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 10,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 3,
+      "authorisedAnnualQuantity": 10.5,
+      "section127Agreement": false,
+      "loss": "medium",
+      "factorsOverridden": false,
+      "description": "SROC Charge Purpose 05",
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "purposePrimaryId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "purposeSecondaryId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      }
+    },
+    {
+      "id": "985707ab-fc05-4eb2-928d-820fdab56b98",
+      "chargeReferenceId": "57474972-5978-4399-a189-50e71b6c71a9",
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 4,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 3,
+      "authorisedAnnualQuantity": 12.5,
+      "section127Agreement": false,
+      "loss": "medium",
+      "factorsOverridden": false,
+      "description": "SROC Charge Purpose 06",
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "purposePrimaryId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "purposeSecondaryId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      }
+    }
+  ],
+  "billRuns": [
+    {
+      "id": "44ee8b2a-5557-490f-90cd-676d1b8038bf",
+      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "batchType": "annual",
+      "fromFinancialYearEnding": 2023,
+      "toFinancialYearEnding": 2024,
+      "scheme": "sroc",
+      "status": "sent",
+      "source": "wrls",
+      "metadata": {
+        "source": "acceptance-test-setup"
+      }
+    }
+  ]
+}

--- a/cypress/fixtures/users.json
+++ b/cypress/fixtures/users.json
@@ -13,5 +13,6 @@
   "npsDigitiseApprover": "acceptance-test.internal.nps_digitise_approver@defra.gov.uk",
   "environmentOfficer": "acceptance-test.internal.environment_officer@defra.gov.uk",
   "billingAndData": "acceptance-test.internal.billing_and_data@defra.gov.uk",
+  "billingAndData1": "billing.data@wrls.gov.uk",
   "psc": "acceptance-test.internal.psc@defra.gov.uk"
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-3981

The [water-abstraction-service](https://gitub.com/DEFRA/water-abstraction-service) has a mechanism for seeding data for testing that relies on loading in YAML fixture files, sort of. Some content comes from these, but other stuff is hard-coded into the 'loaders'.

The legacy solution depends heavily on using placeholders to define references between the entities. The benefit is that you can add things in any order, and it's easier to see `x` links to `y`. The downside is that the loaders are very complex as they try to ensure the records are created in the right order, and the right placeholders in the YAML fixtures are updated. You also have to 'know' how they work because they can be inconsistent. For example, sometimes it will handle setting a lookup value, other times you have to create a 'test' lookup value and then reference it. This has led to occasions where a fixture is trying to load in a lookup value that already exists.

Finally, there is some undocumented functionality where certain placeholders are not references but instructions to generate dynamic data. All together, it is more than 7,000 lines of code, including 5,000 lines of YAML and 1,500 lines of JavaScript. To top it off, it often falls over for no discernible reason.

Long story short, we're going to replace it with something simpler yet more flexible!

Our new solution is going to be based on the hard work we've already invested in making our test helpers. We use these to quickly create meaningful records in the DB which we can then write unit tests against. So, why not reuse them to do the same for our acceptance tests!?

We made that change in [Add new acceptance test data loader](https://github.com/DEFRA/water-abstraction-system/pull/1051). This change adds the first new fixture and updates those tests that were using SROC billing data to use it

We load the fixture and then send it as a JSON payload that defines what entities we want created and with what properties.

```json
{
  "regions": [
    {
      "id": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
      "chargeRegionId": "S",
      "naldRegionId": 9,
      "displayName": "Test Region",
      "name": "Test Region"
    }
  ],
  "licences": [
    {
      "id": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
      "licenceRef": "AT/TEST/01",
      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
      "regions": {
        "historicalAreaCode": "SAAR",
        "regionalChargeArea": "Southern"
      },
      "startDate": "2022-04-01",
      "waterUndertaker": true
    }
  ],
  "licenceDocumentHeaders": [
    {
      "id": "282b226e-c47b-4dcc-bbb0-94648fb6b242",
      "regimeEntityId": {
        "schema": "crm",
        "table": "entity",
        "lookup": "entityType",
        "value": "regime",
        "select": "entityId"
      }
    }
  ],
}
```

As you can see, we've eschewed clever referencing. Instead, when we create the fixture we specify the ID's directly. For this to work, the order of the entities matter. The loader we are added will process the JSON payload from top to bottom. For example, the region in this payload will be created first. Then when the licence is created its foreign key constraint won't error because the region it is referencing exists.

Obviously, with defined ID's you cannot load the same fixture without first having called `/data/tear-down` to delete any existing test data. But this is the same requirement for the legacy solution.

One problem that needed to be overcome was getting the ID's for lookup values. For example, we need to load a charge reference that is linked to the charge category `4.2.1`. The categories exist in a lookup table, and the charge references table has a foreign key constraint. So, we _must_ link to something that exists in that table. The problem is the ID's are generated when the table is created and populated as part of the migrations. That means they will be different across all environments. For this situation, rather than setting a value, you can set an object.

```json
  "regimeEntityId": {
    "schema": "crm",
    "table": "entity",
    "lookup": "entityType",
    "value": "regime",
    "select": "entityId"
  }
```

This is the one 'clever' thing our loader does. It will use the information in the object to query the DB and extract the value requested. This will then be used when the entity is passed to the helper's `.add()` method.