### PR TITLE
Fix Return Requirements fixtures file

### DIFF
--- a/cypress/fixtures/returns-requirements.json
+++ b/cypress/fixtures/returns-requirements.json
@@ -178,6 +178,7 @@
     {
       "id": "a4f9b0b5-11ac-4aa2-98c9-61c6c12088bb",
       "licenceVersionId": "b846afb6-9334-42c4-8da3-1d559a6e3ea7",
+      "externalId": "6:12345",
       "purposeId": {
         "schema": "public",
         "table": "purposes",
@@ -203,6 +204,7 @@
     {
       "id": "b1fa0800-9028-4a46-872c-7f70676701ca",
       "licenceVersionId": "2f9362e8-4fdc-4018-880a-31bba8d9b23b",
+      "externalId": "6:123456",
       "purposeId": {
         "schema": "public",
         "table": "purposes",


### PR DESCRIPTION
After running the acceptance tests multiple times our QA team discovered that the return requirements tests were randomly failing on the data load. 

As we know nothing is ever random...

The return requirements tests all pull in the same fixtures file `returns-requirements.json`. The load service was failing with an error `duplicate key value violates unique constraint "uindx_licence_version_purposes_external_id"`. On the fixtures file for licenceVersionPurposes, the externalId wasn't hard-coded data meaning it was using our helper in the system repo. The helper in the system repo is randomly generating the externalId each time.

My guess is that because the acceptance test is using our local db, which in the licenceVersionPurposes table has thousands of records, sometimes the randomly generated externalId clashed with a real record we have and therefore failed to load. With this change, we have hardcoded the ID to avoid this clash. After spamming the acceptance tests it has passed every time.