### PR TITLE
Updating testing scenario one for two-part tariff review pages

### DIFF
--- a/cypress/e2e/internal/billing/two-part-tariff/scenario-one.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/scenario-one.cy.js
@@ -76,23 +76,24 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
 
     // Review licences ~ Test you can filter by licence ref
     cy.get('.govuk-details__summary').click()
-    cy.get('#filter-licence-holder').type('AT/1')
+    cy.get('#filter-licence-holder-number').type('AT/1')
     cy.contains('Apply filters').click()
     cy.get('.govuk-table__caption').should('contain.text', 'Showing 0 of 1 licences')
     cy.contains('Clear filters').click()
     cy.get('.govuk-details__summary').click()
-    cy.get('#filter-licence-holder').type('AT/TEST/01')
+    cy.get('#filter-licence-holder-number').type('AT/TEST/01')
     cy.contains('Apply filters').click()
     cy.get('.govuk-table__caption').should('contain.text', 'Showing all 1 licences')
+    cy.contains('Clear filters').click()
 
     // Review licences ~ Test you can filter by licence holder
     cy.get('.govuk-details__summary').click()
-    cy.get('#filter-licence-holder').type('Miss A Test')
+    cy.get('#filter-licence-holder-number').type('Miss A Test')
     cy.contains('Apply filters').click()
     cy.get('.govuk-table__caption').should('contain.text', 'Showing 0 of 1 licences')
     cy.contains('Clear filters').click()
     cy.get('.govuk-details__summary').click()
-    cy.get('#filter-licence-holder').type('Mr J J Testerson')
+    cy.get('#filter-licence-holder-number').type('Mr J J Testerson')
     cy.contains('Apply filters').click()
     cy.get('.govuk-table__caption').should('contain.text', 'Showing all 1 licences')
 

--- a/cypress/e2e/internal/billing/two-part-tariff/scenario-one.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/scenario-one.cy.js
@@ -74,6 +74,28 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     cy.get('[data-test="meta-data-scheme"]').should('contain.text', 'Current')
     cy.get('[data-test="meta-data-year"]').should('contain.text', '2022 to 2023')
 
+    // Review licences ~ Test you can filter by licence ref
+    cy.get('.govuk-details__summary').click()
+    cy.get('#filter-licence-holder').type('AT/1')
+    cy.contains('Apply filters').click()
+    cy.get('.govuk-table__caption').should('contain.text', 'Showing 0 of 1 licences')
+    cy.contains('Clear filters').click()
+    cy.get('.govuk-details__summary').click()
+    cy.get('#filter-licence-holder').type('AT/TEST/01')
+    cy.contains('Apply filters').click()
+    cy.get('.govuk-table__caption').should('contain.text', 'Showing all 1 licences')
+
+    // Review licences ~ Test you can filter by licence holder
+    cy.get('.govuk-details__summary').click()
+    cy.get('#filter-licence-holder').type('Miss A Test')
+    cy.contains('Apply filters').click()
+    cy.get('.govuk-table__caption').should('contain.text', 'Showing 0 of 1 licences')
+    cy.contains('Clear filters').click()
+    cy.get('.govuk-details__summary').click()
+    cy.get('#filter-licence-holder').type('Mr J J Testerson')
+    cy.contains('Apply filters').click()
+    cy.get('.govuk-table__caption').should('contain.text', 'Showing all 1 licences')
+
     // Review licences ~ Test it has the correct licence
     cy.get('[data-test="licence-1"]').should('contain.text', 'AT/TEST/01')
     cy.get('[data-test="licence-2"]').should('not.exist')
@@ -121,6 +143,7 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     cy.get('[data-test="charge-reference-link-0"]').should('contain.text', 'View details')
     cy.get('[data-test="element-count-0"]').should('contain.text', 'Element 1 of 1')
     cy.get('[data-test="element-description-0"]').should('contain.text', 'SROC Charge Purpose 01')
+    cy.get('[data-test="element-description-0"]').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="element-dates-0"]').should('contain.text', '1 April 2022 to 31 March 2023')
     cy.get('[data-test="charge-element-issues-0"]').should('contain.text', '')
     cy.get('[data-test="charge-element-billable-returns-0"]').should('contain.text', '32 ML / 32 ML')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4452

Scenario one for the two-part tariff review screens is our happy path scenario. This testing scenario was written whilst live testing was happening in our pre-production environment with the billing and data team. During their testing of the two-part tariff engine and review screens, they requested some changes to make it more user-friendly. This PR is updating the acceptance test for scenario one to cater for the changes to the review page that have since been made.