### PR TITLE
Returns required journey acceptance tests

### DIFF
--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -34,5 +34,31 @@ describe('Submit and cancel no returns requirement (internal)', () => {
 
     // confirm we are on the charge information tab
     cy.get('#charge > :nth-child(1)').contains('Charge information')
+
+    // click set up new returns requirement
+    cy.get('[data-test="meta-data-returns-required"]').click()
+
+    // choose the licence version start date and click continue
+    cy.get('#licence-start-date').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the reason page
+    cy.get('.govuk-fieldset__heading').contains('Select the reason for the requirements for returns')
+
+    // choose returns exception and click continue
+    cy.get('#reason-2').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the set up page
+    cy.get('.govuk-fieldset__heading').contains('How do you want to set up the requirements for returns?')
+
+    // click set up manually and continue
+    cy.get('#setup-3').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the purpose page
+    cy.get('.govuk-heading-xl').contains('Select the purpose for the requirements for returns')
+
+    // choose a purpose for the requirement
   })
 })

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -277,5 +277,73 @@ describe('Submit and cancel no returns requirement (internal)', () => {
     // confirm we are back on the check page and see the agreements exceptions changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
     cy.get(':nth-child(8) > .govuk-summary-list__value').contains('requirement.agreementsExceptions')
+
+    // click the add another requirement button
+    cy.get('form > .govuk-button').click()
+
+    // confirm we are on the purpose page
+    cy.get('.govuk-heading-xl').contains('Select the purpose for the requirements for returns')
+
+    // choose a purpose for the requirement and continue
+    cy.get('#purposes').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the points page
+    cy.get('.govuk-heading-xl').contains('Select the points for the requirements for returns')
+
+    // choose a points for the requirement and continue
+    cy.get('#points').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the abstraction period page
+    cy.get('.govuk-heading-xl').contains('Enter the abstraction period for the requirements for returns')
+
+    // enter start and end dates for the abstraction period and click continue
+    cy.get('#abstraction-period-start-day').type('07')
+    cy.get('#abstraction-period-start-month').type('07')
+    cy.get('#abstraction-period-end-day').type('08')
+    cy.get('#abstraction-period-end-month').type('12')
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the returns cycle page
+    cy.get('.govuk-heading-xl').contains('Select the returns cycle for the requirements for returns')
+
+    // choose a returns cycle and continue
+    cy.get('#returnsCycle').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the site description page
+    cy.get('.govuk-label').contains('Enter a site description for the requirements for returns')
+
+    // enter a site description and continue
+    cy.get('#site-description').type('This is a valid site description for the second requirement')
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the readings collected page
+    cy.get('.govuk-heading-xl').contains('Select how often readings or volumes are collected')
+
+    // choose a collected time frame and continue
+    cy.get('#frequencyCollected-3').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the readings reported page
+    cy.get('.govuk-heading-xl').contains('Select how often readings or volumes are reported')
+
+    // choose a reporting time frame and continue
+    cy.get('#frequencyReported').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the agreements and exceptions page
+    cy.get('.govuk-heading-l').contains('Select agreements and exceptions for the requirements for returns')
+
+    // choose a agreement and exception and continue
+    cy.get('#agreementsExceptions').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the check page
+    cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
+
+    // confirm we see the new requirement
+    cy.get(':nth-child(4) > .govuk-summary-card > .govuk-summary-card__title-wrapper').contains('second requirement')
   })
 })

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -154,7 +154,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('[data-test="meta-data-reason"]').contains('New licence')
 
     // confirm we see the purposes selected
-    cy.get('.govuk-summary-card__content').contains('requirement.purposes')
+    cy.get(':nth-child(1) > .govuk-summary-list__value > p').contains('General Farming & Domestic')
 
     // choose the change option for purposes
     cy.get('[data-test="meta-data-change-purpose"]').click()
@@ -166,10 +166,10 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the purpose changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get('.govuk-summary-card__content').contains('requirement.purposes')
+    cy.get(':nth-child(1) > .govuk-summary-list__value > p').contains('Hydroelectric Power Generation')
 
     // confirm we see the points selected
-    cy.get('.govuk-summary-card__content').contains('requirement.points')
+    cy.get('.govuk-summary-card__content').contains('At National Grid Reference TQ 1234 1234 (Test local name 1)')
 
     // choose the change option for points
     cy.get('[data-test="meta-data-change-points"]').click()
@@ -181,7 +181,7 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the points changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get('.govuk-summary-card__content').contains('requirement.points')
+    cy.get('.govuk-summary-card__content').contains('At National Grid Reference TT 5678 5678 (Test local name 2)')
 
     // confirm we see the abstraction period selected
     cy.get(':nth-child(3) > .govuk-summary-list__value').contains('From 1 December to 3 September')
@@ -206,7 +206,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get(':nth-child(3) > .govuk-summary-list__value').contains('From 2 October to 5 December')
 
     // confirm we see the returns cycle selected
-    cy.get(':nth-child(4) > .govuk-summary-list__value').contains('requirement.returnsCycle')
+    cy.get(':nth-child(4) > .govuk-summary-list__value').contains('Summer')
 
     // choose the change option for the returns cycle
     cy.get('[data-test="meta-data-change-returns-cycle"]').click()
@@ -217,7 +217,7 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the returns cycle changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get(':nth-child(4) > .govuk-summary-list__value').contains('requirement.returnsCycle')
+    cy.get(':nth-child(4) > .govuk-summary-list__value').contains('Winter')
 
     // confirm we see the site description we selected
     cy.get(':nth-child(5) > .govuk-summary-list__value').contains('This is a valid site description')
@@ -263,7 +263,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get(':nth-child(7) > .govuk-summary-list__value').contains('Monthly')
 
     // confirm we see the agreements and exceptions we selected
-    cy.get(':nth-child(8) > .govuk-summary-list__value').contains('requirement.agreementsExceptions')
+    cy.get(':nth-child(8) > .govuk-summary-list__value').contains('Gravity fill')
 
     // choose the change option for agreements exceptions
     cy.get('[data-test="meta-data-change-agreements-exceptions"]').click()
@@ -276,7 +276,7 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the agreements exceptions changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get(':nth-child(8) > .govuk-summary-list__value').contains('requirement.agreementsExceptions')
+    cy.get(':nth-child(8) > .govuk-summary-list__value').contains('Transfer re-abstraction scheme and Two-part tariff')
 
     // click the add another requirement button
     cy.get('form > .govuk-button').click()
@@ -346,8 +346,8 @@ describe('Submit returns requirement (internal)', () => {
     // confirm we see the new requirement
     cy.get(':nth-child(4) > .govuk-summary-card > .govuk-summary-card__title-wrapper').contains('second requirement')
 
-    // choose the remove requirement the second requirement
-    cy.get(':nth-child(4) > .govuk-button').click()
+    // choose the remove requirement button for the second requirement
+    cy.get('.govuk-button').eq(2).should('contain', 'Remove requirement').click()
 
     // confirm we are on the remove page
     cy.get('.govuk-heading-xl').contains('You are about to remove these requirements for returns')

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -121,5 +121,43 @@ describe('Submit and cancel no returns requirement (internal)', () => {
 
     // confirm we are on the check page
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
+
+    // confirm we can see the information we have selected and make changes
+    // start date
+    cy.get('#main-content > :nth-child(2)').contains('1 April 2022')
+    cy.get('[data-test="meta-data-change-start-date"]').click()
+
+    // change start date and continue
+    cy.get('#another-start-date').check()
+    cy.get('#other-start-date-day').type('02')
+    cy.get('#other-start-date-month').type('08')
+    cy.get('#other-start-date-year').type('2023')
+    cy.get('.govuk-button').click()
+
+    // confirm we are back on check page and start date changes
+    cy.get('#main-content > :nth-child(2)').contains('2 August 2023')
+
+    // // reason
+    // cy.get('#main-content > :nth-child(2)').contains('Licence holder name or address change')
+
+    // // purposes
+
+    // // points
+
+    // // abstraction period
+    // cy.get(':nth-child(3) > .govuk-summary-list__value').contains('From 1 December to 3 September')
+
+    // // returns cycle
+
+    // // site description
+    // cy.get(':nth-child(5) > .govuk-summary-list__value').contains('This is a valid site description')
+
+    // // collection frequency
+    // cy.get(':nth-child(6) > .govuk-summary-list__value').contains('Daily')
+
+    // // reporting frequency
+    // cy.get(':nth-child(7) > .govuk-summary-list__value').contains('Daily')
+
+    // // agreements and exceptions
   })
 })

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -44,35 +44,35 @@ describe('Submit returns requirement (internal)', () => {
 
     // choose the licence version start date and click continue
     cy.get('#licence-start-date').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are on the reason page
     cy.get('.govuk-fieldset__heading').contains('Select the reason for the requirements for returns')
 
     // choose returns exception and click continue
     cy.get('#reason-2').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are on the set up page
     cy.get('.govuk-fieldset__heading').contains('How do you want to set up the requirements for returns?')
 
     // click set up manually and continue
     cy.get('#setup-4').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are on the purpose page
     cy.get('.govuk-heading-xl').contains('Select the purpose for the requirements for returns')
 
     // choose a purpose for the requirement and continue
     cy.get('#purposes').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are on the points page
     cy.get('.govuk-heading-xl').contains('Select the points for the requirements for returns')
 
     // choose a points for the requirement and continue
     cy.get('#points').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are on the abstraction period page
     cy.get('.govuk-heading-xl').contains('Enter the abstraction period for the requirements for returns')
@@ -82,42 +82,42 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('#abstraction-period-start-month').type('12')
     cy.get('#abstraction-period-end-day').type('03')
     cy.get('#abstraction-period-end-month').type('09')
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are on the returns cycle page
     cy.get('.govuk-heading-xl').contains('Select the returns cycle for the requirements for returns')
 
     // choose a returns cycle and continue
     cy.get('#returnsCycle').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are on the site description page
     cy.get('.govuk-label').contains('Enter a site description for the requirements for returns')
 
     // enter a site description and continue
     cy.get('#site-description').type('This is a valid site description')
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are on the readings collected page
     cy.get('.govuk-heading-xl').contains('Select how often readings or volumes are collected')
 
     // choose a collected time frame and continue
     cy.get('#frequencyCollected').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are on the readings reported page
     cy.get('.govuk-heading-xl').contains('Select how often readings or volumes are reported')
 
     // choose a reporting time frame and continue
     cy.get('#frequencyReported').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are on the agreements and exceptions page
     cy.get('.govuk-heading-l').contains('Select agreements and exceptions for the requirements for returns')
 
     // choose an agreement and exception and continue
     cy.get('#agreementsExceptions').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are on the check page
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
@@ -133,7 +133,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('#other-start-date-day').type('02')
     cy.get('#other-start-date-month').type('08')
     cy.get('#other-start-date-year').type('2023')
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are back on check page and see the start date changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
@@ -147,7 +147,7 @@ describe('Submit returns requirement (internal)', () => {
 
     // change the reason and continue
     cy.get('#reason-8').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the reason changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
@@ -162,7 +162,7 @@ describe('Submit returns requirement (internal)', () => {
     // change the purpose and continue
     cy.get('#purposes').uncheck()
     cy.get('#purposes-2').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the purpose changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
@@ -177,7 +177,7 @@ describe('Submit returns requirement (internal)', () => {
     // change the points and continue
     cy.get('#points').uncheck()
     cy.get('#points-2').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the points changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
@@ -199,7 +199,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('#abstraction-period-start-month').type('10')
     cy.get('#abstraction-period-end-day').type('05')
     cy.get('#abstraction-period-end-month').type('12')
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the abstraction period changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
@@ -213,7 +213,7 @@ describe('Submit returns requirement (internal)', () => {
 
     // change the returns cycle and continue
     cy.get('#returnsCycle-2').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the returns cycle changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
@@ -228,7 +228,7 @@ describe('Submit returns requirement (internal)', () => {
     // change the site description and continue
     cy.get('#site-description').clear()
     cy.get('#site-description').type('This is another valid site description')
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the site description changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
@@ -242,7 +242,7 @@ describe('Submit returns requirement (internal)', () => {
 
     // change the collection frequency and continue
     cy.get('#frequencyCollected-2').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the collection frequency changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
@@ -256,7 +256,7 @@ describe('Submit returns requirement (internal)', () => {
 
     // change the reporting frequency and continue
     cy.get('#frequencyReported-3').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the reporting frequency changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
@@ -272,7 +272,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('#agreementsExceptions').uncheck()
     cy.get('#agreementsExceptions-2').check()
     cy.get('#agreementsExceptions-3').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the agreements exceptions changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
@@ -286,14 +286,14 @@ describe('Submit returns requirement (internal)', () => {
 
     // choose a purpose for the requirement and continue
     cy.get('#purposes').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are on the points page
     cy.get('.govuk-heading-xl').contains('Select the points for the requirements for returns')
 
     // choose a points for the requirement and continue
     cy.get('#points').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are on the abstraction period page
     cy.get('.govuk-heading-xl').contains('Enter the abstraction period for the requirements for returns')
@@ -303,42 +303,42 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('#abstraction-period-start-month').type('07')
     cy.get('#abstraction-period-end-day').type('08')
     cy.get('#abstraction-period-end-month').type('12')
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are on the returns cycle page
     cy.get('.govuk-heading-xl').contains('Select the returns cycle for the requirements for returns')
 
     // choose a returns cycle and continue
     cy.get('#returnsCycle').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are on the site description page
     cy.get('.govuk-label').contains('Enter a site description for the requirements for returns')
 
     // enter a site description and continue
     cy.get('#site-description').type('This is a valid site description for the second requirement')
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are on the readings collected page
     cy.get('.govuk-heading-xl').contains('Select how often readings or volumes are collected')
 
     // choose a collected time frame and continue
     cy.get('#frequencyCollected-3').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are on the readings reported page
     cy.get('.govuk-heading-xl').contains('Select how often readings or volumes are reported')
 
     // choose a reporting time frame and continue
     cy.get('#frequencyReported').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are on the agreements and exceptions page
     cy.get('.govuk-heading-l').contains('Select agreements and exceptions for the requirements for returns')
 
     // choose a agreement and exception and continue
     cy.get('#agreementsExceptions').check()
-    cy.get('.govuk-button').click()
+    cy.contains('Continue').click()
 
     // confirm we are on the check page
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
@@ -356,7 +356,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('div.govuk-body > .govuk-body').contains('Summer daily requirements for returns, This is a valid site description for the second requirement.')
 
     // choose the remove button
-    cy.get('.govuk-button').click()
+    cy.contains('Remove').click()
 
     // confirm we are on the check page
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -123,10 +123,10 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
 
     // confirm we see the start date information we expect
-    cy.get('[data-test="meta-data-start-date"]').contains('1 April 2022')
+    cy.get('[data-test="start-date"]').contains('1 April 2022')
 
     // choose the change option for the start date
-    cy.get('[data-test="meta-data-change-start-date"]').click()
+    cy.get('[data-test="change-start-date"]').click()
 
     // change start date and continue
     cy.get('#another-start-date').check()
@@ -137,13 +137,13 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on check page and see the start date changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get('[data-test="meta-data-start-date"]').contains('2 August 2023')
+    cy.get('[data-test="start-date"]').contains('2 August 2023')
 
     // confirm we see the reason we selected
-    cy.get('[data-test="meta-data-reason"]').contains('Licence holder name or address change')
+    cy.get('[data-test="reason"]').contains('Licence holder name or address change')
 
     // choose the change option for reason
-    cy.get('[data-test="meta-data-change-reason"]').click()
+    cy.get('[data-test="change-reason"]').click()
 
     // change the reason and continue
     cy.get('#reason-8').check()
@@ -151,13 +151,13 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the reason changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get('[data-test="meta-data-reason"]').contains('New licence')
+    cy.get('[data-test="reason"]').contains('New licence')
 
     // confirm we see the purposes selected
-    cy.get('[data-test="meta-data-purposes-0"]').should('contain', 'General Farming & Domestic')
+    cy.get('[data-test="purposes-0"]').should('contain', 'General Farming & Domestic')
 
     // choose the change option for purposes
-    cy.get('[data-test="meta-data-change-purposes-0"]').click()
+    cy.get('[data-test="change-purposes-0"]').click()
 
     // change the purpose and continue
     cy.get('#purposes').uncheck()
@@ -166,13 +166,13 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the purpose changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get('[data-test="meta-data-purposes-0"]').contains('Hydroelectric Power Generation')
+    cy.get('[data-test="purposes-0"]').contains('Hydroelectric Power Generation')
 
     // confirm we see the points selected
-    cy.get('[data-test="meta-data-points-0"]').should('contain', 'At National Grid Reference TQ 1234 1234 (Test local name 1)')
+    cy.get('[data-test="points-0"]').should('contain', 'At National Grid Reference TQ 1234 1234 (Test local name 1)')
 
     // choose the change option for points
-    cy.get('[data-test="meta-data-change-points-0"]').click()
+    cy.get('[data-test="change-points-0"]').click()
 
     // change the points and continue
     cy.get('#points').uncheck()
@@ -181,13 +181,13 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the points changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get('[data-test="meta-data-points-0"]').contains('At National Grid Reference TT 5678 5678 (Test local name 2)')
+    cy.get('[data-test="points-0"]').contains('At National Grid Reference TT 5678 5678 (Test local name 2)')
 
     // confirm we see the abstraction period selected
-    cy.get('[data-test="meta-data-abstraction-period-0"]').contains('From 1 December to 3 September')
+    cy.get('[data-test="abstraction-period-0"]').contains('From 1 December to 3 September')
 
     // choose the change option for the abstraction period
-    cy.get('[data-test="meta-data-change-abstraction-period-0"]').click()
+    cy.get('[data-test="change-abstraction-period-0"]').click()
 
     // change the abstraction period and continue
     cy.get('#abstraction-period-start-day').clear()
@@ -203,13 +203,13 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the abstraction period changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get('[data-test="meta-data-abstraction-period-0"]').contains('From 2 October to 5 December')
+    cy.get('[data-test="abstraction-period-0"]').contains('From 2 October to 5 December')
 
     // confirm we see the returns cycle selected
-    cy.get('[data-test="meta-data-returns-cycle-0"]').contains('Summer')
+    cy.get('[data-test="returns-cycle-0"]').contains('Summer')
 
     // choose the change option for the returns cycle
-    cy.get('[data-test="meta-data-change-returns-cycle-0"]').click()
+    cy.get('[data-test="change-returns-cycle-0"]').click()
 
     // change the returns cycle and continue
     cy.get('#returnsCycle-2').check()
@@ -217,13 +217,13 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the returns cycle changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get('[data-test="meta-data-returns-cycle-0"]').contains('Winter')
+    cy.get('[data-test="returns-cycle-0"]').contains('Winter')
 
     // confirm we see the site description we selected
-    cy.get('[data-test="meta-data-site-description-0"]').contains('This is a valid site description')
+    cy.get('[data-test="site-description-0"]').contains('This is a valid site description')
 
     // choose the change option for the site description
-    cy.get('[data-test="meta-data-change-site-description-0"]').click()
+    cy.get('[data-test="change-site-description-0"]').click()
 
     // change the site description and continue
     cy.get('#site-description').clear()
@@ -232,13 +232,13 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the site description changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get('[data-test="meta-data-site-description-0"]').contains('This is another valid site description')
+    cy.get('[data-test="site-description-0"]').contains('This is another valid site description')
 
     // confirm we see the collection frequency we selected
-    cy.get('[data-test="meta-data-frequency-collected-0"]').contains('Daily')
+    cy.get('[data-test="frequency-collected-0"]').contains('Daily')
 
     // choose the change option for the collection frequency
-    cy.get('[data-test="meta-data-change-frequency-collected-0"]').click()
+    cy.get('[data-test="change-frequency-collected-0"]').click()
 
     // change the collection frequency and continue
     cy.get('#frequencyCollected-2').check()
@@ -246,13 +246,13 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the collection frequency changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get('[data-test="meta-data-frequency-collected-0"]').contains('Weekly')
+    cy.get('[data-test="frequency-collected-0"]').contains('Weekly')
 
     // confirm we see the reporting frequency we selected
-    cy.get('[data-test="meta-data-frequency-reported-0"]').contains('Daily')
+    cy.get('[data-test="frequency-reported-0"]').contains('Daily')
 
     // choose the change option for the reporting frequency
-    cy.get('[data-test="meta-data-change-frequency-reported-0"]').click()
+    cy.get('[data-test="change-frequency-reported-0"]').click()
 
     // change the reporting frequency and continue
     cy.get('#frequencyReported-3').check()
@@ -260,13 +260,13 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the reporting frequency changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get('[data-test="meta-data-frequency-reported-0"]').contains('Monthly')
+    cy.get('[data-test="frequency-reported-0"]').contains('Monthly')
 
     // confirm we see the agreements and exceptions we selected
-    cy.get('[data-test="meta-data-agreements-exceptions-0"]').contains('Gravity fill')
+    cy.get('[data-test="agreements-exceptions-0"]').contains('Gravity fill')
 
     // choose the change option for agreements exceptions
-    cy.get('[data-test="meta-data-change-agreements-exceptions-0"]').click()
+    cy.get('[data-test="change-agreements-exceptions-0"]').click()
 
     // change the agreements exceptions and continue
     cy.get('#agreementsExceptions').uncheck()
@@ -276,7 +276,7 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the agreements exceptions changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get('[data-test="meta-data-agreements-exceptions-0"]').contains('Transfer re-abstraction scheme and Two-part tariff')
+    cy.get('[data-test="agreements-exceptions-0"]').contains('Transfer re-abstraction scheme and Two-part tariff')
 
     // click the add another requirement button
     cy.contains('Add another requirement').click()
@@ -344,10 +344,10 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
 
     // confirm we see the new requirement
-    cy.get('[data-test="meta-data-requirement-1"]').contains('This is a valid site description for the second requirement')
+    cy.get('[data-test="requirement-1"]').contains('This is a valid site description for the second requirement')
 
     // choose the remove requirement button for the second requirement
-    cy.get('[data-test="meta-data-remove-1"]').click()
+    cy.get('[data-test="remove-1"]').click()
 
     // confirm we are on the remove page
     cy.get('.govuk-heading-xl').contains('You are about to remove these requirements for returns')
@@ -365,7 +365,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-notification-banner').contains('Requirement removed')
 
     // confirm the second requirement has been removed
-    cy.get('[data-test="meta-data-requirement-1"]').should('not.exist')
+    cy.get('[data-test="requirement-1"]').should('not.exist')
 
     // choose the approve return requirement button
     cy.contains('Approve returns requirement').click()

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -63,6 +63,63 @@ describe('Submit and cancel no returns requirement (internal)', () => {
     // confirm we are on the purpose page
     cy.get('.govuk-heading-xl').contains('Select the purpose for the requirements for returns')
 
-    // choose a purpose for the requirement
+    // choose a purpose for the requirement and continue
+    cy.get('#purposes').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the points page
+    cy.get('.govuk-heading-xl').contains('Select the points for the requirements for returns')
+
+    // choose a points for the requirement and continue
+    cy.get('#points').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the abstraction period page
+    cy.get('.govuk-heading-xl').contains('Enter the abstraction period for the requirements for returns')
+
+    // enter start and end dates for the abstraction period and click continue
+    cy.get('#abstraction-period-start-day').type('01')
+    cy.get('#abstraction-period-start-month').type('12')
+    cy.get('#abstraction-period-end-day').type('03')
+    cy.get('#abstraction-period-end-month').type('09')
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the returns cycle page
+    cy.get('.govuk-heading-xl').contains('Select the returns cycle for the requirements for returns')
+
+    // choose a returns cycle and continue
+    cy.get('#returnsCycle').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the site description page
+    cy.get('.govuk-label').contains('Enter a site description for the requirements for returns')
+
+    // enter a site description and continue
+    cy.get('#site-description').type('This is a valid site description')
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the readings collected page
+    cy.get('.govuk-heading-xl').contains('Select how often readings or volumes are collected')
+
+    // choose a collected time frame and continue
+    cy.get('#frequencyCollected').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the readings reported page
+    cy.get('.govuk-heading-xl').contains('Select how often readings or volumes are reported')
+
+    // choose a reporting time frame and continue
+    cy.get('#frequencyReported').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the agreements and exceptions page
+    cy.get('.govuk-heading-l').contains('Select agreements and exceptions for the requirements for returns')
+
+    // choose a agreement and exception and continue
+    cy.get('#agreementsExceptions').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the check page
+    cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
   })
 })

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -344,7 +344,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
 
     // confirm we see the new requirement
-    cy.get(':nth-child(4) > .govuk-summary-card > .govuk-summary-card__title-wrapper').contains('second sdfsdf requirement')
+    cy.get('[data-test="meta-data-requirement-1"]').contains('This is a valid site description for the second requirement')
 
     // choose the remove requirement button for the second requirement
     cy.get('[data-test="meta-data-remove-1"]').click()
@@ -365,7 +365,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-notification-banner').contains('Requirement removed')
 
     // confirm the second requirement has been removed
-    cy.contains('This is a valid site description for the second requirement').should('not.exist')
+    cy.get('[data-test="meta-data-requirement-1"]').should('not.exist')
 
     // choose the approve return requirement button
     cy.contains('Approve returns requirement').click()
@@ -374,9 +374,9 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-panel__title').contains('Requirements for returns approved')
 
     // click link to return to licence set up
-    cy.get(':nth-child(4) > .govuk-link').click()
+    cy.contains('Return to licence set up').click()
 
     // confirm we are on the charge information tab
-    cy.get('#charge > :nth-child(1)').contains('Charge information')
+    cy.get('#charge').contains('Charge information')
   })
 })

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -3,8 +3,12 @@
 describe('Submit and cancel no returns requirement (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('sroc-billing-current')
-    cy.fixture('users.json').its('billingAndData').as('userEmail')
+
+    cy.fixture('returns-requirements.json').then((fixture) => {
+      cy.load(fixture)
+    })
+
+    cy.fixture('users.json').its('billingAndData1').as('userEmail')
   })
 
   it('creates a no returns requirement and approves the requirement', () => {
@@ -24,12 +28,12 @@ describe('Submit and cancel no returns requirement (internal)', () => {
     cy.contains('Search')
 
     // search for a licence
-    cy.get('#query').type('AT/SROC/SUPB/01')
+    cy.get('#query').type('AT/TEST/01')
     cy.get('.search__button').click()
     cy.get('.govuk-table__row > :nth-child(1) > a').click()
 
     // confirm we are on the licence page and select charge information tab
-    cy.contains('AT/SROC/SUPB/01')
+    cy.contains('AT/TEST/01')
     cy.get('#tab_charge').click()
 
     // confirm we are on the charge information tab

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -1,6 +1,6 @@
 'use strict'
 
-describe('Submit and cancel no returns requirement (internal)', () => {
+describe('Submit returns requirement (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
 
@@ -11,7 +11,7 @@ describe('Submit and cancel no returns requirement (internal)', () => {
     cy.fixture('users.json').its('billingAndData1').as('userEmail')
   })
 
-  it('creates a no returns requirement and approves the requirement', () => {
+  it('creates a return requirement and approves the requirement', () => {
     cy.visit('/')
 
     // enter the user name and Password

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -1,0 +1,38 @@
+'use strict'
+
+describe('Submit and cancel no returns requirement (internal)', () => {
+  beforeEach(() => {
+    cy.tearDown()
+    cy.setUp('sroc-billing-current')
+    cy.fixture('users.json').its('billingAndData').as('userEmail')
+  })
+
+  it('creates a no returns requirement and approves the requirement', () => {
+    cy.visit('/')
+
+    // enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('#email').type(userEmail)
+    })
+
+    cy.get('#password').type(Cypress.env('defaultPassword'))
+
+    // click Sign in Button
+    cy.get('form > .govuk-button').click()
+
+    // assert the user signed in and we're on the search page
+    cy.contains('Search')
+
+    // search for a licence
+    cy.get('#query').type('AT/SROC/SUPB/01')
+    cy.get('.search__button').click()
+    cy.get('.govuk-table__row > :nth-child(1) > a').click()
+
+    // confirm we are on the licence page and select charge information tab
+    cy.contains('AT/SROC/SUPB/01')
+    cy.get('#tab_charge').click()
+
+    // confirm we are on the charge information tab
+    cy.get('#charge > :nth-child(1)').contains('Charge information')
+  })
+})

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -123,7 +123,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
 
     // confirm we see the start date information we expect
-    cy.get('[data-test="start-date"]').contains('1 April 2022')
+    cy.get('[data-test="start-date"]').contains('12 June 2023')
 
     // choose the change option for the start date
     cy.get('[data-test="change-start-date"]').click()

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -122,9 +122,10 @@ describe('Submit and cancel no returns requirement (internal)', () => {
     // confirm we are on the check page
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
 
-    // confirm we can see the information we have selected and make changes
-    // start date
+    // confirm we see the start date information we expect
     cy.get('#main-content > :nth-child(2)').contains('1 April 2022')
+
+    // choose the change option for the start date
     cy.get('[data-test="meta-data-change-start-date"]').click()
 
     // change start date and continue
@@ -134,30 +135,147 @@ describe('Submit and cancel no returns requirement (internal)', () => {
     cy.get('#other-start-date-year').type('2023')
     cy.get('.govuk-button').click()
 
-    // confirm we are back on check page and start date changes
-    cy.get('#main-content > :nth-child(2)').contains('2 August 2023')
+    // confirm we are back on check page and see the start date changes
+    cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
+    cy.get('[data-test="meta-data-start-date"]').contains('2 August 2023')
 
-    // // reason
-    // cy.get('#main-content > :nth-child(2)').contains('Licence holder name or address change')
+    // confirm we see the reason we selected
+    cy.get('[data-test="meta-data-reason"]').contains('Licence holder name or address change')
 
-    // // purposes
+    // choose the change option for reason
+    cy.get('[data-test="meta-data-change-reason"]').click()
 
-    // // points
+    // change the reason and continue
+    cy.get('#reason-8').check()
+    cy.get('.govuk-button').click()
 
-    // // abstraction period
-    // cy.get(':nth-child(3) > .govuk-summary-list__value').contains('From 1 December to 3 September')
+    // confirm we are back on the check page and see the reason changes
+    cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
+    cy.get('[data-test="meta-data-reason"]').contains('New licence')
 
-    // // returns cycle
+    // confirm we see the purposes selected
+    cy.get('.govuk-summary-card__content').contains('requirement.purposes')
 
-    // // site description
-    // cy.get(':nth-child(5) > .govuk-summary-list__value').contains('This is a valid site description')
+    // choose the change option for purposes
+    cy.get('[data-test="meta-data-change-purpose"]').click()
 
-    // // collection frequency
-    // cy.get(':nth-child(6) > .govuk-summary-list__value').contains('Daily')
+    // change the purpose and continue
+    cy.get('#purposes').uncheck()
+    cy.get('#purposes-2').check()
+    cy.get('.govuk-button').click()
 
-    // // reporting frequency
-    // cy.get(':nth-child(7) > .govuk-summary-list__value').contains('Daily')
+    // confirm we are back on the check page and see the purpose changes
+    cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
+    cy.get('.govuk-summary-card__content').contains('requirement.purposes')
 
-    // // agreements and exceptions
+    // confirm we see the points selected
+    cy.get('.govuk-summary-card__content').contains('requirement.points')
+
+    // choose the change option for points
+    cy.get('[data-test="meta-data-change-points"]').click()
+
+    // change the points and continue
+    cy.get('#points').uncheck()
+    cy.get('#points-2').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are back on the check page and see the points changes
+    cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
+    cy.get('.govuk-summary-card__content').contains('requirement.points')
+
+    // confirm we see the abstraction period selected
+    cy.get(':nth-child(3) > .govuk-summary-list__value').contains('From 1 December to 3 September')
+
+    // choose the change option for the abstraction period
+    cy.get('[data-test="meta-data-change-abstraction-period"]').click()
+
+    // change the abstraction period and continue
+    cy.get('#abstraction-period-start-day').clear()
+    cy.get('#abstraction-period-start-month').clear()
+    cy.get('#abstraction-period-end-day').clear()
+    cy.get('#abstraction-period-end-month').clear()
+
+    cy.get('#abstraction-period-start-day').type('02')
+    cy.get('#abstraction-period-start-month').type('10')
+    cy.get('#abstraction-period-end-day').type('05')
+    cy.get('#abstraction-period-end-month').type('12')
+    cy.get('.govuk-button').click()
+
+    // confirm we are back on the check page and see the abstraction period changes
+    cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
+    cy.get(':nth-child(3) > .govuk-summary-list__value').contains('From 2 October to 5 December')
+
+    // confirm we see the returns cycle selected
+    cy.get(':nth-child(4) > .govuk-summary-list__value').contains('requirement.returnsCycle')
+
+    // choose the change option for the returns cycle
+    cy.get('[data-test="meta-data-change-returns-cycle"]').click()
+
+    // change the returns cycle and continue
+    cy.get('#returnsCycle-2').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are back on the check page and see the returns cycle changes
+    cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
+    cy.get(':nth-child(4) > .govuk-summary-list__value').contains('requirement.returnsCycle')
+
+    // confirm we see the site description we selected
+    cy.get(':nth-child(5) > .govuk-summary-list__value').contains('This is a valid site description')
+
+    // choose the change option for the site description
+    cy.get('[data-test="meta-data-change-site-description"]').click()
+
+    // change the site description and continue
+    cy.get('#site-description').clear()
+    cy.get('#site-description').type('This is another valid site description')
+    cy.get('.govuk-button').click()
+
+    // confirm we are back on the check page and see the site description changes
+    cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
+    cy.get(':nth-child(5) > .govuk-summary-list__value').contains('This is another valid site description')
+
+    // confirm we see the collection frequency we selected
+    cy.get(':nth-child(6) > .govuk-summary-list__value').contains('Daily')
+
+    // choose the change option for the collection frequency
+    cy.get('[data-test="meta-data-change-frequency-collected"]').click()
+
+    // change the collection frequency and continue
+    cy.get('#frequencyCollected-2').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are back on the check page and see the collection frequency changes
+    cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
+    cy.get(':nth-child(6) > .govuk-summary-list__value').contains('Weekly')
+
+    // confirm we see the reporting frequency we selected
+    cy.get(':nth-child(7) > .govuk-summary-list__value').contains('Daily')
+
+    // choose the change option for the reporting frequency
+    cy.get('[data-test="meta-data-change-frequency-reported"]').click()
+
+    // change the reporting frequency and continue
+    cy.get('#frequencyReported-3').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are back on the check page and see the collection frequency changes
+    cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
+    cy.get(':nth-child(7) > .govuk-summary-list__value').contains('Monthly')
+
+    // confirm we see the agreements and exceptions we selected
+    cy.get(':nth-child(8) > .govuk-summary-list__value').contains('requirement.agreementsExceptions')
+
+    // choose the change option for agreements exceptions
+    cy.get('[data-test="meta-data-change-agreements-exceptions"]').click()
+
+    // change the agreements exceptions and continue
+    cy.get('#agreementsExceptions').uncheck()
+    cy.get('#agreementsExceptions-2').check()
+    cy.get('#agreementsExceptions-3').check()
+    cy.get('.govuk-button').click()
+
+    // confirm we are back on the check page and see the agreements exceptions changes
+    cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
+    cy.get(':nth-child(8) > .govuk-summary-list__value').contains('requirement.agreementsExceptions')
   })
 })

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -345,5 +345,26 @@ describe('Submit and cancel no returns requirement (internal)', () => {
 
     // confirm we see the new requirement
     cy.get(':nth-child(4) > .govuk-summary-card > .govuk-summary-card__title-wrapper').contains('second requirement')
+
+    // choose the remove requirement the second requirement
+    cy.get(':nth-child(4) > .govuk-button').click()
+
+    // confirm we are on the remove page
+    cy.get('.govuk-heading-xl').contains('You are about to remove these requirements for returns')
+
+    // confirm we see the correct requirement to be removed
+    cy.get('div.govuk-body > .govuk-body').contains('Summer daily requirements for returns, This is a valid site description for the second requirement.')
+
+    // choose the remove button
+    cy.get('.govuk-button').click()
+
+    // confirm we are on the check page
+    cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
+
+    // confirm we receive a notification pop up confirming the removed requirement
+    cy.get('.govuk-notification-banner').contains('Requirement removed')
+
+    // confirm the second requirement has been removed
+    cy.contains('This is a valid site description for the second requirement').should('not.exist')
   })
 })

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -366,5 +366,17 @@ describe('Submit and cancel no returns requirement (internal)', () => {
 
     // confirm the second requirement has been removed
     cy.contains('This is a valid site description for the second requirement').should('not.exist')
+
+    // choose the approve return requirement button
+    cy.get('[data-test="meta-data-approve"]').click({ force: true })
+
+    // confirm we are on the approved page
+    cy.get('.govuk-panel__title').contains('Requirements for returns approved')
+
+    // click link to return to licence set up
+    cy.get(':nth-child(4) > .govuk-link').click()
+
+    // confirm we are on the charge information tab
+    cy.get('#charge > :nth-child(1)').contains('Charge information')
   })
 })

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -40,7 +40,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('#charge > :nth-child(1)').contains('Charge information')
 
     // click set up new returns requirement
-    cy.get('[data-test="meta-data-returns-required"]').click()
+    cy.contains('Set up new returns requirement').click()
 
     // choose the licence version start date and click continue
     cy.get('#licence-start-date').check()
@@ -57,7 +57,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-fieldset__heading').contains('How do you want to set up the requirements for returns?')
 
     // click set up manually and continue
-    cy.get('#setup-3').check()
+    cy.get('#setup-4').check()
     cy.get('.govuk-button').click()
 
     // confirm we are on the purpose page
@@ -115,7 +115,7 @@ describe('Submit returns requirement (internal)', () => {
     // confirm we are on the agreements and exceptions page
     cy.get('.govuk-heading-l').contains('Select agreements and exceptions for the requirements for returns')
 
-    // choose a agreement and exception and continue
+    // choose an agreement and exception and continue
     cy.get('#agreementsExceptions').check()
     cy.get('.govuk-button').click()
 
@@ -123,7 +123,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
 
     // confirm we see the start date information we expect
-    cy.get('#main-content > :nth-child(2)').contains('1 April 2022')
+    cy.get('[data-test="meta-data-start-date"]').contains('1 April 2022')
 
     // choose the change option for the start date
     cy.get('[data-test="meta-data-change-start-date"]').click()
@@ -154,10 +154,10 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('[data-test="meta-data-reason"]').contains('New licence')
 
     // confirm we see the purposes selected
-    cy.get(':nth-child(1) > .govuk-summary-list__value > p').contains('General Farming & Domestic')
+    cy.get('[data-test="meta-data-purposes-0"]').should('contain', 'General Farming & Domestic')
 
     // choose the change option for purposes
-    cy.get('[data-test="meta-data-change-purpose"]').click()
+    cy.get('[data-test="meta-data-change-purposes-0"]').click()
 
     // change the purpose and continue
     cy.get('#purposes').uncheck()
@@ -166,13 +166,13 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the purpose changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get(':nth-child(1) > .govuk-summary-list__value > p').contains('Hydroelectric Power Generation')
+    cy.get('[data-test="meta-data-purposes-0"]').contains('Hydroelectric Power Generation')
 
     // confirm we see the points selected
-    cy.get('.govuk-summary-card__content').contains('At National Grid Reference TQ 1234 1234 (Test local name 1)')
+    cy.get('[data-test="meta-data-points-0"]').should('contain', 'At National Grid Reference TQ 1234 1234 (Test local name 1)')
 
     // choose the change option for points
-    cy.get('[data-test="meta-data-change-points"]').click()
+    cy.get('[data-test="meta-data-change-points-0"]').click()
 
     // change the points and continue
     cy.get('#points').uncheck()
@@ -181,13 +181,13 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the points changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get('.govuk-summary-card__content').contains('At National Grid Reference TT 5678 5678 (Test local name 2)')
+    cy.get('[data-test="meta-data-points-0"]').contains('At National Grid Reference TT 5678 5678 (Test local name 2)')
 
     // confirm we see the abstraction period selected
-    cy.get(':nth-child(3) > .govuk-summary-list__value').contains('From 1 December to 3 September')
+    cy.get('[data-test="meta-data-abstraction-period-0"]').contains('From 1 December to 3 September')
 
     // choose the change option for the abstraction period
-    cy.get('[data-test="meta-data-change-abstraction-period"]').click()
+    cy.get('[data-test="meta-data-change-abstraction-period-0"]').click()
 
     // change the abstraction period and continue
     cy.get('#abstraction-period-start-day').clear()
@@ -203,13 +203,13 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the abstraction period changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get(':nth-child(3) > .govuk-summary-list__value').contains('From 2 October to 5 December')
+    cy.get('[data-test="meta-data-abstraction-period-0"]').contains('From 2 October to 5 December')
 
     // confirm we see the returns cycle selected
-    cy.get(':nth-child(4) > .govuk-summary-list__value').contains('Summer')
+    cy.get('[data-test="meta-data-returns-cycle-0"]').contains('Summer')
 
     // choose the change option for the returns cycle
-    cy.get('[data-test="meta-data-change-returns-cycle"]').click()
+    cy.get('[data-test="meta-data-change-returns-cycle-0"]').click()
 
     // change the returns cycle and continue
     cy.get('#returnsCycle-2').check()
@@ -217,13 +217,13 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the returns cycle changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get(':nth-child(4) > .govuk-summary-list__value').contains('Winter')
+    cy.get('[data-test="meta-data-returns-cycle-0"]').contains('Winter')
 
     // confirm we see the site description we selected
-    cy.get(':nth-child(5) > .govuk-summary-list__value').contains('This is a valid site description')
+    cy.get('[data-test="meta-data-site-description-0"]').contains('This is a valid site description')
 
     // choose the change option for the site description
-    cy.get('[data-test="meta-data-change-site-description"]').click()
+    cy.get('[data-test="meta-data-change-site-description-0"]').click()
 
     // change the site description and continue
     cy.get('#site-description').clear()
@@ -232,13 +232,13 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the site description changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get(':nth-child(5) > .govuk-summary-list__value').contains('This is another valid site description')
+    cy.get('[data-test="meta-data-site-description-0"]').contains('This is another valid site description')
 
     // confirm we see the collection frequency we selected
-    cy.get(':nth-child(6) > .govuk-summary-list__value').contains('Daily')
+    cy.get('[data-test="meta-data-frequency-collected-0"]').contains('Daily')
 
     // choose the change option for the collection frequency
-    cy.get('[data-test="meta-data-change-frequency-collected"]').click()
+    cy.get('[data-test="meta-data-change-frequency-collected-0"]').click()
 
     // change the collection frequency and continue
     cy.get('#frequencyCollected-2').check()
@@ -246,27 +246,27 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the collection frequency changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get(':nth-child(6) > .govuk-summary-list__value').contains('Weekly')
+    cy.get('[data-test="meta-data-frequency-collected-0"]').contains('Weekly')
 
     // confirm we see the reporting frequency we selected
-    cy.get(':nth-child(7) > .govuk-summary-list__value').contains('Daily')
+    cy.get('[data-test="meta-data-frequency-reported-0"]').contains('Daily')
 
     // choose the change option for the reporting frequency
-    cy.get('[data-test="meta-data-change-frequency-reported"]').click()
+    cy.get('[data-test="meta-data-change-frequency-reported-0"]').click()
 
     // change the reporting frequency and continue
     cy.get('#frequencyReported-3').check()
     cy.get('.govuk-button').click()
 
-    // confirm we are back on the check page and see the collection frequency changes
+    // confirm we are back on the check page and see the reporting frequency changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get(':nth-child(7) > .govuk-summary-list__value').contains('Monthly')
+    cy.get('[data-test="meta-data-frequency-reported-0"]').contains('Monthly')
 
     // confirm we see the agreements and exceptions we selected
-    cy.get(':nth-child(8) > .govuk-summary-list__value').contains('Gravity fill')
+    cy.get('[data-test="meta-data-agreements-exceptions-0"]').contains('Gravity fill')
 
     // choose the change option for agreements exceptions
-    cy.get('[data-test="meta-data-change-agreements-exceptions"]').click()
+    cy.get('[data-test="meta-data-change-agreements-exceptions-0"]').click()
 
     // change the agreements exceptions and continue
     cy.get('#agreementsExceptions').uncheck()
@@ -276,10 +276,10 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the agreements exceptions changes
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
-    cy.get(':nth-child(8) > .govuk-summary-list__value').contains('Transfer re-abstraction scheme and Two-part tariff')
+    cy.get('[data-test="meta-data-agreements-exceptions-0"]').contains('Transfer re-abstraction scheme and Two-part tariff')
 
     // click the add another requirement button
-    cy.get('form > .govuk-button').click()
+    cy.contains('Add another requirement').click()
 
     // confirm we are on the purpose page
     cy.get('.govuk-heading-xl').contains('Select the purpose for the requirements for returns')
@@ -344,10 +344,10 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
 
     // confirm we see the new requirement
-    cy.get(':nth-child(4) > .govuk-summary-card > .govuk-summary-card__title-wrapper').contains('second requirement')
+    cy.get(':nth-child(4) > .govuk-summary-card > .govuk-summary-card__title-wrapper').contains('second sdfsdf requirement')
 
     // choose the remove requirement button for the second requirement
-    cy.get('.govuk-button').eq(2).should('contain', 'Remove requirement').click()
+    cy.get('[data-test="meta-data-remove-1"]').click()
 
     // confirm we are on the remove page
     cy.get('.govuk-heading-xl').contains('You are about to remove these requirements for returns')
@@ -368,7 +368,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('This is a valid site description for the second requirement').should('not.exist')
 
     // choose the approve return requirement button
-    cy.get('[data-test="meta-data-approve"]').click({ force: true })
+    cy.contains('Approve returns requirement').click()
 
     // confirm we are on the approved page
     cy.get('.govuk-panel__title').contains('Requirements for returns approved')

--- a/cypress/fixtures/returns-requirements.json
+++ b/cypress/fixtures/returns-requirements.json
@@ -1,0 +1,238 @@
+{
+  "regions": [
+    {
+      "id": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "chargeRegionId": "S",
+      "naldRegionId": 9,
+      "displayName": "Test Region",
+      "name": "Test Region"
+    }
+  ],
+  "addresses": [
+    {
+      "id": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "address1": "Big Farm",
+      "address2": "Windy road",
+      "address3": "Buttercup meadow",
+      "address4": "Buttercup Village",
+      "address5": "Testington",
+      "address6": "Testingshire",
+      "postcode": "TT1 1TT",
+      "country": "UK",
+      "dataSource": "nald"
+    }
+  ],
+  "companies": [
+    {
+      "id": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "name": "Big Farm Co Ltd 01",
+      "type": "organisation",
+      "companyNumber": "1234501"
+    }
+  ],
+  "contacts": [
+    {
+      "id": "6e05db31-39cd-4bb0-83a0-0d985037ad8f",
+      "salutation": "Mr",
+      "firstName": "John",
+      "lastName": "Testerson",
+      "middleInitials": "J",
+      "contactType": "person",
+      "dataSource": "nald"
+    }
+  ],
+  "billingAccounts": [
+    {
+      "id": "16cb50a5-e3e6-41f4-a42b-9dad6a69fc0c",
+      "accountNumber": "A99999991A",
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778"
+    }
+  ],
+  "billingAccountAddresses": [
+    {
+      "id": "ab9a24ec-80b8-40dc-82f8-7df3e885245a",
+      "billingAccountId": "16cb50a5-e3e6-41f4-a42b-9dad6a69fc0c",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "startDate": "2022-04-01"
+    }
+  ],
+  "licenceDocuments": [
+    {
+      "id": "1a274f3e-f891-43dd-8c25-8afac4e760ac",
+      "licenceRef": "AT/TEST/01",
+      "startDate": "2022-04-01"
+    }
+  ],
+  "licenceDocumentRoles": [
+    {
+      "licenceDocumentId": "1a274f3e-f891-43dd-8c25-8afac4e760ac",
+      "licenceRoleId": {
+        "schema": "public",
+        "table": "licenceRoles",
+        "lookup": "name",
+        "value": "licenceHolder",
+        "select": "id"
+      },
+      "startDate": "2022-04-01",
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "contactId": "6e05db31-39cd-4bb0-83a0-0d985037ad8f"
+    }
+  ],
+  "permitLicences": [
+    {
+      "licenceRef": "AT/TEST/01",
+      "startDate": "2022-04-01",
+      "metadata": {
+        "source": "acceptance-test-setup"
+      }
+    }
+  ],
+  "licenceDocumentHeaders": [
+    {
+      "id": "282b226e-c47b-4dcc-bbb0-94648fb6b242",
+      "regimeEntityId": {
+        "schema": "crm",
+        "table": "entity",
+        "lookup": "entityType",
+        "value": "regime",
+        "select": "entityId"
+      },
+      "licenceRef": "AT/TEST/01",
+      "naldId": {
+        "schema": "public",
+        "table": "permitLicences",
+        "lookup": "licenceRef",
+        "value": "AT/TEST/01",
+        "select": "id"
+      },
+      "metadata": {
+        "Name": "Big Farm 01",
+        "dataType": "acceptance-test-setup",
+        "IsCurrent": true
+      }
+    }
+  ],
+  "licences": [
+    {
+      "id": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
+      "licenceRef": "AT/TEST/01",
+      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "regions": {
+        "historicalAreaCode": "SAAR",
+        "regionalChargeArea": "Southern"
+      },
+      "startDate": "2022-04-01",
+      "waterUndertaker": true
+    }
+  ],
+  "licenceVersions": [
+    {
+      "id": "b846afb6-9334-42c4-8da3-1d559a6e3ea7",
+      "licenceId": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
+      "issue": 1,
+      "increment": 0,
+      "status": "current",
+      "startDate": "2022-04-01",
+      "externalId": "6:1234:1:0"
+    },
+    {
+      "id": "2f9362e8-4fdc-4018-880a-31bba8d9b23b",
+      "licenceId": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
+      "issue": 1,
+      "increment": 0,
+      "status": "current",
+      "startDate": "2022-04-01",
+      "externalId": "6:1234:2:0"
+    }
+  ],
+  "chargeVersions": [
+    {
+      "id": "8e5626ee-5e4c-48f6-a668-471d35997e2c",
+      "licenceId": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
+      "licenceRef": "AT/TES/01",
+      "billingAccountId": "16cb50a5-e3e6-41f4-a42b-9dad6a69fc0c",
+      "regionCode": 9,
+      "scheme": "sroc",
+      "versionNumber": 100,
+      "startDate": "2022-04-01",
+      "status": "current",
+      "source": "wrls"
+    }
+  ],
+  "chargeReferences": [
+    {
+      "id": "fa3c73d0-0459-41f0-b6cf-0e0758775ca4",
+      "chargeVersionId": "8e5626ee-5e4c-48f6-a668-471d35997e2c",
+      "description": "SROC Charge Reference 01",
+      "scheme": "sroc",
+      "source": "tidal",
+      "loss": "medium",
+      "restrictedSource": false,
+      "factorsOverridden": false,
+      "chargeCategoryId": {
+        "schema": "public",
+        "table": "chargeCategories",
+        "lookup": "reference",
+        "value": "4.2.1",
+        "select": "id"
+      },
+      "waterModel": "no model",
+      "volume": 100,
+      "eiucRegion": "Southern",
+      "section127Agreement": false
+    }
+  ],
+  "licenceVersionPurposes": [
+    {
+      "id": "a4f9b0b5-11ac-4aa2-98c9-61c6c12088bb",
+      "licenceVersionId": "b846afb6-9334-42c4-8da3-1d559a6e3ea7",
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "purposePrimaryId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "purposeSecondaryId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      }
+    },
+    {
+      "id": "b1fa0800-9028-4a46-872c-7f70676701ca",
+      "licenceVersionId": "2f9362e8-4fdc-4018-880a-31bba8d9b23b",
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "240",
+        "select": "id"
+      },
+      "purposePrimaryId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "W",
+        "select": "purposePrimaryId"
+      },
+      "purposeSecondaryId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "FAD",
+        "select": "purposeSecondaryId"
+      }
+    }
+  ]
+}

--- a/cypress/fixtures/returns-requirements.json
+++ b/cypress/fixtures/returns-requirements.json
@@ -139,10 +139,10 @@
     {
       "id": "2f9362e8-4fdc-4018-880a-31bba8d9b23b",
       "licenceId": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
-      "issue": 1,
+      "issue": 2,
       "increment": 0,
       "status": "current",
-      "startDate": "2022-04-01",
+      "startDate": "2023-06-12",
       "externalId": "6:1234:2:0"
     }
   ],


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4485

As the return requirements journey is now nearing completion, we are starting to create automated acceptance tests for the returns setup functionality.

This PR is primarily focused on creating the acceptance tests for the returns required journey. It includes tests for changing selected options throughout the journey as well as adding and removing a requirement.