### PR TITLE
Replace notify mock data

### DIFF
--- a/cypress/e2e/external/notify-callback.cy.js
+++ b/cypress/e2e/external/notify-callback.cy.js
@@ -3,13 +3,15 @@
 describe('Notify callback endpoint', () => {
   beforeEach(() => {
     cy.tearDown()
-    cy.setUp('notify-mock-notification')
-    cy.fixture('users.json').its('notifyCallbackTestEmail').as('userEmail')
+    cy.fixture('notify-mock-notification.json').then((fixture) => {
+      cy.load(fixture)
+    })
+    cy.fixture('users.json').its('billingAndData1').as('userEmail')
   })
 
   it('when called by Notify sets the status of the notification to delivered', () => {
     // Pretending to be the Notify Service, submit a callback to the service, which updates the status of the
-    // Notification record added in setup() to 'delivered'
+    // Notification record added in the fixture to 'delivered'
     cy.simulateNotifyCallback('82fda2b8-0a53-4f02-bcaa-1e13949b250b')
       .its('status', { log: false }).should('equal', 204)
 

--- a/cypress/fixtures/notify-mock-notification.json
+++ b/cypress/fixtures/notify-mock-notification.json
@@ -1,0 +1,15 @@
+{
+  "scheduledNotifications": [
+    {
+      "messageRef": "test-ref",
+      "recipient": "billing.data@wrls.gov.uk",
+      "messageType": "email",
+      "notifyId": "82fda2b8-0a53-4f02-bcaa-1e13949b250b",
+      "plaintext": "Test",
+      "personalisation": {
+        "one": 1
+      },
+      "createdAt": "2020-01-01"
+    }
+  ]
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4523

As part of our work to replace the legacy code, we’ve tackled the complexities and failures of the old test data loader that hindered our acceptance tests. This PR switches the notify acceptance tests to use the new fixture file in the acceptance tests repo, eliminating the dependency on the service repo's test data.