### PR TITLE
Fix failing requirement due to new reasons added

### DIFF
--- a/cypress/e2e/internal/returns-requirements/abstraction-data.cy.js
+++ b/cypress/e2e/internal/returns-requirements/abstraction-data.cy.js
@@ -65,7 +65,7 @@ describe('Submit returns requirement (internal) using abstraction data', () => {
 
     // confirm we see the start data and reason options selected previously
     cy.get('[data-test="start-date"]').contains('1 April 2022')
-    cy.get('[data-test="reason"]').contains('Licence holder name or address change')
+    cy.get('[data-test="reason"]').contains('Change to special agreement')
 
     // choose the change purpose button for the requirement
     cy.get('[data-test="change-purposes-0"]').click()

--- a/cypress/e2e/internal/returns-requirements/cancel-returns.cy.js
+++ b/cypress/e2e/internal/returns-requirements/cancel-returns.cy.js
@@ -126,7 +126,7 @@ describe('Cancel a return requirement (internal)', () => {
     cy.get('[data-test="start-date"]').contains('12 June 2023')
 
     // confirm we see the reason we selected
-    cy.get('[data-test="reason"]').contains('Licence holder name or address change')
+    cy.get('[data-test="reason"]').contains('Change to special agreement')
 
     // confirm we see the purposes selected
     cy.get('[data-test="purposes-0"]').should('contain', 'General Farming & Domestic')

--- a/cypress/e2e/internal/returns-requirements/copy-existing.cy.js
+++ b/cypress/e2e/internal/returns-requirements/copy-existing.cy.js
@@ -72,7 +72,7 @@ describe('Submit returns requirement using copy existing (internal)', () => {
 
     // confirm we see the start date and reason selected
     cy.get('[data-test="start-date"]').contains('12 June 2023')
-    cy.get('[data-test="reason"]').contains('Licence holder name or address change')
+    cy.get('[data-test="reason"]').contains('Change to special agreement')
 
     // confirm we see the purpose for the requirement copied from existing
     cy.get('[data-test="purposes-0"]').contains('Hydroelectric Power Generation')

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -140,7 +140,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('[data-test="start-date"]').contains('2 August 2023')
 
     // confirm we see the reason we selected
-    cy.get('[data-test="reason"]').contains('Licence holder name or address change')
+    cy.get('[data-test="reason"]').contains('Change to special agreement')
 
     // choose the change option for reason
     cy.get('[data-test="change-reason"]').click()
@@ -151,7 +151,7 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the reason changes
     cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
-    cy.get('[data-test="reason"]').contains('New licence')
+    cy.get('[data-test="reason"]').contains('Minor change')
 
     // confirm we see the purposes selected
     cy.get('[data-test="purposes-0"]').should('contain', 'General Farming & Domestic')


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-system/pull/1169

During the development stage of the return requirements journey, we seem to have missed out on including two options from the reason page. The new options have now been added to the journey but as a result, some of our acceptance tests are now failing.

This PR is focused on fixing the acceptance tests failing due to the two new options added to the reason page.