### PR TITLE
Update acceptance tests to new view licence page

### DIFF
--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
@@ -138,11 +138,11 @@ describe('Change billing account in current financial year (internal)', () => {
     cy.get('.search__button').click()
     cy.get('.govuk-table__row > :nth-child(1) > a').click()
 
-    // click the Charge information link
-    cy.get('#tab_charge').click()
+    // click the licence set up tab
+    cy.contains('Licence set up').click()
 
     // set up a new charge for the current financial year to change the billing account
-    cy.get('#charge > a.govuk-button').contains('Set up a new charge').click()
+    cy.contains('Set up a new charge').click()
     cy.get('.govuk-radios > :nth-child(1) > #reason').click()
     cy.get('form > .govuk-button').click()
 
@@ -204,7 +204,7 @@ describe('Change billing account in current financial year (internal)', () => {
     cy.get('.govuk-button').contains('Continue').click()
 
     // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    cy.contains('Bill runs').click()
 
     // Bill runs
     // click the Create a bill run button

--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
@@ -140,11 +140,11 @@ describe('Change billing account in previous financial year (internal)', () => {
     cy.get('.search__button').click()
     cy.get('.govuk-table__row > :nth-child(1) > a').click()
 
-    // click the Charge information link
-    cy.get('#tab_charge').click()
+    // click the licence set up tab
+    cy.contains('Licence set up').click()
 
     // set up a new charge for the previous financial year to change the billing account
-    cy.get('#charge > a.govuk-button').contains('Set up a new charge').click()
+    cy.contains('Set up a new charge').click()
     cy.get('.govuk-radios > :nth-child(1) > #reason').click()
     cy.get('form > .govuk-button').click()
 
@@ -206,7 +206,7 @@ describe('Change billing account in previous financial year (internal)', () => {
     cy.get('.govuk-button').contains('Continue').click()
 
     // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    cy.contains('Bill runs').click()
 
     // Bill runs
     // click the Create a bill run button

--- a/cypress/e2e/internal/billing/supplementary/non-charge-licence-credit.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/non-charge-licence-credit.cy.js
@@ -112,10 +112,10 @@ describe('Make licence non-chargeable then see credit in next bill run (internal
     cy.get('.govuk-table__row').contains('AT/TEST/02').click()
 
     // Charge information
-    // confirm we are on the licence page and select charge information tab. Then click to make the licence
+    // confirm we are on the licence page and select licence set up tab. Then click to make the licence
     // non-chargeable
     cy.contains('AT/TEST/02')
-    cy.get('#tab_charge').click()
+    cy.contains('Licence set up').click()
     cy.get('.govuk-button').contains('Make licence non-chargeable').click()
 
     // Why is this licence not chargeable?
@@ -147,7 +147,7 @@ describe('Make licence non-chargeable then see credit in next bill run (internal
 
     // Charge information
     // select to review it
-    cy.get('#charge > table > tbody > tr:nth-child(1) > td:nth-child(5) > a').contains('Review').click()
+    cy.contains('Review').click()
 
     // Check charge information
     // approve the new charge version
@@ -158,19 +158,17 @@ describe('Make licence non-chargeable then see credit in next bill run (internal
     // Charge information
     // confirm our new charge information is APPROVED and that the licence has been flagged for the next supplementary
     // bill run
-    cy.get('#charge > table > tbody > tr:nth-child(1)').within(() => {
-      cy.get('td:nth-child(4) > strong').should('contain.text', 'Approved')
-    })
+    cy.contains('Review').should('not.exist')
 
     // -------------------------------------------------------------------------
     cy.log('Create the second SROC supplementary bill run and confirm credit generated')
 
     // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    cy.contains('Bill runs').click()
 
     // Bill runs
     // click the Create a bill run button
-    cy.get('.govuk-button').contains('Create a bill run').click()
+    cy.contains('Create a bill run').click()
 
     // Which kind of bill run do you want to create?
     // choose Supplementary and continue

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
@@ -61,11 +61,11 @@ describe('Replace charge version in the 2023 financial year with no changes (int
     cy.get('.search__button').click()
     cy.get('.govuk-table__row > :nth-child(1) > a').click()
 
-    // click the Charge information link
-    cy.get('#tab_charge').click()
+    // click the licence set up tab
+    cy.contains('Licence set up').click()
 
     // set up a new replacement charge making no changes. This will correct the issue with the billing account
-    cy.get('#charge > a.govuk-button').contains('Set up a new charge').click()
+    cy.contains('Set up a new charge').click()
     cy.get('#reason-8').click()
     cy.get('form > .govuk-button').click()
 
@@ -122,7 +122,7 @@ describe('Replace charge version in the 2023 financial year with no changes (int
     cy.log('Creating, confirming and sending the SROC supplementary bill run')
 
     // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    cy.contains('Bill runs').click()
 
     // Bill runs
     // click the Create a bill run button
@@ -217,11 +217,11 @@ describe('Replace charge version in the 2023 financial year with no changes (int
     cy.get('.search__button').click()
     cy.get('.govuk-table__row > :nth-child(1) > a').click()
 
-    // click the Charge information link
-    cy.get('#tab_charge').click()
+    // click the licence set up tab
+    cy.contains('Licence set up').click()
 
     // set up a new charge for the 2023 financial year that doesn't change anything
-    cy.get('#charge > a.govuk-button').contains('Set up a new charge').click()
+    cy.contains('Set up a new charge').click()
     cy.get('#reason-8').click()
     cy.get('form > .govuk-button').click()
 
@@ -261,7 +261,7 @@ describe('Replace charge version in the 2023 financial year with no changes (int
     cy.get('.govuk-button').contains('Continue').click()
 
     // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    cy.contains('Bill runs').click()
 
     // Bill runs
     // click the Create a bill run button

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
@@ -61,11 +61,11 @@ describe('Replace charge version in current financial year change the charge ref
     cy.get('.search__button').click()
     cy.get('.govuk-table__row > :nth-child(1) > a').click()
 
-    // click the Charge information link
-    cy.get('#tab_charge').click()
+    // click the licence set up tab
+    cy.contains('Licence set up').click()
 
     // set up a new replacement charge making no changes. This will correct the issue with the billing account
-    cy.get('#charge > a.govuk-button').contains('Set up a new charge').click()
+    cy.contains('Set up a new charge').click()
     cy.get('#reason-8').click()
     cy.get('form > .govuk-button').click()
 
@@ -122,7 +122,7 @@ describe('Replace charge version in current financial year change the charge ref
     cy.log('Creating, confirming and sending the SROC supplementary bill run')
 
     // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    cy.contains('Bill runs').click()
 
     // Bill runs
     // click the Create a bill run button
@@ -217,11 +217,11 @@ describe('Replace charge version in current financial year change the charge ref
     cy.get('.search__button').click()
     cy.get('.govuk-table__row > :nth-child(1) > a').click()
 
-    // click the Charge information link
-    cy.get('#tab_charge').click()
+    // click the licence set up tab
+    cy.contains('Licence set up').click()
 
     // set up a new charge for the current FY changing the charge and adding adjustments and additional charges
-    cy.get('#charge > a.govuk-button').contains('Set up a new charge').click()
+    cy.contains('Set up a new charge').click()
     cy.get('#reason-8').click()
     cy.get('form > .govuk-button').click()
 
@@ -310,7 +310,7 @@ describe('Replace charge version in current financial year change the charge ref
     cy.get('.govuk-button').contains('Continue').click()
 
     // click the Bill runs menu link
-    cy.get('#navbar-bill-runs').contains('Bill runs').click()
+    cy.contains('Bill runs').click()
 
     // Bill runs
     // click the Create a bill run button

--- a/cypress/e2e/internal/charge-information/presroc/licence-transfer.cy.js
+++ b/cypress/e2e/internal/charge-information/presroc/licence-transfer.cy.js
@@ -28,13 +28,13 @@ describe('PRESROC licence transfer (internal)', () => {
     cy.contains('Licences')
     cy.get('.govuk-table__row').contains('AT/CURR/DAILY/01').click()
 
-    // Confirm we are on the licence page and select charge information tab
+    // Confirm we are on the licence page and select licence set up tab
     cy.contains('AT/CURR/DAILY/01')
-    cy.get('#tab_charge').click()
+    cy.contains('Licence set up').click()
 
     // Confirm we are on the tab page and then click Set up a new charge
-    cy.get('#charge > .govuk-heading-l').contains('Charge information')
-    cy.get('#charge').contains('Set up a new charge').click()
+    cy.contains('Licence set up')
+    cy.contains('Set up a new charge').click()
 
     // Select reason for new charge information
     // choose Licence transferred and now chargeable and continue
@@ -146,7 +146,7 @@ describe('PRESROC licence transfer (internal)', () => {
 
     // Charge information
     // select to review it
-    cy.get('#charge > table > tbody > tr:nth-child(1) > td:nth-child(5) > a').contains('Review').click()
+    cy.contains('Review').click()
 
     // Check charge information
     // approve the new charge version
@@ -157,9 +157,8 @@ describe('PRESROC licence transfer (internal)', () => {
     // Charge information
     // confirm our new charge information is APPROVED and that the licence has been flagged for the next supplementary
     // bill run
-    cy.get('#charge > table > tbody > tr:nth-child(1)').within(() => {
-      cy.get('td:nth-child(4) > strong').should('contain.text', 'Approved')
-    })
+    cy.contains('Review').should('not.exist')
+
     cy.get('.govuk-notification-banner__content')
       .should('contain.text', 'This licence has been marked for the next supplementary bill run for the old charge scheme.')
   })

--- a/cypress/e2e/internal/charge-information/sroc/journey.cy.js
+++ b/cypress/e2e/internal/charge-information/sroc/journey.cy.js
@@ -28,13 +28,13 @@ describe('SROC charge information journey (internal)', () => {
     cy.contains('Licences')
     cy.get('.govuk-table__row').contains('AT/CURR/DAILY/01').click()
 
-    // Confirm we are on the licence page and select charge information tab
+    // Confirm we are on the licence page and select the licence set up tab
     cy.contains('AT/CURR/DAILY/01')
-    cy.get('#tab_charge').click()
+    cy.contains('Licence set up').click()
 
     // Confirm we are on the tab page and then click Set up a new charge
-    cy.get('#charge > .govuk-heading-l').contains('Charge information')
-    cy.get('#charge').contains('Set up a new charge').click()
+    cy.contains('Charge information')
+    cy.contains('Set up a new charge').click()
 
     // Select reason for new charge information
     // choose Strategic review of charges (SRoC) and continue
@@ -200,7 +200,7 @@ describe('SROC charge information journey (internal)', () => {
 
     // Charge information
     // select to review it
-    cy.get('#charge > table > tbody > tr:nth-child(1) > td:nth-child(5) > a').contains('Review').click()
+    cy.contains('Review').click()
 
     // Check charge information
     // approve the new charge version
@@ -211,9 +211,8 @@ describe('SROC charge information journey (internal)', () => {
     // Charge information
     // confirm our new charge information is APPROVED and that the licence has been flagged for the next supplementary
     // bill run
-    cy.get('#charge > table > tbody > tr:nth-child(1)').within(() => {
-      cy.get('td:nth-child(4) > strong').should('contain.text', 'Approved')
-    })
+    cy.contains('Review').should('not.exist')
+
     cy.get('.govuk-notification-banner__content')
       .should('contain.text', 'This licence has been marked for the next supplementary bill run.')
   })

--- a/cypress/e2e/internal/charge-information/sroc/validation.cy.js
+++ b/cypress/e2e/internal/charge-information/sroc/validation.cy.js
@@ -28,13 +28,13 @@ describe('SROC charge information validation (internal)', () => {
     cy.contains('Licences')
     cy.get('.govuk-table__row').contains('AT/CURR/DAILY/01').click()
 
-    // Confirm we are on the licence page and select charge information tab
+    // Confirm we are on the licence page and select the licence set up tab
     cy.contains('AT/CURR/DAILY/01')
-    cy.get('#tab_charge').click()
+    cy.contains('Licence set up').click()
 
     // Confirm we are on the tab page and then click Set up a new charge
-    cy.get('#charge > .govuk-heading-l').contains('Charge information')
-    cy.get('#charge').contains('Set up a new charge').click()
+    cy.contains('Charge information')
+    cy.contains('Set up a new charge').click()
 
     // Select reason for new charge information
     // test submitting nothing
@@ -348,8 +348,6 @@ describe('SROC charge information validation (internal)', () => {
 
     // Charge information
     // confirm our new charge information is in REVIEW
-    cy.get('#charge > table > tbody > tr:nth-child(1)').within(() => {
-      cy.get('td:nth-child(4) > strong').should('contain.text', 'Review')
-    })
+    cy.contains('Review')
   })
 })

--- a/cypress/e2e/internal/licence-agreements/delete-licence-agreement.cy.js
+++ b/cypress/e2e/internal/licence-agreements/delete-licence-agreement.cy.js
@@ -32,8 +32,8 @@ describe('Delete licence agreement journey (internal)', () => {
     // cypress/e2e/internal/licence-agreements/new-licence-agreement.cy.js. But for this test we have to use the UI to
     // create a record to then delete it. So, the following also creates a new licence agreement but we strip out the
     // checks and assertions for brevity
-    cy.get('#tab_charge').click()
-    cy.get('#charge').contains('Set up a new agreement').click()
+    cy.contains('Licence set up').click()
+    cy.contains('Set up a new agreement').click()
     cy.get('#financialAgreementCode-3').check()
     cy.get('form > .govuk-button').click()
     cy.get('#isDateSignedKnown-2').check()
@@ -47,8 +47,8 @@ describe('Delete licence agreement journey (internal)', () => {
 
     // Charge information
     // back on the Charge Information tab select to delete the licence
-    cy.get('#charge').should('be.visible')
-    cy.get('#charge > table:nth-child(8) > tbody > tr > td:nth-child(5) > a:nth-child(1)').click()
+    cy.get('#set-up').should('be.visible')
+    cy.contains('Delete').click()
 
     // You're about to delete this agreement
     // confirm we are on the right page and it is showing the right agreement then delete it
@@ -64,11 +64,15 @@ describe('Delete licence agreement journey (internal)', () => {
       // end date
       cy.get('td:nth-child(4)').should('contain.text', ' ')
     })
-    cy.get('form > .govuk-button').contains('Delete agreement').click()
+    cy.contains('Delete').click()
+
+    // confirm we are on the delete agreement page and click delete agreement
+    cy.get('.govuk-heading-l').contains("You're about to delete this agreement")
+    cy.contains('Delete agreement').click()
 
     // Charge information
     // confirm we are back on the Charge Information tab and our licence agreement is no longer present
-    cy.get('#charge').should('be.visible')
-    cy.get('#charge > p').should('contain.text', 'No agreements for this licence.')
+    cy.get('#set-up').should('be.visible')
+    cy.should('contain.text', 'No agreements for this licence.')
   })
 })

--- a/cypress/e2e/internal/licence-agreements/end-licence-agreement.cy.js
+++ b/cypress/e2e/internal/licence-agreements/end-licence-agreement.cy.js
@@ -32,8 +32,8 @@ describe('End licence agreement journey (internal)', () => {
     // cypress/e2e/internal/licence-agreements/new-licence-agreement.cy.js. But for this test we have to use the UI to
     // create a record to then end it. So, the following also creates a new licence agreement but we strip out the
     // checks and assertions for brevity
-    cy.get('#tab_charge').click()
-    cy.get('#charge').contains('Set up a new agreement').click()
+    cy.contains('Licence set up').click()
+    cy.contains('Set up a new agreement').click()
     cy.get('#financialAgreementCode-3').check()
     cy.get('form > .govuk-button').click()
     cy.get('#isDateSignedKnown-2').check()
@@ -47,8 +47,8 @@ describe('End licence agreement journey (internal)', () => {
 
     // Charge information
     // back on the Charge Information tab select to end the licence
-    cy.get('#charge').should('be.visible')
-    cy.get('#charge > table:nth-child(8) > tbody > tr > td:nth-child(5) > a:nth-child(2)').click()
+    cy.get('#set-up').should('be.visible')
+    cy.get(':nth-child(12) > .govuk-table__body > .govuk-table__row > :nth-child(5)').contains('End').click()
 
     // Set agreement end date
     // first check the validation for invalid dates is working
@@ -79,21 +79,22 @@ describe('End licence agreement journey (internal)', () => {
     cy.get('form > .govuk-button').contains('End agreement').click()
 
     // Charge information
-    // confirm we are back on the Charge Information tab and our licence agreement is present with an end date and only
+    // confirm we are back on the licence set up tab and our licence agreement is present with an end date and only
     // the delete action available
-    cy.get('#charge').should('be.visible')
-    cy.get('#charge > table:nth-child(8) > tbody > tr').within(() => {
+    cy.get('#set-up').should('be.visible')
+
+    cy.get(':nth-child(12) > .govuk-table__body > .govuk-table__row').within(() => {
       // start date
-      cy.get('td:nth-child(1)').should('contain.text', '1 January 2018')
+      cy.get(':nth-child(1)').should('contain.text', '1 January 2018')
       // end date
-      cy.get('td:nth-child(2)').should('contain.text', '31 March 2022')
+      cy.get(':nth-child(2)').should('contain.text', '31 March 2022')
       // agreement
-      cy.get('td:nth-child(3)').should('contain.text', 'Canal and Rivers Trust, unsupported source (S130U)')
+      cy.get(':nth-child(3)').should('contain.text', 'Canal and Rivers Trust, unsupported source (S130U)')
       // date signed
-      cy.get('td:nth-child(4)').should('contain.text', ' ')
+      cy.get(':nth-child(4)').should('contain.text', '')
       // actions
-      cy.get('td:nth-child(5) > a:nth-child(1)').should('contain.text', 'Delete')
-      cy.get('td:nth-child(5) > a:nth-child(2)').should('not.exist')
+      cy.get(':nth-child(5) > a:nth-child(1)').should('contain.text', 'Delete')
+      cy.get(':nth-child(5) > a:nth-child(2)').should('not.exist')
     })
   })
 })

--- a/cypress/e2e/internal/licence-agreements/new-licence-agreement.cy.js
+++ b/cypress/e2e/internal/licence-agreements/new-licence-agreement.cy.js
@@ -28,13 +28,13 @@ describe('New licence agreement journey (internal)', () => {
     cy.contains('Licences')
     cy.get('.govuk-table__row').contains('AT/CURR/DAILY/01').click()
 
-    // Confirm we are on the licence page and select charge information tab
+    // Confirm we are on the licence page and select the licence set up tab
     cy.contains('AT/CURR/DAILY/01')
-    cy.get('#tab_charge').click()
+    cy.contains('Licence set up').click()
 
     // Confirm we are on the tab page and then click Set up a new agreement
-    cy.get('#charge > .govuk-heading-l').contains('Charge information')
-    cy.get('#charge').contains('Set up a new agreement').click()
+    cy.contains('Charge information')
+    cy.contains('Set up a new agreement').click()
 
     // Select agreement
     // select Canal and Rivers Trust, unsupported source (S130U) then continue
@@ -63,19 +63,20 @@ describe('New licence agreement journey (internal)', () => {
 
     // Charge information
     // confirm we are back on the Charge Information tab and our licence agreement is present
-    cy.get('#charge').should('be.visible')
-    cy.get('#charge > table:nth-child(8) > tbody > tr').within(() => {
+    cy.get('#set-up').should('be.visible')
+
+    cy.get(':nth-child(12) > .govuk-table__body > .govuk-table__row').within(() => {
       // start date
-      cy.get('td:nth-child(1)').should('contain.text', '1 January 2018')
+      cy.get(':nth-child(1)').should('contain.text', '1 January 2018')
       // end date
-      cy.get('td:nth-child(2)').should('contain.text', ' ')
+      cy.get(':nth-child(2)').should('contain.text', '')
       // agreement
-      cy.get('td:nth-child(3)').should('contain.text', 'Canal and Rivers Trust, unsupported source (S130U)')
+      cy.get(':nth-child(3)').should('contain.text', 'Canal and Rivers Trust, unsupported source (S130U)')
       // date signed
-      cy.get('td:nth-child(4)').should('contain.text', ' ')
+      cy.get(':nth-child(4)').should('contain.text', '')
       // actions
-      cy.get('td:nth-child(5) > a:nth-child(1)').should('contain.text', 'Delete')
-      cy.get('td:nth-child(5) > a:nth-child(2)').should('contain.text', 'End')
+      cy.get(':nth-child(5) > a:nth-child(1)').should('contain.text', 'Delete')
+      cy.get(':nth-child(5) > a:nth-child(2)').should('contain.text', 'End')
     })
   })
 })

--- a/cypress/e2e/internal/returns-requirements/abstraction-data.cy.js
+++ b/cypress/e2e/internal/returns-requirements/abstraction-data.cy.js
@@ -32,15 +32,15 @@ describe('Submit returns requirement (internal) using abstraction data', () => {
     cy.get('.search__button').click()
     cy.get('.govuk-table__row > :nth-child(1) > a').click()
 
-    // confirm we are on the licence page and select charge information tab
+    // confirm we are on the licence page and select licence set up tab
     cy.contains('AT/TEST/01')
-    cy.get('#tab_charge').click()
+    cy.contains('Licence set up').click()
 
-    // confirm we are on the charge information tab
-    cy.get('#charge > :nth-child(1)').contains('Charge information')
+    // confirm we are on the licence set up tab
+    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
 
-    // click set up new returns requirement
-    cy.contains('Set up new returns requirement').click()
+    // click set up new requirements
+    cy.contains('Set up new requirements').click()
 
     // choose the licence version start date and click continue
     cy.get('#licence-start-date').check()
@@ -177,7 +177,7 @@ describe('Submit returns requirement (internal) using abstraction data', () => {
     // click link to return to licence set up
     cy.contains('Return to licence set up').click()
 
-    // confirm we are on the charge information tab
-    cy.get('#charge').contains('Charge information')
+    // confirm we are on the licence set up tab
+    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
   })
 })

--- a/cypress/e2e/internal/returns-requirements/cancel-returns.cy.js
+++ b/cypress/e2e/internal/returns-requirements/cancel-returns.cy.js
@@ -32,15 +32,15 @@ describe('Cancel a return requirement (internal)', () => {
     cy.get('.search__button').click()
     cy.get('.govuk-table__row > :nth-child(1) > a').click()
 
-    // confirm we are on the licence page and select charge information tab
+    // confirm we are on the licence page and select licence set up tab
     cy.contains('AT/TEST/01')
-    cy.get('#tab_charge').click()
+    cy.contains('Licence set up').click()
 
-    // confirm we are on the charge information tab
-    cy.get('#charge > :nth-child(1)').contains('Charge information')
+    // confirm we are on the licence set up tab
+    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
 
-    // click set up new returns requirement
-    cy.contains('Set up new returns requirement').click()
+    // click set up new requirements
+    cy.contains('Set up new requirements').click()
 
     // choose the licence version start date and click continue
     cy.get('#licence-start-date').check()
@@ -164,7 +164,7 @@ describe('Cancel a return requirement (internal)', () => {
     // click the confirm cancel button
     cy.contains('Confirm cancel').click()
 
-    // confirm we are on the charge information tab
-    cy.get('#charge').contains('Charge information')
+    // confirm we are on the licence set up tab
+    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
   })
 })

--- a/cypress/e2e/internal/returns-requirements/copy-existing.cy.js
+++ b/cypress/e2e/internal/returns-requirements/copy-existing.cy.js
@@ -32,15 +32,15 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     cy.get('.search__button').click()
     cy.get('.govuk-table__row > :nth-child(1) > a').click()
 
-    // confirm we are on the licence page and select charge information tab
+    // confirm we are on the licence page and select licence set up tab
     cy.contains('AT/TEST/01')
-    cy.get('#tab_charge').click()
+    cy.contains('Licence set up').click()
 
-    // confirm we are on the charge information tab
-    cy.get('#charge > :nth-child(1)').contains('Charge information')
+    // confirm we are on the licence set up tab
+    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
 
-    // click set up new returns requirement
-    cy.contains('Set up new returns requirement').click()
+    // click set up new requirements
+    cy.contains('Set up new requirements').click()
 
     // choose the licence version start date and click continue
     cy.get('#licence-start-date').check()
@@ -191,7 +191,7 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     // click link to return to licence set up
     cy.contains('Return to licence set up').click()
 
-    // confirm we are on the charge information tab
-    cy.get('#charge').contains('Charge information')
+    // confirm we are on the licence set up tab
+    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
   })
 })

--- a/cypress/e2e/internal/returns-requirements/no-returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/no-returns-required.cy.js
@@ -32,15 +32,15 @@ describe('Submit no returns requirement (internal)', () => {
     cy.get('.search__button').click()
     cy.get('.govuk-table__row > :nth-child(1) > a').click()
 
-    // confirm we are on the licence page and select charge information tab
+    // confirm we are on the licence page and select licence set up tab
     cy.contains('AT/TEST/01')
-    cy.get('#tab_charge').click()
+    cy.contains('Licence set up').click()
 
-    // confirm we are on the charge information tab
-    cy.get('#charge > :nth-child(1)').contains('Charge information')
+    // confirm we are on the licence set up tab
+    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
 
     // click set up no returns requirement
-    cy.contains('No returns required').click()
+    cy.contains("Mark licence as 'no returns needed'").click()
 
     // confirm we are on the start date page
     cy.get('.govuk-fieldset__heading').contains('Select the start date for the requirements for returns')
@@ -57,7 +57,7 @@ describe('Submit no returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are on the check page
-    cy.get('.govuk-heading-xl').contains('Check the return requirements')
+    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
 
     // confirm we see text about no returns required
     cy.contains('Returns are not required for this licence')
@@ -77,7 +77,7 @@ describe('Submit no returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are back on check page and see the reason changes
-    cy.get('.govuk-heading-xl').contains('Check the return requirements for Mr J J Testerson')
+    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
     cy.get('[data-test="reason"]').contains('Transfer licence')
 
     // confirm we see the option to add note
@@ -97,7 +97,7 @@ describe('Submit no returns requirement (internal)', () => {
     cy.contains('Confirm').click()
 
     // confirm we are back on the check page
-    cy.get('.govuk-heading-xl').contains('Check the return requirements')
+    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
 
     // confirm we see pop up notification confirming changes have been made
     cy.get('.govuk-notification-banner').contains('Changes made')
@@ -114,7 +114,7 @@ describe('Submit no returns requirement (internal)', () => {
     cy.contains('Confirm').click()
 
     // confirm we are back on the check page
-    cy.get('.govuk-heading-xl').contains('Check the return requirements')
+    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
 
     // confirm we see pop up notification confirming changes have been made
     cy.get('.govuk-notification-banner').contains('Changes made')
@@ -140,7 +140,7 @@ describe('Submit no returns requirement (internal)', () => {
     // click link to return to licence set up
     cy.contains('Return to licence set up').click()
 
-    // confirm we are on the charge information tab
-    cy.get('#charge').contains('Charge information')
+    // confirm we are on the licence set up tab
+    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
   })
 })

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -32,15 +32,15 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.search__button').click()
     cy.get('.govuk-table__row > :nth-child(1) > a').click()
 
-    // confirm we are on the licence page and select charge information tab
+    // confirm we are on the licence page and select licence set up tab
     cy.contains('AT/TEST/01')
-    cy.get('#tab_charge').click()
+    cy.contains('Licence set up').click()
 
-    // confirm we are on the charge information tab
-    cy.get('#charge > :nth-child(1)').contains('Charge information')
+    // confirm we are on the licence set up tab
+    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
 
-    // click set up new returns requirement
-    cy.contains('Set up new returns requirement').click()
+    // click set up new requirements
+    cy.contains('Set up new requirements').click()
 
     // choose the licence version start date and click continue
     cy.get('#licence-start-date').check()
@@ -376,7 +376,7 @@ describe('Submit returns requirement (internal)', () => {
     // click link to return to licence set up
     cy.contains('Return to licence set up').click()
 
-    // confirm we are on the charge information tab
-    cy.get('#charge').contains('Charge information')
+    // confirm we are on the licence set up tab
+    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
   })
 })

--- a/cypress/e2e/internal/user/permissions/billing-and-data.cy.js
+++ b/cypress/e2e/internal/user/permissions/billing-and-data.cy.js
@@ -34,11 +34,12 @@ describe('Billing & Data permissions (internal)', () => {
     // confirm we are on the licence page
     cy.contains('AT/CURR/DAILY/01')
 
-    // confirm we can see the summary, contacts, returns, communications, bill runs and charge information tabs
-    cy.get('#tab_summary').should('have.text', 'Summary')
-    cy.get('#tab_returns').should('have.text', 'Returns')
-    cy.get('#tab_communications').should('have.text', 'Communications')
-    cy.get('#tab_bills').should('have.text', 'Bills')
-    cy.get('#tab_charge').should('have.text', 'Charge information')
+    // confirm we can see the summary, contact details, returns, communications, bill runs and licence set up tabs
+    cy.get('.govuk-tabs__list-item--selected > .govuk-tabs__tab').should('contain.text', 'Summary')
+    cy.get(':nth-child(2) > .govuk-tabs__tab').should('contain.text', 'Contact details')
+    cy.get(':nth-child(3) > .govuk-tabs__tab').should('contain.text', 'Returns')
+    cy.get(':nth-child(4) > .govuk-tabs__tab').should('contain.text', 'Communications')
+    cy.get(':nth-child(5) > .govuk-tabs__tab').should('contain.text', 'Bills')
+    cy.get(':nth-child(6) > .govuk-tabs__tab').should('contain.text', 'Licence set up')
   })
 })

--- a/cypress/e2e/internal/user/permissions/psc.cy.js
+++ b/cypress/e2e/internal/user/permissions/psc.cy.js
@@ -34,13 +34,14 @@ describe('PSC permissions (internal)', () => {
     // confirm we are on the licence page
     cy.contains('AT/CURR/DAILY/01')
 
-    // confirm we can see the summary, contacts, returns, communications and charge information tabs
-    cy.get('#tab_summary').should('have.text', 'Summary')
-    cy.get('#tab_returns').should('have.text', 'Returns')
-    cy.get('#tab_communications').should('have.text', 'Communications')
-    cy.get('#tab_charge').should('have.text', 'Charge information')
+    // confirm we can see the summary, contact details, returns, communications and licence set up tabs
+    cy.get('.govuk-tabs__list-item--selected > .govuk-tabs__tab').should('contain.text', 'Summary')
+    cy.get(':nth-child(2) > .govuk-tabs__tab').should('contain.text', 'Contact details')
+    cy.get(':nth-child(3) > .govuk-tabs__tab').should('contain.text', 'Returns')
+    cy.get(':nth-child(4) > .govuk-tabs__tab').should('contain.text', 'Communications')
+    cy.get(':nth-child(5) > .govuk-tabs__tab').should('contain.text', 'Licence set up')
 
     // confirm we cannot see the bills tab
-    cy.get('#main-content > div > div > div > ul').children().should('not.contain', 'Bills')
+    cy.get('.govuk-tabs__list').should('not.contain', 'Bills')
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4555

With us creating a new view licence page and making it the default, the ‘elements’ in the page will have changed. Acceptance tests rely on finding and interacting with the elements of a page, so this means some of our existing tests will fail.

This PR will focus on finding the tests affected by the changes to the elements and updating them to the updated elements.