### PR TITLE
Update return requirement tests 4 purpose changes

### DIFF
--- a/cypress/e2e/internal/returns-requirements/abstraction-data.cy.js
+++ b/cypress/e2e/internal/returns-requirements/abstraction-data.cy.js
@@ -71,8 +71,8 @@ describe('Submit returns requirement (internal) using abstraction data', () => {
     cy.get('[data-test="change-purposes-0"]').click()
 
     // choose another purpose and continue
-    cy.get('#purposes').uncheck()
-    cy.get('#purposes-2').check()
+    cy.get('[data-test="purpose-0"]').uncheck()
+    cy.get('[data-test="purpose-1"]').check()
     cy.contains('Continue').click()
 
     // confirm we see the changed purpose for the requirement
@@ -96,8 +96,8 @@ describe('Submit returns requirement (internal) using abstraction data', () => {
     cy.get('.govuk-heading-xl').contains('Select the purpose for the requirements for returns')
 
     // choose a purpose and click continue
-    cy.get('#purposes').check()
-    cy.get('#purposes-2').check()
+    cy.get('[data-test="purpose-0"]').check()
+    cy.get('[data-test="purpose-1"]').check()
     cy.contains('Continue').click()
 
     // confirm we are on the points page

--- a/cypress/e2e/internal/returns-requirements/cancel-returns.cy.js
+++ b/cypress/e2e/internal/returns-requirements/cancel-returns.cy.js
@@ -64,7 +64,7 @@ describe('Cancel a return requirement (internal)', () => {
     cy.get('.govuk-heading-xl').contains('Select the purpose for the requirements for returns')
 
     // choose a purpose for the requirement and continue
-    cy.get('#purposes').check()
+    cy.get('[data-test="purpose-0"]').check()
     cy.contains('Continue').click()
 
     // confirm we are on the points page

--- a/cypress/e2e/internal/returns-requirements/copy-existing.cy.js
+++ b/cypress/e2e/internal/returns-requirements/copy-existing.cy.js
@@ -82,8 +82,8 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     cy.get('.govuk-heading-xl').contains('Select the purpose for the requirements for returns')
 
     // choose another purpose and continue
-    cy.get('#purposes-2').uncheck()
-    cy.get('#purposes').check()
+    cy.get('[data-test="purpose-1"]').uncheck()
+    cy.get('[data-test="purpose-0"]').check()
     cy.contains('Continue').click()
 
     // confirm we see the purpose changes on the check page
@@ -113,7 +113,7 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     cy.get('.govuk-heading-xl').contains('Select the purpose for the requirements for returns')
 
     // choose a purpose and continue
-    cy.get('#purposes-2').check()
+    cy.get('[data-test="purpose-1"]').check()
     cy.contains('Continue').click()
 
     // confirm we are on the points page

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -64,7 +64,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-heading-xl').contains('Select the purpose for the requirements for returns')
 
     // choose a purpose for the requirement and continue
-    cy.get('#purposes').check()
+    cy.get('[data-test="purpose-0"]').check()
     cy.contains('Continue').click()
 
     // confirm we are on the points page
@@ -160,8 +160,8 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('[data-test="change-purposes-0"]').click()
 
     // change the purpose and continue
-    cy.get('#purposes').uncheck()
-    cy.get('#purposes-2').check()
+    cy.get('[data-test="purpose-0"]').uncheck()
+    cy.get('[data-test="purpose-1"]').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the purpose changes
@@ -285,7 +285,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-heading-xl').contains('Select the purpose for the requirements for returns')
 
     // choose a purpose for the requirement and continue
-    cy.get('#purposes').check()
+    cy.get('[data-test="purpose-0"]').check()
     cy.contains('Continue').click()
 
     // confirm we are on the points page


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4573

> Part of the return requirements set up work

We have updated the checkboxes on the 'Select purpose' page of the return requirements set up journey to support users adding an optional purpose description.

The change, though, has broken some tests because we had to rename them to make them distinct. Thankfully we also added `data-test` attributes during the changes so its simple enough to fix the return requirement tests and get them passing again.