### PR TITLE
Fix two-part tariff scenario one acceptance test

### DIFF
--- a/cypress/e2e/internal/billing/two-part-tariff/scenario-one.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/scenario-one.cy.js
@@ -113,9 +113,9 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
 
     // Review Licence AT/TEST/01 ~ Check the Licence links
-    cy.get('[data-test="summary-link"] > .govuk-link').should('exist')
-    cy.get('[data-test="returns-link"] > .govuk-link').should('exist')
-    cy.get('[data-test="charge-information-link"] > .govuk-link').should('exist')
+    cy.get('[data-test="summary-link"]').should('exist')
+    cy.get('[data-test="returns-link"]').should('exist')
+    cy.get('[data-test="charge-information-link"]').should('exist')
     cy.get('[data-test="charge-period-0"]').should('exist')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('exist')
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4450

During a change to the [licence review page](https://github.com/DEFRA/water-abstraction-system/pull/1139) for the two-part tariff review process, all links that direct a user to view the licence were changed along with their data test attributes. This change broke scenario one of the acceptance tests, as the test is looking for a specific tag to check that the links exist. This PR is updating the acceptance test to look for the new tags.