### PR TITLE
Update fixtures to lookup region

### DIFF
--- a/cypress/fixtures/barebones.json
+++ b/cypress/fixtures/barebones.json
@@ -313,7 +313,7 @@
     {
       "id": "8717da0e-28d4-4833-8e32-1da050b60055",
       "licenceRef": "AT/CURR/DAILY/01",
-      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
       "regions": {
         "historicalAreaCode": "SAAR",
         "regionalChargeArea": "Southern"
@@ -324,7 +324,7 @@
     {
       "id": "bcdf5049-fd2d-4e45-a3d6-37bcd443d431",
       "licenceRef": "AT/CURR/WEEKLY/01",
-      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
       "regions": {
         "historicalAreaCode": "SAAR",
         "regionalChargeArea": "Southern"
@@ -335,7 +335,7 @@
     {
       "id": "bb5605c9-5c28-43d3-a8b3-875013366b69",
       "licenceRef": "AT/CURR/MONTHLY/01",
-      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
       "regions": {
         "historicalAreaCode": "SAAR",
         "regionalChargeArea": "Southern"
@@ -346,7 +346,7 @@
     {
       "id": "844e5fd5-f21c-418e-8d64-0be4d283133a",
       "licenceRef": "AT/CURR/MONTHLY/02",
-      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
       "regions": {
         "historicalAreaCode": "SAAR",
         "regionalChargeArea": "Southern"

--- a/cypress/fixtures/generate-using-abstraction-data.json
+++ b/cypress/fixtures/generate-using-abstraction-data.json
@@ -1070,7 +1070,7 @@
     {
       "id": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
       "licenceRef": "AT/TEST/01",
-      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
       "regions": {
         "historicalAreaCode": "SAAR",
         "regionalChargeArea": "Test Region"

--- a/cypress/fixtures/pre-sroc-two-part-tariff-bill-run.json
+++ b/cypress/fixtures/pre-sroc-two-part-tariff-bill-run.json
@@ -160,7 +160,7 @@
     {
       "id": "8717da0e-28d4-4833-8e32-1da050b60055",
       "licenceRef": "L1",
-      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
       "regions": {
         "historicalAreaCode": "ARCA",
         "regionalChargeArea": "Anglian"

--- a/cypress/fixtures/returns-requirements.json
+++ b/cypress/fixtures/returns-requirements.json
@@ -108,7 +108,7 @@
     {
       "id": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
       "licenceRef": "AT/TEST/01",
-      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
       "regions": {
         "historicalAreaCode": "SAAR",
         "regionalChargeArea": "Test Region"

--- a/cypress/fixtures/review-scenario-licence.json
+++ b/cypress/fixtures/review-scenario-licence.json
@@ -122,7 +122,7 @@
     {
       "id": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
       "licenceRef": "AT/TEST/01",
-      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
       "regions": {
         "historicalAreaCode": "SAAR",
         "regionalChargeArea": "Test Region"

--- a/cypress/fixtures/sroc-billing.json
+++ b/cypress/fixtures/sroc-billing.json
@@ -416,7 +416,7 @@
     {
       "id": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
       "licenceRef": "AT/TEST/01",
-      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
       "regions": {
         "historicalAreaCode": "SAAR",
         "regionalChargeArea": "Southern"
@@ -427,7 +427,7 @@
     {
       "id": "482bf7ed-e2d9-426e-bfba-183784e6d459",
       "licenceRef": "AT/TEST/02",
-      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
       "regions": {
         "historicalAreaCode": "SAAR",
         "regionalChargeArea": "Southern"
@@ -440,7 +440,7 @@
     {
       "id": "d1599b0f-2343-41c8-bc49-6a25ba5fe4c2",
       "licenceRef": "AT/TEST/03",
-      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
       "regions": {
         "historicalAreaCode": "SAAR",
         "regionalChargeArea": "Southern"
@@ -451,7 +451,7 @@
     {
       "id": "85f74e84-e0de-45ac-b9d4-f21a1913eb95",
       "licenceRef": "AT/TEST/04",
-      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
       "regions": {
         "historicalAreaCode": "SAAR",
         "regionalChargeArea": "Southern"
@@ -964,7 +964,7 @@
   "billRuns": [
     {
       "id": "44ee8b2a-5557-490f-90cd-676d1b8038bf",
-      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
       "batchType": "annual",
       "fromFinancialYearEnding": 2023,
       "toFinancialYearEnding": 2024,

--- a/cypress/fixtures/sroc-two-part-tariff-simple-licence-data.json
+++ b/cypress/fixtures/sroc-two-part-tariff-simple-licence-data.json
@@ -74,7 +74,7 @@
     {
       "id": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
       "licenceRef": "AT/TEST/01",
-      "regionId": "d0a4123d-1e19-480d-9dd4-f70f3387c4b9",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
       "regions": {
         "historicalAreaCode": "SAAR",
         "regionalChargeArea": "Test Region"


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/124

As part of our ongoing efforts to remove the dependency on cleaning the DB before a test, we introduced seeders for some of the reference data we depend on. That means, for example, you can no longer add a region using our test helpers and the loaders.

In [Replace loaded region with seeded ones](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/129), we updated our fixtures because of this. Other reference records are already using lookups instead of hard coding seeded IDs, and on reflection, we should have done the same for the region.

We cannot 'guarantee' that the test region will have _definitely_ been seeded with the ID we provided. For reasons out of our control, it might have a different one. Plus, there is the concept of consistency; why have a hard-coded ID when we have lookups for others?

This updates any fixture that relies on creating a record linked to the test region to use a lookup instead of the hard-coded ID.