### PR TITLE
Fix external login journey for blank environment

### DIFF
--- a/cypress/e2e/external/login/journey.cy.js
+++ b/cypress/e2e/external/login/journey.cy.js
@@ -22,7 +22,7 @@ describe('Login and log out (external)', () => {
     cy.get('.govuk-button.govuk-button--start').click()
 
     //  Assert the user signed in
-    cy.contains('Add licences or give access')
+    cy.get('#navbar-view').should('exist')
 
     //  Click Sign out Button
     cy.get('#signout').click()


### PR DESCRIPTION
We hit an issue recently where the `cypress/e2e/external/login/journey.cy.js` test worked for the devs but not one of the QA's.

When we investigated, we found that the assertion was based on the external user logging in already having licences linked to their account.

Before we migrated the tests, this would have been the case because the user was created as part of a significant import of data referred to as 'barebones'. (psst! It wasn't that bare!)

Once migrated and after we switched to our new data seeder, we dropped the fixture load for this test. All non-prod environments now seed the same users, so for a simple login test, there should be no need to load a fixture.

It was working for most users because we had linked a licence to the seeded external user at some point as part of other testing/investigations.

But the QA this test failed for had never done that, so the element the test was asserting against never showed.

We can fix the test by asserting against an element that appears regardless of whether the user has linked licences.