### PR TITLE
Rename Gauging stations to Monitoring stations

### DIFF
--- a/cypress/fixtures/barebones.json
+++ b/cypress/fixtures/barebones.json
@@ -844,7 +844,7 @@
       "restrictedSource": false
     }
   ],
-  "gaugingStations": [
+  "monitoringStations": [
     {
       "label": "Test Station 500"
     }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4679

> See also [Rename gauging stations to monitoring stations](https://github.com/DEFRA/water-abstraction-system/pull/1415)

When we first added gauging stations as a model to this project it was as part of our work to migrate the view licence page. Its summary tab will display any gauging stations the licence is linked to.

Though that's not really true! It displays the 'Monitoring stations' a licence is linked to. If you click through one that is listed, the page you'll see will be on the URL `/monitoring-stations` (both legacy and ours). The results are displayed under the section titled 'Monitoring stations' if you use the main search.

When we migrated the view licence page, we challenged why we still refer to them as 'Gauging stations' and whether we should update the UI to match.

The answer we got back was that though 'Gauging stations' is commonly used by the users we speak to, they are only one type of station that we have in our system. So, when this feature was added it was agreed to use the generic term 'Monitoring stations'.

What we now have is one of those discrepancies we often find in the legacy code which causes confusion. The DB and/or code are named differently from what we see in the UI.

So, before we do anything too adventurous with them, this change updates anything named 'gauging station' to be 'monitoring station'.