### PR TITLE
Add purpose alias check to return requirement tests

### DIFF
--- a/cypress/e2e/internal/returns-requirements/copy-existing.cy.js
+++ b/cypress/e2e/internal/returns-requirements/copy-existing.cy.js
@@ -74,21 +74,22 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     cy.get('[data-test="start-date"]').contains('12 June 2023')
     cy.get('[data-test="reason"]').contains('Change to special agreement')
 
-    // confirm we see the purpose and purpose alias for the requirement copied from existing
+    // confirm we see the purpose and purpose description for the requirement copied from existing
     cy.get('[data-test="purposes-0"]').contains('Hydroelectric Power Generation (This is a test purpose alias)')
 
     // choose the change link for the purpose and confirm we are on the purpose page
     cy.get('[data-test="change-purposes-0"]').click()
     cy.get('.govuk-heading-xl').contains('Select the purpose for the requirements for returns')
 
-    // choose another purpose and continue
+    // choose another purpose and add another purpose description and click continue
     cy.get('[data-test="purpose-1"]').uncheck()
     cy.get('[data-test="purpose-0"]').check()
+    cy.get('[data-test="purpose-alias-0"]').type('This is another purpose description')
     cy.contains('Continue').click()
 
     // confirm we see the purpose changes on the check page
     cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
-    cy.get('[data-test="purposes-0"]').contains('General Farming & Domestic')
+    cy.get('[data-test="purposes-0"]').contains('General Farming & Domestic (This is another purpose description)')
 
     // confirm we see the points for the requirement copied from existing
     cy.get('[data-test="points-0"]').contains('At National Grid Reference TQ 1234 1234 (Test local name 1)')

--- a/cypress/e2e/internal/returns-requirements/copy-existing.cy.js
+++ b/cypress/e2e/internal/returns-requirements/copy-existing.cy.js
@@ -74,8 +74,8 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     cy.get('[data-test="start-date"]').contains('12 June 2023')
     cy.get('[data-test="reason"]').contains('Change to special agreement')
 
-    // confirm we see the purpose for the requirement copied from existing
-    cy.get('[data-test="purposes-0"]').contains('Hydroelectric Power Generation')
+    // confirm we see the purpose and purpose alias for the requirement copied from existing
+    cy.get('[data-test="purposes-0"]').contains('Hydroelectric Power Generation (This is a test purpose alias)')
 
     // choose the change link for the purpose and confirm we are on the purpose page
     cy.get('[data-test="change-purposes-0"]').click()

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -63,8 +63,9 @@ describe('Submit returns requirement (internal)', () => {
     // confirm we are on the purpose page
     cy.get('.govuk-heading-xl').contains('Select the purpose for the requirements for returns')
 
-    // choose a purpose for the requirement and continue
+    // choose a purpose and add a purpose description for the requirement and continue
     cy.get('[data-test="purpose-0"]').check()
+    cy.get('[data-test="purpose-alias-0"]').type('This is a purpose description')
     cy.contains('Continue').click()
 
     // confirm we are on the points page
@@ -154,19 +155,20 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('[data-test="reason"]').contains('Minor change')
 
     // confirm we see the purposes selected
-    cy.get('[data-test="purposes-0"]').should('contain', 'General Farming & Domestic')
+    cy.get('[data-test="purposes-0"]').should('contain', 'General Farming & Domestic (This is a purpose description)')
 
     // choose the change option for purposes
     cy.get('[data-test="change-purposes-0"]').click()
 
-    // change the purpose and continue
+    // change the purpose and purpose description and click continue
     cy.get('[data-test="purpose-0"]').uncheck()
     cy.get('[data-test="purpose-1"]').check()
+    cy.get('[data-test="purpose-alias-1"]').type('This is another purpose description')
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the purpose changes
     cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
-    cy.get('[data-test="purposes-0"]').contains('Hydroelectric Power Generation')
+    cy.get('[data-test="purposes-0"]').contains('Hydroelectric Power Generation (This is another purpose description)')
 
     // confirm we see the points selected
     cy.get('[data-test="points-0"]').should('contain', 'At National Grid Reference TQ 1234 1234 (Test local name 1)')

--- a/cypress/fixtures/returns-requirements.json
+++ b/cypress/fixtures/returns-requirements.json
@@ -272,7 +272,8 @@
         "lookup": "legacyId",
         "value": "ELC",
         "select": "id"
-      }
+      },
+      "alias": "This is a test purpose alias"
     }
   ],
   "returnRequirementPoints": [


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4594

We have made changes to the return requirements set up journey to allow users to enter an optional ‘purpose description’ (alias). However, we don’t have any coverage of this functionality in our automated acceptance tests.

This PR will add the checks to copy-existing.cy and returns-required.cy for purpose aliases.