### PR TITLE
Fixing broken two-part tariff acceptance tests

### DIFF
--- a/cypress/e2e/internal/billing/two-part-tariff/scenario-eight.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/scenario-eight.cy.js
@@ -109,15 +109,15 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="unmatched-return-action-0"] > .govuk-link').should('not.exist')
 
     // Review Licence AT/TEST/01 ~ Check charge Information details are correct for a licence with a nil return
-    cy.get('[data-test="total-billable-returns-0"]').should('contain.text', '0 ML / 32 ML')
+    cy.get('[data-test="charge-version-0-total-billable-returns-0"]').should('contain.text', '0 ML / 32 ML')
     // Without an aggregate of charge factor we shouldn't see the link "Change details" only "View details"
-    cy.get('[data-test="charge-reference-link-0"]').should('contain.text', 'View details')
-    cy.get('[data-test="charge-element-issues-0"]').should('contain.text', '')
-    cy.get('[data-test="charge-element-billable-returns-0"]').should('contain.text', '0 ML / 32 ML')
-    cy.get('[data-test="charge-element-return-volumes-0"]').should('contain.text', '0 ML (10021668)')
+    cy.get('[data-test="charge-version-0-charge-reference-link-0"]').should('contain.text', 'View details')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-issues-0"]').should('contain.text', '')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-billable-returns-0"]').should('contain.text', '0 ML / 32 ML')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-return-volumes-0"]').should('contain.text', '0 ML (10021668)')
 
     // View match details
-    cy.get('[data-test="charge-element-match-details-0"]').click()
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
     cy.get('[data-test="matched-return-summary-0"]').contains('General Farming & Domestic A DRAIN SOMEWHERE')

--- a/cypress/e2e/internal/billing/two-part-tariff/scenario-five.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/scenario-five.cy.js
@@ -122,15 +122,15 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
 
     // Review Licence AT/TEST/01 ~ Check charge Information details are correct for a licence with "overlap of charge
     // dates"
-    cy.get('[data-test="charge-element-issues-0"]').should('contain.text', 'Overlap of charge dates')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-issues-0"]').should('contain.text', 'Overlap of charge dates')
     // Even with the issue "overlap of charge dates" we still expect the return to allocate fully to the charge element
-    cy.get('[data-test="charge-element-billable-returns-0"]').should('contain.text', '32 ML / 32 ML')
-    cy.get('[data-test="charge-element-return-volumes-0"]').should('contain.text', '32 ML (10021668)')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-billable-returns-0"]').should('contain.text', '32 ML / 32 ML')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-return-volumes-0"]').should('contain.text', '32 ML (10021668)')
     // Without an aggregate of charge factor we shouldn't see the link "Change details" only "View details"
-    cy.get('[data-test="charge-reference-link-0"]').should('contain.text', 'View details')
+    cy.get('[data-test="charge-version-0-charge-reference-link-0"]').should('contain.text', 'View details')
 
     // View match details
-    cy.get('[data-test="charge-element-match-details-0"]').click()
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
     cy.get('[data-test="matched-return-summary-0"]').contains('General Farming & Domestic A DRAIN SOMEWHERE')

--- a/cypress/e2e/internal/billing/two-part-tariff/scenario-four.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/scenario-four.cy.js
@@ -121,13 +121,13 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="unmatched-return-action-0"] > .govuk-link').should('not.exist')
 
     // Review Licence AT/TEST/01 ~ Check charge Information details are correct for a licence with an aggregate
-    cy.get('[data-test="charge-element-issues-0"]').should('contain.text', 'Aggregate')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-issues-0"]').should('contain.text', 'Aggregate')
     // Even with an  aggregate issue flagged we still expect the return to allocate fully to the charge element
-    cy.get('[data-test="charge-element-billable-returns-0"]').should('contain.text', '32 ML / 32 ML')
-    cy.get('[data-test="charge-element-return-volumes-0"]').should('contain.text', '32 ML (10021668)')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-billable-returns-0"]').should('contain.text', '32 ML / 32 ML')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-return-volumes-0"]').should('contain.text', '32 ML (10021668)')
 
     // View match details
-    cy.get('[data-test="charge-element-match-details-0"]').click()
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
     cy.get('[data-test="matched-return-summary-0"]').contains('General Farming & Domestic A DRAIN SOMEWHERE')
@@ -139,7 +139,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
 
     // When an aggregate is present on the charge reference, this changes the reference link from "View details" to
     // "Change details"
-    cy.get('[data-test="charge-reference-link-0"]').should('contain.text', 'Change details')
+    cy.get('[data-test="charge-version-0-charge-reference-link-0"]').should('contain.text', 'Change details')
     cy.contains('Change details').click()
 
     // Charge reference details

--- a/cypress/e2e/internal/billing/two-part-tariff/scenario-one.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/scenario-one.cy.js
@@ -123,7 +123,7 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
-    cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', '\n          General Farming & Domestic\n       ')
+    cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="matched-return-total-0"]').should('contain.text', '32 ML / 32 ML')
 
@@ -134,27 +134,28 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     // Review Licence AT/TEST/01 ~ Check charge Information details
     cy.get('[data-test="financial-year"]').should('contain.text', 'Financial year 2022 to 2023')
     cy.get('#charge-version-0 > .govuk-heading-l').should('contain.text', 'Charge periods 1 April 2022 to 31 March 2023')
+    cy.get('[data-test="charge-version-0-details"]').should('contain.text', '1 charge reference  with 1 two-part tariff charge element')
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('.govuk-details__summary').click()
     cy.get('[data-test="billing-account"]').should('contain.text', 'A99999991A')
     cy.get('[data-test="account-name"]').should('contain.text', 'Big Farm Co Ltd 01')
-    cy.get('[data-test="reference-0"]').should('contain.text', 'Charge reference 4.6.12')
-    cy.get('[data-test="charge-description-0"]').should('contain.text', 'High loss, non-tidal, restricted water, greater than 15 up to and including 50 ML/yr, Tier 2 model')
-    cy.get('[data-test="total-billable-returns-0"]').should('contain.text', '32 ML / 32 ML')
-    cy.get('[data-test="charge-reference-link-0"]').should('contain.text', 'View details')
-    cy.get('[data-test="element-count-0"]').should('contain.text', 'Element 1 of 1')
-    cy.get('[data-test="element-description-0"]').should('contain.text', 'SROC Charge Purpose 01')
-    cy.get('[data-test="element-description-0"]').should('contain.text', 'General Farming & Domestic')
-    cy.get('[data-test="element-dates-0"]').should('contain.text', '1 April 2022 to 31 March 2023')
-    cy.get('[data-test="charge-element-issues-0"]').should('contain.text', '')
-    cy.get('[data-test="charge-element-billable-returns-0"]').should('contain.text', '32 ML / 32 ML')
-    cy.get('[data-test="charge-element-return-volumes-0"]').should('contain.text', '32 ML (10021668)')
+    cy.get('[data-test="charge-version-0-reference-0"]').should('contain.text', 'Charge reference 4.6.12')
+    cy.get('[data-test="charge-version-0-charge-description-0"]').should('contain.text', 'High loss, non-tidal, restricted water, greater than 15 up to and including 50 ML/yr, Tier 2 model')
+    cy.get('[data-test="charge-version-0-total-billable-returns-0"]').should('contain.text', '32 ML / 32 ML')
+    cy.get('[data-test="charge-version-0-charge-reference-link-0"]').should('contain.text', 'View details')
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-count-0"]').should('contain.text', 'Element 1 of 1')
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', 'SROC Charge Purpose 01')
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', 'General Farming & Domestic')
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-dates-0"]').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-issues-0"]').should('contain.text', '')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-billable-returns-0"]').should('contain.text', '32 ML / 32 ML')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-return-volumes-0"]').should('contain.text', '32 ML (10021668)')
 
     // Review Licence AT/TEST/01 ~ Check there is only 1 charge version, charge reference and charge element
     cy.get('#charge-version-1 > .govuk-heading-l').should('not.exist')
-    cy.get('[data-test="charge-reference-1"]').should('not.exist')
-    cy.get('[data-test="element-count-1"]').should('not.exist')
-    cy.get('[data-test="charge-reference-link-0"]').click()
+    cy.get('[data-test="charge-version-0-reference-1"]').should('not.exist')
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-count-1"]').should('not.exist')
+    cy.get('[data-test="charge-version-0-charge-reference-link-0"]').click()
 
     // Charge reference details
     cy.get('[data-test="charge-reference"]').should('contain.text', 'Charge reference 4.6.12')
@@ -172,8 +173,9 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     cy.get('.govuk-back-link').click()
 
     // View match details
-    cy.get('[data-test="charge-element-match-details-0"]').click()
-    cy.get('.govuk-heading-l').should('contain.text', '\n        SROC Charge Purpose 01\n         1 April 2022 to 31 March 2023 \n      ')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
+    cy.get('.govuk-heading-l').should('contain.text', 'SROC Charge Purpose 01')
+    cy.get('.govuk-heading-l').should('contain.text', '1 April 2022 to 31 March 2023')
     cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
     cy.get('[data-test="financial-year"]').should('contain.text', 'Financial year 2022 to 2023')
     cy.get('[data-test="charge-period"]').should('contain.text', 'Charge period 1 April 2022 to 31 March 2023')
@@ -182,7 +184,8 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     cy.get('[data-test="issues-0"]').should('not.exist')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
-    cy.get('[data-test="matched-return-summary-0"]').should('contain.text', '\n        \n          General Farming & Domestic\n        \n          A DRAIN SOMEWHERE\n      ')
+    cy.get('[data-test="matched-return-summary-0"]').should('contain.text', 'General Farming & Domestic')
+    cy.get('[data-test="matched-return-summary-0"]').should('contain.text', 'A DRAIN SOMEWHERE')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="matched-return-total-0"] > :nth-child(1)').should('contain.text', '32 ML / 32 ML')
 
@@ -204,7 +207,7 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     cy.get('.govuk-back-link').click()
 
     // Review Licence AT/TEST/01 ~ Check billable returns has updated on licence review page
-    cy.get('[data-test="charge-element-billable-returns-0"]').should('contain.text', '20.123 ML / 32 ML')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-billable-returns-0"]').should('contain.text', '20.123 ML / 32 ML')
 
     // Review Licence AT/TEST/01 ~ Put licence into review
     cy.contains('Put licence into review').click()

--- a/cypress/e2e/internal/billing/two-part-tariff/scenario-seven.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/scenario-seven.cy.js
@@ -124,15 +124,15 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
 
     // Review Licence AT/TEST/01 ~ Check charge Information details are correct for a licence with the "Returns received
     // but not processed issue
-    cy.get('[data-test="total-billable-returns-0"]').should('contain.text', '0 ML / 32 ML')
+    cy.get('[data-test="charge-version-0-total-billable-returns-0"]').should('contain.text', '0 ML / 32 ML')
     // Without an aggregate of charge factor we shouldn't see the link "Change details" only "View details"
-    cy.get('[data-test="charge-reference-link-0"]').should('contain.text', 'View details')
-    cy.get('[data-test="charge-element-issues-0"]').should('contain.text', '')
-    cy.get('[data-test="charge-element-billable-returns-0"]').should('contain.text', '0 ML / 32 ML')
-    cy.get('[data-test="charge-element-return-volumes-0"]').should('contain.text', '32 ML (10021668)')
+    cy.get('[data-test="charge-version-0-charge-reference-link-0"]').should('contain.text', 'View details')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-issues-0"]').should('contain.text', '')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-billable-returns-0"]').should('contain.text', '0 ML / 32 ML')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-return-volumes-0"]').should('contain.text', '32 ML (10021668)')
 
     // View match details
-    cy.get('[data-test="charge-element-match-details-0"]').click()
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
     cy.get('[data-test="matched-return-summary-0"]').contains('General Farming & Domestic A DRAIN SOMEWHERE')

--- a/cypress/e2e/internal/billing/two-part-tariff/scenario-six.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/scenario-six.cy.js
@@ -124,15 +124,15 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
 
     // Review Licence AT/TEST/01 ~ Check charge Information details are correct for a licence with the "Under query"
     // issue
-    cy.get('[data-test="total-billable-returns-0"]').should('contain.text', '0 ML / 32 ML')
+    cy.get('[data-test="charge-version-0-total-billable-returns-0"]').should('contain.text', '0 ML / 32 ML')
     // Without an aggregate of charge factor we shouldn't see the link "Change details" only "View details"
-    cy.get('[data-test="charge-reference-link-0"]').should('contain.text', 'View details')
-    cy.get('[data-test="charge-element-issues-0"]').should('contain.text', '')
-    cy.get('[data-test="charge-element-billable-returns-0"]').should('contain.text', '0 ML / 32 ML')
-    cy.get('[data-test="charge-element-return-volumes-0"]').should('contain.text', '32 ML (10021668)')
+    cy.get('[data-test="charge-version-0-charge-reference-link-0"]').should('contain.text', 'View details')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-issues-0"]').should('contain.text', '')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-billable-returns-0"]').should('contain.text', '0 ML / 32 ML')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-return-volumes-0"]').should('contain.text', '32 ML (10021668)')
 
     // View match details
-    cy.get('[data-test="charge-element-match-details-0"]').click()
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
     cy.get('[data-test="matched-return-summary-0"]').contains('General Farming & Domestic A DRAIN SOMEWHERE')

--- a/cypress/e2e/internal/billing/two-part-tariff/scenario-three.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/scenario-three.cy.js
@@ -118,12 +118,12 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="unmatched-return-action-0"] > .govuk-link').should('not.exist')
 
     // Review Licence AT/TEST/01 ~ Check charge Information details are correct for a licence with a late returns issue
-    cy.get('[data-test="charge-element-issues-0"]').should('contain.text', '')
-    cy.get('[data-test="charge-element-billable-returns-0"]').should('contain.text', '32 ML / 32 ML')
-    cy.get('[data-test="charge-element-return-volumes-0"]').should('contain.text', '32 ML (10021668)')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-issues-0"]').should('contain.text', '')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-billable-returns-0"]').should('contain.text', '32 ML / 32 ML')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-return-volumes-0"]').should('contain.text', '32 ML (10021668)')
 
     // View match details
-    cy.get('[data-test="charge-element-match-details-0"]').click()
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
     cy.get('[data-test="matched-return-summary-0"]').contains('General Farming & Domestic A DRAIN SOMEWHERE')

--- a/cypress/e2e/internal/billing/two-part-tariff/scenario-two.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/scenario-two.cy.js
@@ -105,17 +105,17 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="unmatched-return-action-0"] > .govuk-link').should('not.exist')
 
     // Review Licence AT/TEST/01 ~ Check charge Information details
-    cy.get('[data-test="reference-0"]').should('contain.text', 'Charge reference 4.6.12')
-    cy.get('[data-test="charge-description-0"]').should('contain.text', 'High loss, non-tidal, restricted water, greater than 15 up to and including 50 ML/yr, Tier 2 model')
-    cy.get('[data-test="total-billable-returns-0"]').should('contain.text', '32 ML / 32 ML')
-    cy.get('[data-test="element-description-0"]').should('contain.text', 'SROC Charge Purpose 01')
-    cy.get('[data-test="charge-element-issues-0"]').should('contain.text', '')
-    cy.get('[data-test="charge-element-billable-returns-0"]').should('contain.text', '32 ML / 32 ML')
-    cy.get('[data-test="charge-element-return-volumes-0"]').should('contain.text', '32 ML (10021668)')
+    cy.get('[data-test="charge-version-0-reference-0"]').should('contain.text', 'Charge reference 4.6.12')
+    cy.get('[data-test="charge-version-0-charge-description-0"]').should('contain.text', 'High loss, non-tidal, restricted water, greater than 15 up to and including 50 ML/yr, Tier 2 model')
+    cy.get('[data-test="charge-version-0-total-billable-returns-0"]').should('contain.text', '32 ML / 32 ML')
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', 'SROC Charge Purpose 01')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-issues-0"]').should('contain.text', '')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-billable-returns-0"]').should('contain.text', '32 ML / 32 ML')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-return-volumes-0"]').should('contain.text', '32 ML (10021668)')
 
     // Review Licence AT/TEST/01 ~ Check there is only 1 charge version, charge reference and charge element
     cy.get('#charge-version-1 > .govuk-heading-l').should('not.exist')
-    cy.get('[data-test="charge-reference-1"]').should('not.exist')
-    cy.get('[data-test="element-count-1"]').should('not.exist')
+    cy.get('[data-test="charge-version-0-reference-1"]').should('not.exist')
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-count-1"]').should('not.exist')
   })
 })


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/106

While writing the acceptance test for scenario nine in our two-part tariff testing scenarios I had to update the tags on the licence review page. This was because this is the first scenario where we have multiple charge versions, charge references and charge elements and it became clear that the tags weren't handling the indexes of these correctly. Once the tags were updated the rest of the acceptance tests broke, meaning this PR is me fixing them!