### PR TITLE
Altering two-part tariff scenario one fixtures

### DIFF
--- a/cypress/fixtures/sroc-two-part-tariff-scenario-one-data.json
+++ b/cypress/fixtures/sroc-two-part-tariff-scenario-one-data.json
@@ -114,7 +114,13 @@
       "startDate": "2022-04-01",
       "status": "current",
       "source": "wrls",
-      "changeReasonId": "db394fa0-55a8-412f-a170-16888e424b37"
+      "changeReasonId": {
+        "schema" : "water",
+        "table" : "changeReasons",
+        "lookup" : "description",
+        "value" : "Strategic review of charges (SRoC)",
+        "select" : "changeReasonId"
+      }
     }
   ],
   "chargeReferences": [


### PR DESCRIPTION
During the testing of scenario one, it was noticed that the fixtures file was set up incorrectly, meaning the QA team could not run the tests. This is due to an ID being used that was only available on my local machine and therefore not in the QA team database. This should not have been a hardcoded value, but rather a lookup for the correct ID. 

This PR is changing the ID from a hardcoded value to a lookup value instead.