### PR TITLE
Scenario Ten for the two-part tariff review pages

### DIFF
--- a/cypress/e2e/internal/billing/two-part-tariff/scenario-ten.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/scenario-ten.cy.js
@@ -1,0 +1,134 @@
+'use strict'
+
+describe('Testing a two-part tariff bill run with a similar licence to scenario one, licence is current and not in workflow, it has one applicable charge version with a single charge reference and one charge element. It has no matching returns', () => {
+  beforeEach(() => {
+    cy.tearDown()
+    cy.fixture('sroc-two-part-tariff-simple-licence-data.json').then((fixture) => {
+      // We set the isTwoPartTariff to false so the return, the return submission, and return lines don't get picked up
+      // by the engine
+      fixture.returnLogs[0].metadata.isTwoPartTariff = false
+
+      cy.load(fixture)
+    })
+    cy.fixture('users.json').its('billingAndData1').as('userEmail')
+
+    // Get the current date as a string, for example 12 July 2023
+    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
+      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
+    })
+  })
+
+  it('creates a SROC two-part tariff bill run and once built navigates through all the review pages checking the charge information', () => {
+    cy.visit('/')
+
+    // Enter the user name and password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    // Click the Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    // Assert the user signed in and we're on the search page
+    cy.contains('Search')
+
+    // Click the Bill runs menu link
+    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+
+    // Bill runs
+    // Click the Create a bill run button
+    cy.get('.govuk-button').contains('Create a bill run').click()
+
+    // Which kind of bill run do you want to create?
+    // Choose Two-part tariff then continue
+    cy.get('label.govuk-radios__label').contains('Two-part tariff').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Select the region
+    // Choose Test Region and continue
+    cy.get('label.govuk-radios__label').contains('Test Region').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Select the financial year
+    // Choose 2021 to 2022 and continue
+    cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
+    // seconds though so to avoid the test failing we use our custom Cypress command to look for the status REVIEW, and
+    // if not found reload the page and try again. We then select it using the link on the date created
+    cy.reloadUntilTextFound('[data-test="bill-run-status-0"] > .govuk-tag', 'review')
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+      cy.get('[data-test="date-created-0"]').should('contain.text', formattedCurrentDate)
+    })
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Two-part tariff')
+    cy.get('[data-test="date-created-0"] > .govuk-link').click()
+
+    // Review licences ~ Test its the correct bill run
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'review')
+    cy.get('h1').should('contain.text', 'Review licences')
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+      cy.get('[data-test="meta-data-created"]').should('contain.text', formattedCurrentDate)
+    })
+    cy.get('[data-test="meta-data-region"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="meta-data-type"]').should('contain.text', 'Two-part tariff')
+    cy.get('[data-test="meta-data-scheme"]').should('contain.text', 'Current')
+    cy.get('[data-test="meta-data-year"]').should('contain.text', '2022 to 2023')
+
+    // Review licences ~ Test you can filter by licence issue
+    cy.get('.govuk-details__summary').click()
+    cy.get('[data-test="aggregate-factor"]').click()
+    cy.contains('Apply filters').click()
+    cy.get('.govuk-table__caption').should('contain.text', 'Showing 0 of 1 licences')
+    cy.contains('Clear filters').click()
+
+    cy.get('.govuk-details__summary').click()
+    cy.get('[data-test="unable-to-match-return"]').click()
+    cy.contains('Apply filters').click()
+    cy.get('.govuk-table__caption').should('contain.text', 'Showing all 1 licences')
+    cy.contains('Clear filters').click()
+
+    // Review licences ~ Test it has the correct licence
+    cy.get('[data-test="licence-1"]').should('contain.text', 'AT/TEST/01')
+    cy.get('[data-test="licence-2"]').should('not.exist')
+    cy.get('[data-test="licence-holder-1"]').should('contain.text', 'Mr J J Testerson')
+    cy.get('[data-test="licence-issue-1"]').should('contain.text', 'Unable to match return')
+    cy.get('[data-test="licence-progress-1"]').should('contain.text', '')
+    // Licence should be a review status due to the "returns received but not processed" issue
+    cy.get('[data-test="licence-status-1"] > .govuk-tag').should('contain.text', 'review')
+    cy.get('[data-test="licence-1"] > .govuk-link').click()
+
+    // Review Licence AT/TEST/01 ~ Check the licence details
+    cy.get('h1').should('contain.text', 'Licence AT/TEST/01')
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'review')
+    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff bill run')
+    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
+
+    // Review Licence AT/TEST/01 ~ Check there are no returns
+    cy.get('h2.govuk-heading-m').should('contain.text', 'No two-part tariff returns')
+    cy.get('[data-test="matched-return-action-0"] > div').should('not.exist')
+    cy.get('[data-test="matched-return-summary-0"] > div').should('not.exist')
+    cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('not.exist')
+    cy.get('[data-test="unmatched-return-action-0"] > .govuk-link').should('not.exist')
+
+    // Review Licence AT/TEST/01 ~ Check charge Information details are correct for a licence with no returns
+    cy.get('[data-test="charge-version-0-total-billable-returns-0"]').should('contain.text', '0 ML / 32 ML')
+    // Without an aggregate of charge factor we shouldn't see the link "Change details" only "View details"
+    cy.get('[data-test="charge-version-0-charge-reference-link-0"]').should('contain.text', 'View details')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-issues-0"]').should('contain.text', 'Unable to match return')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-billable-returns-0"]').should('contain.text', '0 ML / 32 ML')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-return-volumes-0"]').should('contain.text', '')
+
+    // View match details
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
+    cy.get('[data-test="billable-returns"]').should('contain.text', '0ML')
+    cy.get('[data-test="authorised-volume"]').should('contain.text', '32ML')
+    cy.get('[data-test="issues-0"]').should('contain.text', 'Unable to match return')
+    cy.get('#main-content > :nth-child(6)').should('contain.text', 'No two-part tariff returns')
+    cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('not.exist')
+    cy.get('[data-test="matched-return-summary-0"]').should('not.exist')
+  })
+})

--- a/cypress/e2e/internal/billing/two-part-tariff/scenario-ten.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/scenario-ten.cy.js
@@ -97,7 +97,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="licence-holder-1"]').should('contain.text', 'Mr J J Testerson')
     cy.get('[data-test="licence-issue-1"]').should('contain.text', 'Unable to match return')
     cy.get('[data-test="licence-progress-1"]').should('contain.text', '')
-    // Licence should be a review status due to the "returns received but not processed" issue
+    // Licence should be a review status due to the "unable to match returns" issue
     cy.get('[data-test="licence-status-1"] > .govuk-tag').should('contain.text', 'review')
     cy.get('[data-test="licence-1"] > .govuk-link').click()
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4504

As the work for the two-part tariff engine and review pages is nearing completion, we are starting to create automated acceptance tests for the scenarios we mapped out at the beginning of this work. This PR focuses on Scenario Ten of our two-part tariff scenario spreadsheet which we used during the creation of our engine. This scenario involves having a licence with no matching returns. This should flag the 'Unable to match return' issue and nothing should be allocated.