### PR TITLE
Update all scenarios to use new points solution

### DIFF
--- a/cypress/e2e/internal/returns-requirements/cancel-returns.cy.js
+++ b/cypress/e2e/internal/returns-requirements/cancel-returns.cy.js
@@ -132,7 +132,7 @@ describe('Cancel a return requirement (internal)', () => {
     cy.get('[data-test="purposes-0"]').should('contain', 'Hydroelectric Power Generation')
 
     // confirm we see the points selected
-    cy.get('[data-test="points-0"]').should('contain', 'At National Grid Reference TQ 1234 5678 (Example licence point 1)')
+    cy.get('[data-test="points-0"]').should('contain', 'At National Grid Reference TQ 1234 5678 (Example point 1)')
 
     // confirm we see the abstraction period selected
     cy.get('[data-test="abstraction-period-0"]').contains('From 1 December to 3 September')

--- a/cypress/e2e/internal/returns-requirements/copy-existing.cy.js
+++ b/cypress/e2e/internal/returns-requirements/copy-existing.cy.js
@@ -92,8 +92,8 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     cy.get('[data-test="purposes-0"]').contains('Laundry Use (This is another purpose description)')
 
     // confirm we see the points for the requirement copied from existing
-    cy.get('[data-test="points-0"] > :nth-child(1)').contains('At National Grid Reference TQ 1234 5678 (Example licence point 1)')
-    cy.get('[data-test="points-0"] > :nth-child(2)').contains('At National Grid Reference TT 9876 5432 (Example licence point 2)')
+    cy.get('[data-test="points-0"] > :nth-child(1)').contains('At National Grid Reference TQ 1234 5678 (Example point 1)')
+    cy.get('[data-test="points-0"] > :nth-child(2)').contains('At National Grid Reference TT 9876 5432 (Example point 2)')
 
     // choose the change link for the points and confirm we are on the points page
     cy.get('[data-test="change-points-0"]').click()
@@ -105,7 +105,7 @@ describe('Submit returns requirement using copy existing (internal)', () => {
 
     // confirm we see the points changes on the check page
     cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
-    cy.get('[data-test="points-0"]').contains('At National Grid Reference TT 9876 5432 (Example licence point 2)')
+    cy.get('[data-test="points-0"]').contains('At National Grid Reference TT 9876 5432 (Example point 2)')
 
     // choose add another requirement
     cy.contains('Add another requirement').click()
@@ -178,7 +178,7 @@ describe('Submit returns requirement using copy existing (internal)', () => {
 
     // confirm we see the new added requirement and details selected
     cy.get('[data-test="purposes-1"]').contains('Hydroelectric Power Generation')
-    cy.get('[data-test="points-1"]').contains('At National Grid Reference TQ 1234 5678 (Example licence point 1)')
+    cy.get('[data-test="points-1"]').contains('At National Grid Reference TQ 1234 5678 (Example point 1)')
     cy.get('[data-test="abstraction-period-1"]').contains('From 1 December to 3 November')
     cy.get('[data-test="returns-cycle-1"]').contains('Summer')
     cy.get('[data-test="site-description-1"]').contains('Site description for another return requirement')

--- a/cypress/e2e/internal/returns-requirements/returns-required.cy.js
+++ b/cypress/e2e/internal/returns-requirements/returns-required.cy.js
@@ -171,7 +171,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('[data-test="purposes-0"]').contains('Laundry Use (This is another purpose description)')
 
     // confirm we see the points selected
-    cy.get('[data-test="points-0"]').should('contain', 'At National Grid Reference TQ 1234 5678 (Example licence point 1)')
+    cy.get('[data-test="points-0"]').should('contain', 'At National Grid Reference TQ 1234 5678 (Example point 1)')
 
     // choose the change option for points
     cy.get('[data-test="change-points-0"]').click()
@@ -183,7 +183,7 @@ describe('Submit returns requirement (internal)', () => {
 
     // confirm we are back on the check page and see the points changes
     cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
-    cy.get('[data-test="points-0"]').contains('At National Grid Reference TT 9876 5432 (Example licence point 2)')
+    cy.get('[data-test="points-0"]').contains('At National Grid Reference TT 9876 5432 (Example point 2)')
 
     // confirm we see the abstraction period selected
     cy.get('[data-test="abstraction-period-0"]').contains('From 1 December to 3 September')

--- a/cypress/e2e/internal/returns-requirements/start-by-using-abstraction-data.cy.js
+++ b/cypress/e2e/internal/returns-requirements/start-by-using-abstraction-data.cy.js
@@ -69,23 +69,23 @@ describe('Submit returns requirement (internal) using abstraction data', () => {
 
     // confirm we see return requirements generated from abstraction data
     // Return requirement 1
-    cy.get('#requirement-0 > div.govuk-summary-card__title-wrapper > h2').contains('Example licence point 1')
+    cy.get('#requirement-0 > div.govuk-summary-card__title-wrapper > h2').contains('Example point 1')
     cy.get('[data-test="purposes-0"]').contains('Hydroelectric Power Generation')
-    cy.get('[data-test="points-0"]').contains('At National Grid Reference TQ 1234 5678 (Example licence point 1)')
+    cy.get('[data-test="points-0"]').contains('At National Grid Reference TQ 1234 5678 (Example point 1)')
     cy.get('[data-test="abstraction-period-0"]').contains('From 1 March to 31 December')
     cy.get('[data-test="returns-cycle-0"]').contains('Winter and all year')
-    cy.get('[data-test="site-description-0"]').contains('Example licence point 1')
+    cy.get('[data-test="site-description-0"]').contains('Example point 1')
     cy.get('[data-test="frequency-collected-0"]').contains('Daily')
     cy.get('[data-test="frequency-reported-0"]').contains('Daily')
     cy.get('[data-test="agreements-exceptions-0"]').contains('None')
 
     // Return requirement 2
-    cy.get('#requirement-1 > div.govuk-summary-card__title-wrapper > h2').contains('Example licence point 2')
+    cy.get('#requirement-1 > div.govuk-summary-card__title-wrapper > h2').contains('Example point 2')
     cy.get('[data-test="purposes-1"]').contains('Laundry Use')
-    cy.get('[data-test="points-1"]').contains('At National Grid Reference TT 9876 5432 (Example licence point 2)')
+    cy.get('[data-test="points-1"]').contains('At National Grid Reference TT 9876 5432 (Example point 2)')
     cy.get('[data-test="abstraction-period-1"]').contains('From 12 June to 29 November')
     cy.get('[data-test="returns-cycle-1"]').contains('Winter and all year')
-    cy.get('[data-test="site-description-1"]').contains('Example licence point 2')
+    cy.get('[data-test="site-description-1"]').contains('Example point 2')
     cy.get('[data-test="frequency-collected-1"]').contains('Monthly')
     cy.get('[data-test="frequency-reported-1"]').contains('Monthly')
     cy.get('[data-test="agreements-exceptions-1"]').contains('None')

--- a/cypress/fixtures/barebones.json
+++ b/cypress/fixtures/barebones.json
@@ -156,8 +156,7 @@
     {
       "id": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
       "name": "Big Farm Co Ltd",
-      "type": "organisation",
-      "companyNumber": "12345"
+      "type": "organisation"
     }
   ],
   "addresses": [
@@ -367,7 +366,7 @@
     },
     {
       "id": "5649a988-3cdf-4a19-91ee-8a61355f8c9d",
-      "licenceId": "bb5605c9-5c28-43d3-a8b3-875013366b69",
+      "licenceId": "bcdf5049-fd2d-4e45-a3d6-37bcd443d431",
       "issue": 1,
       "increment": 0,
       "status": "current",
@@ -376,16 +375,54 @@
     },
     {
       "id": "eede57aa-f8d7-492a-bb6a-b5bccead5ce4",
-      "licenceId": "844e5fd5-f21c-418e-8d64-0be4d283133a",
+      "licenceId": "bb5605c9-5c28-43d3-a8b3-875013366b69",
       "issue": 1,
       "increment": 0,
       "status": "current",
       "startDate": "2020-01-01",
       "externalId": "6:1236:1:0"
+    },
+    {
+      "id": "49bf4843-8d2c-4667-8950-56d472f02bf6",
+      "licenceId": "844e5fd5-f21c-418e-8d64-0be4d283133a",
+      "issue": 1,
+      "increment": 0,
+      "status": "current",
+      "startDate": "2020-01-01",
+      "externalId": "6:1237:1:0"
+    }
+  ],
+  "points": [
+    {
+      "id": "1cb602f8-6a01-4435-96b0-541e03f460da",
+      "description": "Example point 1",
+      "ngr1": "TQ 1234 5678",
+      "externalId": "9:9000031",
+      "sourceId": {
+        "schema": "public",
+        "table": "sources",
+        "lookup": "legacyId",
+        "value": "S",
+        "select": "id"
+      }
+    },
+    {
+      "id": "82fab927-ef31-45a2-a4e6-104315cb9764",
+      "description": "Example point 2",
+      "ngr1": "TT 9876 5432",
+      "externalId": "9:9000032",
+      "sourceId": {
+        "schema": "public",
+        "table": "sources",
+        "lookup": "legacyId",
+        "value": "S",
+        "select": "id"
+      }
     }
   ],
   "licenceVersionPurposes": [
     {
+      "id": "f264184b-22a7-4e26-bd90-d5738eb2e07e",
       "licenceVersionId": "7ac6be4b-b7a0-4e35-9cd4-bd1c783af32b",
       "primaryPurposeId": {
         "schema": "water",
@@ -416,6 +453,7 @@
       "externalId": "6:1234"
     },
     {
+      "id": "fb82d30d-49e5-4295-96f9-03abf126cbd7",
       "licenceVersionId": "5649a988-3cdf-4a19-91ee-8a61355f8c9d",
       "primaryPurposeId": {
         "schema": "water",
@@ -446,6 +484,7 @@
       "externalId": "6:1235"
     },
     {
+      "id": "b663bab5-9875-4823-9b3d-d0a66ef22b9a",
       "licenceVersionId": "eede57aa-f8d7-492a-bb6a-b5bccead5ce4",
       "primaryPurposeId": {
         "schema": "water",
@@ -474,6 +513,55 @@
       "abstractionPeriodEndMonth": 3,
       "annualQuantity": 1554,
       "externalId": "6:1236"
+    },
+    {
+      "id": "2088b5cd-3fd9-425c-a4bd-0331596e6d94",
+      "licenceVersionId": "49bf4843-8d2c-4667-8950-56d472f02bf6",
+      "primaryPurposeId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "secondaryPurposeId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      },
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 4,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 3,
+      "annualQuantity": 1554,
+      "externalId": "6:1237"
+    }
+  ],
+  "licenceVersionPurposePoints": [
+    {
+      "licenceVersionPurposeId": "f264184b-22a7-4e26-bd90-d5738eb2e07e",
+      "pointId": "1cb602f8-6a01-4435-96b0-541e03f460da"
+    },
+    {
+      "licenceVersionPurposeId": "fb82d30d-49e5-4295-96f9-03abf126cbd7",
+      "pointId": "82fab927-ef31-45a2-a4e6-104315cb9764"
+    },
+    {
+      "licenceVersionPurposeId": "b663bab5-9875-4823-9b3d-d0a66ef22b9a",
+      "pointId": "1cb602f8-6a01-4435-96b0-541e03f460da"
+    },
+    {
+      "licenceVersionPurposeId": "2088b5cd-3fd9-425c-a4bd-0331596e6d94",
+      "pointId": "82fab927-ef31-45a2-a4e6-104315cb9764"
     }
   ],
   "returnVersions": [
@@ -484,7 +572,7 @@
       "endDate": null,
       "status": "current",
       "externalId": "6:9999990",
-      "licenceId": "844e5fd5-f21c-418e-8d64-0be4d283133a"
+      "licenceId": "8717da0e-28d4-4833-8e32-1da050b60055"
     },
     {
       "id": "c1c06cf3-5f81-4ebd-b814-b60b782f795b",
@@ -493,7 +581,7 @@
       "endDate": null,
       "status": "current",
       "externalId": "6:9999991",
-      "licenceId": "844e5fd5-f21c-418e-8d64-0be4d283133a"
+      "licenceId": "bcdf5049-fd2d-4e45-a3d6-37bcd443d431"
     },
     {
       "id": "5def1d92-0de9-4a31-aab6-b4373755c483",
@@ -502,7 +590,7 @@
       "endDate": null,
       "status": "current",
       "externalId": "6:9999992",
-      "licenceId": "844e5fd5-f21c-418e-8d64-0be4d283133a"
+      "licenceId": "bb5605c9-5c28-43d3-a8b3-875013366b69"
     },
     {
       "id": "4bba499d-c68c-433f-8f4b-d495ab7c8b34",
@@ -570,6 +658,24 @@
       "siteDescription": "WELL POINTS AT MARS",
       "legacyId": 9999993,
       "externalId": "6:9999993"
+    }
+  ],
+  "returnRequirementPoints": [
+    {
+      "returnRequirementId": "c33b9e4d-4d0f-4686-b1ac-6449ab014fd5",
+      "pointId": "1cb602f8-6a01-4435-96b0-541e03f460da"
+    },
+    {
+      "returnRequirementId": "35eb023b-0911-4876-9093-5f10406c4a2d",
+      "pointId": "82fab927-ef31-45a2-a4e6-104315cb9764"
+    },
+    {
+      "returnRequirementId": "7fe49b9d-4e6a-48da-9c7f-751689c7dd4f",
+      "pointId": "1cb602f8-6a01-4435-96b0-541e03f460da"
+    },
+    {
+      "returnRequirementId": "f4bcab6f-906a-4929-9ce7-87480364331b",
+      "pointId": "82fab927-ef31-45a2-a4e6-104315cb9764"
     }
   ],
   "returnRequirementPurposes": [

--- a/cypress/fixtures/returns-requirements.json
+++ b/cypress/fixtures/returns-requirements.json
@@ -187,20 +187,44 @@
       "dailyQuantity": "101"
     }
   ],
+  "points": [
+    {
+      "id": "1cb602f8-6a01-4435-96b0-541e03f460da",
+      "description": "Example point 1",
+      "ngr1": "TQ 1234 5678",
+      "externalId": "9:9000031",
+      "sourceId": {
+        "schema": "public",
+        "table": "sources",
+        "lookup": "legacyId",
+        "value": "S",
+        "select": "id"
+      }
+    },
+    {
+      "id": "82fab927-ef31-45a2-a4e6-104315cb9764",
+      "description": "Example point 2",
+      "ngr1": "TT 9876 5432",
+      "externalId": "9:9000032",
+      "sourceId": {
+        "schema": "public",
+        "table": "sources",
+        "lookup": "legacyId",
+        "value": "S",
+        "select": "id"
+      }
+    }
+  ],
   "licenceVersionPurposePoints": [
     {
       "id": "cda7facf-0dab-4e9b-9215-999ac9c24fbd",
       "licenceVersionPurposeId": "a4f9b0b5-11ac-4aa2-98c9-61c6c12088bb",
-      "description": "Example licence point 1",
-      "ngr1": "TQ 1234 5678",
-      "naldPointId": 9000031
+      "pointId": "1cb602f8-6a01-4435-96b0-541e03f460da"
     },
     {
       "id": "2ab25adb-78e6-4504-a8eb-641e4bf99db7",
       "licenceVersionPurposeId": "e1f22696-6a86-4b95-b8e5-6abb68fcf5e0",
-      "description": "Example licence point 2",
-      "ngr1": "TT 9876 5432",
-      "naldPointId": 9000032
+      "pointId": "82fab927-ef31-45a2-a4e6-104315cb9764"
     }
   ],
   "returnVersions": [
@@ -254,21 +278,11 @@
   "returnRequirementPoints": [
     {
       "returnRequirementId": "afa416d5-9b44-4ac5-a717-ead4e769c75f",
-      "description": "Example return point 1",
-      "ngr1": "TQ 1234 5678",
-      "ngr2": null,
-      "ngr3": null,
-      "ngr4": null,
-      "naldPointId": 9000031
+      "pointId": "1cb602f8-6a01-4435-96b0-541e03f460da"
     },
     {
       "returnRequirementId": "afa416d5-9b44-4ac5-a717-ead4e769c75f",
-      "description": "Example return point 2",
-      "ngr1": "TT 9876 5432",
-      "ngr2": null,
-      "ngr3": null,
-      "ngr4": null,
-      "naldPointId": 9000032
+      "pointId": "82fab927-ef31-45a2-a4e6-104315cb9764"
     }
   ]
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4600
https://eaflood.atlassian.net/browse/WATER-4645

> Part of the work to migrate return versions from NALD to WRLS

The new return version setup journey requires at least one point to be selected for each return requirement in the return version. The points to choose from come from those currently linked to the licence. Our initial solution copied what the legacy code did when it needed points, extracting them from the JSONB 'mega-blob' in `permit.licence` table. There simply was no other source.

We then hit a problem in that [water-abstraction-import](https://github.com/DEFRA/water-abstraction-import) wasn't populating this information once a licence was 'ended'. Users need to be able to correct and update the return version history, even for ended licences. We resolved to start importing NALD point information into new tables, along with details of which return requirements and licence version purposes were linked to them. It also includes the water sources for each point.

With this new data source in place, we've updated all functionality ([water-abstraction-system only!](https://github.com/DEFRA/water-abstraction-system)) that depends on points to use the new source.

Of course, this breaks a number of the acceptance tests because they are no longer populating the right tables. This change updates the fixtures to get them working again!