### PR TITLE
Fix two-part tariff scenario nine

### DIFF
--- a/cypress/fixtures/sroc-two-part-tariff-scenario-nine.json
+++ b/cypress/fixtures/sroc-two-part-tariff-scenario-nine.json
@@ -8,7 +8,7 @@
       "regionCode": 9,
       "scheme": "sroc",
       "versionNumber": 100,
-      "startDate": "2022-04-01",
+      "startDate": "2022-03-31",
       "status": "current",
       "source": "wrls",
       "changeReasonId": {

--- a/cypress/fixtures/sroc-two-part-tariff-simple-licence-data.json
+++ b/cypress/fixtures/sroc-two-part-tariff-simple-licence-data.json
@@ -111,7 +111,7 @@
       "regionCode": 9,
       "scheme": "sroc",
       "versionNumber": 100,
-      "startDate": "2022-04-01",
+      "startDate": "2022-04-05",
       "status": "current",
       "source": "wrls",
       "changeReasonId": {

--- a/cypress/fixtures/sroc-two-part-tariff-simple-licence-data.json
+++ b/cypress/fixtures/sroc-two-part-tariff-simple-licence-data.json
@@ -111,7 +111,7 @@
       "regionCode": 9,
       "scheme": "sroc",
       "versionNumber": 100,
-      "startDate": "2022-04-05",
+      "startDate": "2022-04-01",
       "status": "current",
       "source": "wrls",
       "changeReasonId": {


### PR DESCRIPTION
When writing the acceptance test for scenario nine, we discovered inconsistencies in the order in which charge versions, charge references, charge elements, and returns were fetched across different environments. This discrepancy caused scenario nine tests to fail on some testers' machines because they expected the charge versions to appear in a specific order. We have updated the review pages to order all fetched data to address this consistently. This PR updates the scenario nine tests to reflect the new ordering, ensuring consistency in test results across all environments.