### PR TITLE
Scenario Eleven for the two-part tariff review pages

### DIFF
--- a/cypress/e2e/internal/billing/two-part-tariff/scenario-eleven.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/scenario-eleven.cy.js
@@ -1,0 +1,191 @@
+'use strict'
+
+describe('Testing a two-part tariff bill run with a similar licence to scenario one, licence is current and not in workflow, it has one applicable charge version with a single charge reference and two charge elements. The matching return for charge element one is over-abstracted and the matching return for charge element 2 is over-abstracted and abstracted outside the charge period', () => {
+  beforeEach(() => {
+    cy.tearDown()
+    cy.fixture('sroc-two-part-tariff-simple-licence-data.json').then((fixture) => {
+      // Update the charge reference volume to allow both elements to fully allocate
+      fixture.chargeReferences[0].volume = '64'
+      // Update the return submission line quantity to make it an over abstracted volume
+      fixture.returnSubmissionLines[0].quantity = '10000'
+      cy.load(fixture)
+    })
+
+    cy.fixture('sroc-two-part-tariff-scenario-eleven-data.json').then((fixture) => {
+      cy.load(fixture)
+    })
+
+    cy.fixture('users.json').its('billingAndData1').as('userEmail')
+
+    // Get the current date as a string, for example 12 July 2023
+    cy.dayMonthYearFormattedDate().then((formattedCurrentDate) => {
+      cy.wrap(formattedCurrentDate).as('formattedCurrentDate')
+    })
+  })
+
+  it('creates a SROC two-part tariff bill run and once built navigates through all the review pages checking the matched returns and the allocated quantities', () => {
+    cy.visit('/')
+
+    // Enter the user name and password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('input#email').type(userEmail)
+    })
+
+    cy.get('input#password').type(Cypress.env('defaultPassword'))
+
+    // Click the Sign in Button
+    cy.get('.govuk-button.govuk-button--start').click()
+
+    // Assert the user signed in and we're on the search page
+    cy.contains('Search')
+
+    // Click the Bill runs menu link
+    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+
+    // Bill runs
+    // Click the Create a bill run button
+    cy.get('.govuk-button').contains('Create a bill run').click()
+
+    // Which kind of bill run do you want to create?
+    // Choose Two-part tariff then continue
+    cy.get('label.govuk-radios__label').contains('Two-part tariff').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Select the region
+    // Choose Test Region and continue
+    cy.get('label.govuk-radios__label').contains('Test Region').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Select the financial year
+    // Choose 2021 to 2022 and continue
+    cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
+    cy.get('form > .govuk-button').contains('Continue').click()
+
+    // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
+    // seconds though so to avoid the test failing we use our custom Cypress command to look for the status REVIEW, and
+    // if not found reload the page and try again. We then select it using the link on the date created
+    cy.reloadUntilTextFound('[data-test="bill-run-status-0"] > .govuk-tag', 'review')
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+      cy.get('[data-test="date-created-0"]').should('contain.text', formattedCurrentDate)
+    })
+    cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Two-part tariff')
+    cy.get('[data-test="date-created-0"] > .govuk-link').click()
+
+    // Review licences ~ Test its the correct bill run
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'review')
+    cy.get('h1').should('contain.text', 'Review licences')
+    cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
+      cy.get('[data-test="meta-data-created"]').should('contain.text', formattedCurrentDate)
+    })
+    cy.get('[data-test="meta-data-region"]').should('contain.text', 'Test Region')
+    cy.get('[data-test="meta-data-type"]').should('contain.text', 'Two-part tariff')
+    cy.get('[data-test="meta-data-scheme"]').should('contain.text', 'Current')
+    cy.get('[data-test="meta-data-year"]').should('contain.text', '2022 to 2023')
+
+    // Review licences ~ Test you can filter by licence issue
+    cy.get('.govuk-details__summary').click()
+    cy.get('[data-test="aggregate-factor"]').click()
+    cy.contains('Apply filters').click()
+    cy.get('.govuk-table__caption').should('contain.text', 'Showing 0 of 1 licences')
+    cy.contains('Clear filters').click()
+
+    cy.get('.govuk-details__summary').click()
+    cy.get('[data-test="abs-outside-period"]').click()
+    cy.get('[data-test="over-abstraction"]').click()
+    cy.contains('Apply filters').click()
+    cy.get('.govuk-table__caption').should('contain.text', 'Showing all 1 licences')
+    cy.contains('Clear filters').click()
+
+    // Review licences ~ Test it has the correct licence
+    cy.get('[data-test="licence-1"]').should('contain.text', 'AT/TEST/01')
+    cy.get('[data-test="licence-2"]').should('not.exist')
+    cy.get('[data-test="licence-holder-1"]').should('contain.text', 'Mr J J Testerson')
+    cy.get('[data-test="licence-issue-1"]').should('contain.text', 'Multiple Issues')
+    cy.get('[data-test="licence-progress-1"]').should('contain.text', '')
+    // Licence should be a 'ready' status since none of the issues have a 'review' status
+    cy.get('[data-test="licence-status-1"] > .govuk-tag').should('contain.text', 'ready')
+    cy.get('[data-test="licence-1"] > .govuk-link').click()
+
+    // Review Licence AT/TEST/01 ~ Check the licence details
+    cy.get('h1').should('contain.text', 'Licence AT/TEST/01')
+    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
+    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff bill run')
+    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
+
+    // Review Licence AT/TEST/01 ~ Check the first matched return details
+    cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
+    cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
+    cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
+    // When a return is over abstracted the return should still allocate up to the charge element volume or
+    // charge reference volume whichever is lower. It should not allocate the 'over-abstracted' amount
+    cy.get('[data-test="matched-return-total-0"]').should('contain.text', '32 ML / 38 ML')
+    cy.get('[data-test="matched-return-total-0"]').should('contain.text', 'Over abstraction')
+
+    // Review Licence AT/TEST/01 ~ Check the second matched return details
+    cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
+    cy.get('[data-test="matched-return-action-1"] > .govuk-link').should('contain.text', '10021669')
+    cy.get('[data-test="matched-return-action-1"] > div').should('contain.text', '1 May 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-summary-1"] > div').should('contain.text', 'Mineral Washing')
+    cy.get('[data-test="matched-return-status-1"] > .govuk-tag').should('contain.text', 'completed')
+    // When a return is over abstracted the return should still allocate up to the charge element volume or
+    // charge reference volume whichever is lower. It should not allocate the 'over-abstracted' amount
+    cy.get('[data-test="matched-return-total-1"]').should('contain.text', '30 ML / 36 ML')
+    cy.get('[data-test="matched-return-total-1"]').should('contain.text', 'Abstraction outside period')
+    cy.get('[data-test="matched-return-total-1"]').should('contain.text', 'Over abstraction')
+
+    // Review Licence AT/TEST/01 ~ Check there are no other returns
+    cy.get('[data-test="matched-return-action-2"] > .govuk-link').should('not.exist')
+    cy.get('[data-test="unmatched-return-action-0"] > .govuk-link').should('not.exist')
+
+    // Review Licence AT/TEST/01 ~ Check charge Information details are correct for a licence with returns that are over
+    // abstracted
+    cy.get('[data-test="charge-version-0-total-billable-returns-0"]').should('contain.text', '62 ML / 64 ML')
+    // Without an aggregate of charge factor we shouldn't see the link "Change details" only "View details"
+    cy.get('[data-test="charge-version-0-charge-reference-link-0"]').should('contain.text', 'View details')
+    cy.get('[data-test="charge-version-0-details"]').should('contain.text', '1 charge reference  with 2 two-part tariff charge elements')
+    // Charge element 1
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', 'SROC Charge Purpose 01')
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', 'General Farming & Domestic')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-issues-0"]').should('contain.text', '')
+    cy.get(':nth-child(2) > .float-right > .govuk-tag').should('contain.text', 'ready')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-billable-returns-0"]').should('contain.text', '32 ML / 32 ML')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-return-volumes-0"]').should('contain.text', '38 ML (10021668)')
+    // Charge element 2
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-1"]').should('contain.text', 'SROC Charge Purpose 02')
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-1"]').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-1"]').should('contain.text', 'Mineral Washing')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-issues-1"]').should('contain.text', '')
+    cy.get(':nth-child(3) > .float-right > .govuk-tag').should('contain.text', 'ready')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-billable-returns-1"]').should('contain.text', '30 ML / 30 ML')
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-return-volumes-1"]').should('contain.text', '36 ML (10021669)')
+
+    // View match details ~ Charge element 1
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
+    cy.get('[data-test="billable-returns"]').should('contain.text', '32ML')
+    cy.get('[data-test="authorised-volume"]').should('contain.text', '32ML')
+    cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-summary-0"]').contains('General Farming & Domestic A DRAIN SOMEWHERE')
+    cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
+    cy.get('[data-test="matched-return-total-0"] > :nth-child(1)').should('contain.text', '32 ML / 38 ML')
+    cy.get('[data-test="matched-return-total-0"] > :nth-child(2)').should('contain.text', 'Over abstraction')
+    cy.get('.govuk-back-link').click()
+
+    // View match details ~ Charge element 2
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-1"]').click()
+    cy.get('[data-test="billable-returns"]').should('contain.text', '30ML')
+    cy.get('[data-test="authorised-volume"]').should('contain.text', '30ML')
+    cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021669')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 May 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-summary-0"]').contains('Mineral Washing A DRAIN SOMEWHERE')
+    cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
+    cy.get('[data-test="matched-return-total-0"] > :nth-child(1)').should('contain.text', '30 ML / 36 ML')
+    cy.get('[data-test="matched-return-total-0"] > :nth-child(2)').should('contain.text', 'Abstraction outside period')
+    cy.get('[data-test="matched-return-total-0"] > :nth-child(3)').should('contain.text', 'Over abstraction')
+    cy.get('.govuk-back-link').click()
+  })
+})

--- a/cypress/fixtures/sroc-two-part-tariff-scenario-eleven-data.json
+++ b/cypress/fixtures/sroc-two-part-tariff-scenario-eleven-data.json
@@ -1,0 +1,148 @@
+{
+  "chargeElements": [
+    {
+      "id": "6163e393-a466-4fd9-ae1e-721db6d1c81f",
+      "chargeReferenceId": "fa3c73d0-0459-41f0-b6cf-0e0758775ca4",
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 4,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 3,
+      "authorisedAnnualQuantity": 30,
+      "section127Agreement": true,
+      "description": "SROC Charge Purpose 02",
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "300",
+        "select": "id"
+      },
+      "purposePrimaryId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "purposeSecondaryId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      }
+    }
+  ],
+  "returnLogs": [
+    {
+      "id": "v1:1:AT/TEST/01:10021669:2022-05-01:2023-03-31",
+      "returnReference": "10021669",
+      "licenceRef": "AT/TEST/01",
+      "metadata": {
+        "description": "A DRAIN SOMEWHERE",
+        "purposes": [
+          {
+            "primary": {
+              "code": "A",
+              "description": "Agriculture"
+            },
+            "tertiary": {
+              "code": "300",
+              "description": "Mineral Washing"
+            },
+            "secondary": {
+              "code": "AGR",
+              "description": "General Agriculture"
+            }
+          }
+        ],
+        "isTwoPartTariff": true,
+        "nald": {
+          "periodStartDay": "1",
+          "periodStartMonth": "3",
+          "periodEndDay": "31",
+          "periodEndMonth": "10"
+        }
+      },
+      "startDate": "2022-05-01",
+      "endDate": "2023-03-21",
+      "receivedDate": "2023-03-01",
+      "dueDate": "2023-04-28",
+      "status": "completed",
+      "underQuery": false
+    }
+  ],
+  "returnSubmissions": [
+    {
+      "id": "615251b9-eac9-40db-9212-ee4b7260a3a9",
+      "returnLogId": "v1:1:AT/TEST/01:10021669:2022-05-01:2023-03-31",
+      "nilReturn": false,
+      "current": true
+    }
+  ],
+  "returnSubmissionLines": [
+    {
+      "id": "171f3b9a-5c82-4fed-983e-5e1b5c5891d8",
+      "returnSubmissionId": "615251b9-eac9-40db-9212-ee4b7260a3a9",
+      "startDate": "2022-04-01",
+      "endDate": "2022-04-30",
+      "quantity": "4000"
+    },
+    {
+      "id": "309d8134-67a7-4ada-adec-73b8365e0979",
+      "returnSubmissionId": "615251b9-eac9-40db-9212-ee4b7260a3a9",
+      "startDate": "2022-05-01",
+      "endDate": "2022-05-31",
+      "quantity": "4000"
+    },
+    {
+      "id": "ea7a351e-961b-4438-b2b8-b25fed91bc91",
+      "returnSubmissionId": "615251b9-eac9-40db-9212-ee4b7260a3a9",
+      "startDate": "2022-06-01",
+      "endDate": "2022-06-30",
+      "quantity": "4000"
+    },
+    {
+      "id": "3936f4a8-a830-43a7-8d7c-a069fa4f1e33",
+      "returnSubmissionId": "615251b9-eac9-40db-9212-ee4b7260a3a9",
+      "startDate": "2022-07-01",
+      "endDate": "2022-07-31",
+      "quantity": "4000"
+    },
+    {
+      "id": "14ffd710-cc22-486b-8cc0-e81dd13dda9f",
+      "returnSubmissionId": "615251b9-eac9-40db-9212-ee4b7260a3a9",
+      "startDate": "2022-08-01",
+      "endDate": "2022-08-31",
+      "quantity": "4000"
+    },
+    {
+      "id": "64397807-92dd-45c4-8212-01e2f9f3d5db",
+      "returnSubmissionId": "615251b9-eac9-40db-9212-ee4b7260a3a9",
+      "startDate": "2022-09-01",
+      "endDate": "2022-09-30",
+      "quantity": "4000"
+    },
+    {
+      "id": "b18a757d-95bf-4c4a-b71d-c2cb05d09383",
+      "returnSubmissionId": "615251b9-eac9-40db-9212-ee4b7260a3a9",
+      "startDate": "2022-10-01",
+      "endDate": "2022-10-31",
+      "quantity": "4000"
+    },
+    {
+      "id": "f658175a-a0a1-4f01-8104-d63bb19c5f62",
+      "returnSubmissionId": "615251b9-eac9-40db-9212-ee4b7260a3a9",
+      "startDate": "2022-11-01",
+      "endDate": "2022-11-30",
+      "quantity": "4000"
+    },
+    {
+      "id": "aa044a57-133d-4e32-8310-04049975bdfb",
+      "returnSubmissionId": "615251b9-eac9-40db-9212-ee4b7260a3a9",
+      "startDate": "2023-03-01",
+      "endDate": "2023-03-31",
+      "quantity": "4000"
+    }
+  ]
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4506

As the work for the two-part tariff engine and review pages is nearing completion, we are starting to create automated acceptance tests for the scenarios we mapped out at the beginning of this work. This PR focuses on Scenario Eleven of our two-part tariff scenario spreadsheet which we used during the creation of our engine. This scenario involves having a licence with returns that have over-abstracted and abstracted outside the charge period. This should flag the 'Over abstraction' and 'Abstraction outside period 'issues and the over-abstracted amount should not be allocated.