### PR TITLE
Update two-part tariff acceptance tests

### DIFF
--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-01.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-01.cy.js
@@ -67,6 +67,7 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     })
     cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
     cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Two-part tariff')
+    cy.get('[data-test="bill-run-total-0"]').should('contain.text', '')
     cy.get('[data-test="date-created-0"] > .govuk-link').click()
 
     // Review licences ~ Test its the correct bill run
@@ -129,6 +130,7 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="matched-return-total-0"]').should('contain.text', '32 ML / 32 ML')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-02.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-02.cy.js
@@ -99,6 +99,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="matched-return-total-0"]').should('contain.text', '32 ML / 32 ML')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-03.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-03.cy.js
@@ -112,6 +112,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="matched-return-total-0"]').should('contain.text', '32 ML / 32 ML')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-04.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-04.cy.js
@@ -114,6 +114,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="matched-return-total-0"]').should('contain.text', '32 ML / 32 ML')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-05.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-05.cy.js
@@ -114,6 +114,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="matched-return-total-0"]').should('contain.text', '32 ML / 32 ML')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-06.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-06.cy.js
@@ -114,6 +114,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'query')
     // When a return is under query we don't expect the engine to allocate any of its quantities, this will therefore

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-07.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-07.cy.js
@@ -114,6 +114,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'received')
     // When a return status is received we don't expect the engine to allocate any of its quantities, this will

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-08.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-08.cy.js
@@ -102,6 +102,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     // When a return status is a nil return we don't expect anything to be allocated and no issues to be raised

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-09.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-09.cy.js
@@ -120,6 +120,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'overdue')
     cy.get('[data-test="matched-return-total-0"] > :nth-child(1)').should('contain.text', '/')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-11.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-11.cy.js
@@ -116,6 +116,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     // When a return is over abstracted the return should still allocate up to the charge element volume or

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-12.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-12.cy.js
@@ -115,6 +115,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 April to 31 March')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="matched-return-total-0"] > :nth-child(2)').should('contain.text', 'Return split over charge references')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-13.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-13.cy.js
@@ -116,6 +116,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('.govuk-table__caption').should('contain.text', 'Unmatched returns')
     cy.get('[data-test="unmatched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="unmatched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="unmatched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="unmatched-return-summary-0"] > div').should('contain.text', 'Mineral Washing')
     cy.get('[data-test="unmatched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="unmatched-return-total-0"] > :nth-child(2)').should('contain.text', 'Over abstraction')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-14.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-14.cy.js
@@ -100,6 +100,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 April to 31 March')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="matched-return-total-0"] > :nth-child(2)').should('contain.text', '')
@@ -115,7 +116,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('[data-test="charge-version-0-details"]').should('contain.text', '1 charge reference  with 2 two-part tariff charge elements')
     cy.get('[data-test="charge-version-0-total-billable-returns-0"]').should('contain.text', '50 ML / 50 ML')
     // Without an aggregate of charge factor we shouldn't see the link "Change details" only "View details"
-    cy.get('[data-test="charge-version-0-charge-reference-link-0"]').should('contain.text', 'View details')
+    cy.get('[data-test="charge-version-0-charge-reference-link-0"]').should('contain.text', 'Change details')
     //  Charge element 1
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', 'SROC Charge Purpose 01')
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', '1 April 2022 to 31 October 2022')
@@ -135,5 +136,29 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     // allocate here
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-billable-returns-1"]').should('contain.text', '20 ML / 20 ML')
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-return-volumes-1"]').should('contain.text', '50 ML (10021668)')
+
+    // To test the warning text that appears when the sum of the allocated charge elements exceeds the charge reference,
+    // we need to manipulate the data. First, we reduce the allocated quantity on one of the charge elements. Next, we
+    // decrease the authorised amount on the charge reference. Finally, we return to the same charge element and
+    // increase its quantity back to its authorised amount. This will cause the sum of the charge elements to exceed the
+    // authorised volume of the charge reference, triggering the warning.
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
+    cy.get('.govuk-button').contains('Edit the billable returns').click()
+    cy.get('#custom-quantity').click()
+    cy.get('#custom-quantity-input').type('10')
+    cy.get('.govuk-button').contains('Confirm').click()
+    cy.get('.govuk-back-link').click()
+    cy.get('[data-test="charge-version-0-charge-reference-link-0"]').click()
+    cy.get('.govuk-button').contains('Change the authorised volume').click()
+    cy.get('#authorised-volume').clear().type('40')
+    cy.get('.govuk-button').contains('Confirm').click()
+    cy.get('.govuk-back-link').click()
+    cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
+    cy.get('.govuk-button').contains('Edit the billable returns').click()
+    cy.get('#authorised-quantity').click()
+    cy.get('.govuk-button').contains('Confirm').click()
+    cy.get('.govuk-back-link').click()
+    cy.get('.govuk-warning-text__icon').should('exist')
+    cy.get('.govuk-warning-text__text').should('contain.text', 'The total billable return volume exceeds the total authorised volume')
   })
 })

--- a/cypress/fixtures/review-scenario-14.json
+++ b/cypress/fixtures/review-scenario-14.json
@@ -40,7 +40,7 @@
         "s126": null,
         "s127": true,
         "s130": false,
-        "charge": null,
+        "charge": 1.5,
         "winter": false
       },
       "waterModel": "no model",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4513
https://eaflood.atlassian.net/browse/WATER-4548
https://eaflood.atlassian.net/browse/WATER-4549

While testing the two-part tariff review pages, the billing and data team testing the engine wanted a few changes. These were:
* To add a warning to the licence review page if the total sum of the charge elements allocated quantity exceeds that of its charge reference authorised quantity
* Add the returns abstraction period to the licence review page
* Make the total for any two-part tariff bill run in review blank on the bill runs page

This PR is to update the acceptance tests with these changes.