### PR TITLE
Update review tests after tidy up work

### DIFF
--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-01.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-01.cy.js
@@ -143,7 +143,7 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     // Review Licence AT/TEST/01 ~ Check charge Information details
     cy.get('[data-test="financial-year"]').should('contain.text', 'Financial year 2022 to 2023')
     cy.get('#charge-version-0 > .govuk-heading-l').should('contain.text', 'Charge periods 1 April 2022 to 31 March 2023')
-    cy.get('[data-test="charge-version-0-details"]').should('contain.text', '1 charge reference  with 1 two-part tariff charge element')
+    cy.get('[data-test="charge-version-0-details"]').should('contain.text', '1 charge reference with 1 two-part tariff charge element')
     cy.get('.govuk-details__summary-text').should('contain.text', 'Big Farm Co Ltd 01 billing account details')
     cy.get('.govuk-details__summary').click()
     cy.get('[data-test="billing-account"]').should('contain.text', 'S99999991A')
@@ -184,12 +184,12 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     // View match details
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
     cy.get('.govuk-heading-l').should('contain.text', 'SROC Charge Purpose 01')
-    cy.get('.govuk-heading-l').should('contain.text', '1 April 2022 to 31 March 2023')
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
+    cy.get('[data-test="charge-period-0"]').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('.govuk-grid-column-full > .govuk-tag').should('contain.text', 'ready')
     cy.get('[data-test="financial-year"]').should('contain.text', 'Financial year 2022 to 2023')
     cy.get('[data-test="charge-period"]').should('contain.text', 'Charge period 1 April 2022 to 31 March 2023')
-    cy.get('[data-test="billable-returns"]').should('contain.text', '32ML')
-    cy.get('[data-test="authorised-volume"]').should('contain.text', '32ML')
+    cy.get('[data-test="billable-returns"]').should('contain.text', '32 ML')
+    cy.get('[data-test="authorised-volume"]').should('contain.text', '32 ML')
     cy.get('[data-test="issues-0"]').should('not.exist')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
@@ -200,19 +200,20 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
 
     // View match details ~ Edit the billable returns
     cy.get('.govuk-button').click()
-    cy.get('.govuk-caption-l').should('contain.text', 'SROC Charge Purpose 01 1 April 2022 to 31 March 2023')
-    cy.get('[data-test="title"]').should('contain.text', 'Set the billable returns quantity for this bill run')
+    cy.get('.govuk-caption-l').should('contain.text', 'SROC Charge Purpose 01')
+    cy.get('[data-test="charge-period-0"]').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('h1').should('contain.text', 'Set the billable returns quantity for this bill run')
     cy.get('[data-test="financial-year"]').should('contain.text', 'Financial year 2022 to 2023')
     cy.get('[data-test="charge-period"]').should('contain.text', 'Charge period 1 April 2022 to 31 March 2023')
     cy.get('[data-test="authorised-quantity"]').should('contain.text', 'Authorised 32ML')
-    cy.get('#custom-quantity').click()
-    cy.get('#custom-quantity-input').type('20.123')
+    cy.get('#custom-quantity-selector').click()
+    cy.get('#custom-quantity').type('20.123')
     cy.get('.govuk-button').click()
 
     // View match details ~ Check billable returns has updated
     cy.get('.govuk-notification-banner').should('exist')
     cy.get('.govuk-notification-banner__heading').should('contain.text', 'The billable returns for this licence have been updated')
-    cy.get('[data-test="billable-returns"]').should('contain.text', '20.123ML')
+    cy.get('[data-test="billable-returns"]').should('contain.text', '20.123 ML')
     cy.get('.govuk-back-link').click()
 
     // Review Licence AT/TEST/01 ~ Check billable returns has updated on licence review page

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-04.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-04.cy.js
@@ -120,7 +120,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="matched-return-total-0"]').should('contain.text', '32 ML / 32 ML')
     // Should be no issues on the return
-    cy.get('[data-test="matched-return-total-0"] > :nth-child(2)').should('contain.text', '')
+    cy.get('[data-test="matched-0-issue-0"]').should('not.exist')
 
     // Review Licence AT/TEST/01 ~ Check there are no other returns
     cy.get('[data-test="matched-return-action-1"] > .govuk-link').should('not.exist')
@@ -156,17 +156,18 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="total-billable-returns"]').should('contain.text', '32 ML')
     cy.get('[data-test="authorised-volume"]').should('contain.text', '32 ML')
     cy.get('[data-test="additional-charges"]').should('contain.text', 'Public Water Supply')
-    cy.get('[data-test="adjustment-0"]').should('contain.text', 'Aggregate factor (0.5)')
+    cy.get('[data-test="adjustment-0"]').should('contain.text', 'Aggregate factor (0.5 / 0.5)')
+    cy.get('[data-test="adjustment-1"]').should('contain.text', 'Charge adjustment (1 / 1)')
     cy.contains('Change factors').click()
 
     // Change factors page ~ Amend the aggregate
     cy.get('.govuk-heading-xl').should('contain.text', 'Set the adjustment factors')
-    cy.get('.govuk-inset-text > :nth-child(4)').should('contain.text', 'Public Water Supply')
-    cy.get('.govuk-inset-text > :nth-child(5)').should('contain.text', 'Two part tariff agreement')
-    cy.get('#amended-aggregate-factor').should('have.value', '0.5')
+    cy.get('[data-test="adjustment-0"]').should('contain.text', 'Public Water Supply')
+    cy.get('[data-test="adjustment-1"]').should('contain.text', 'Two part tariff agreement')
+    cy.get('#amended-aggregate').should('have.value', '0.5')
     cy.get('#amended-charge-adjustment').should('have.value', '1')
     // By changing the aggregate factor to 1 this removes it
-    cy.get('#amended-aggregate-factor')
+    cy.get('#amended-aggregate')
       .clear()
       .type('1')
     cy.contains('Confirm').click()
@@ -174,17 +175,17 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     // Charge reference details page ~ Checking the amended aggregate
     cy.get('.govuk-notification-banner').should('exist')
     cy.get('#govuk-notification-banner-title').should('contain.text', 'Adjustment updated')
-    // Check the aggregate value has been removed
-    cy.get('[data-test="adjustment-1"]').should('not.exist')
+    // Check the aggregate value has been updated
+    cy.get('[data-test="adjustment-0"]').should('contain.text', 'Aggregate factor (1 / 0.5)')
     // Check the link still exists once all charge adjustments have been removed
     cy.get('.govuk-summary-list__actions > .govuk-link').should('contain.text', 'Change factors')
     cy.contains('Change factors').click()
 
     // Change factors page ~ Amend the charge adjustment
     cy.get('.govuk-heading-xl').should('contain.text', 'Set the adjustment factors')
-    cy.get('.govuk-inset-text > :nth-child(4)').should('contain.text', 'Public Water Supply')
-    cy.get('.govuk-inset-text > :nth-child(5)').should('contain.text', 'Two part tariff agreement')
-    cy.get('#amended-aggregate-factor').should('have.value', '1')
+    cy.get('[data-test="adjustment-0"]').should('contain.text', 'Public Water Supply')
+    cy.get('[data-test="adjustment-1"]').should('contain.text', 'Two part tariff agreement')
+    cy.get('#amended-aggregate').should('have.value', '1')
     cy.get('#amended-charge-adjustment').should('have.value', '1')
     cy.get('#amended-charge-adjustment')
       .clear()
@@ -195,6 +196,6 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('.govuk-notification-banner').should('exist')
     cy.get('#govuk-notification-banner-title').should('contain.text', 'Adjustment updated')
     // This is checking the charge adjustment has been added
-    cy.get('[data-test="adjustment-0"]').should('contain.text', 'Charge adjustment (0.5)')
+    cy.get('[data-test="adjustment-1"]').should('contain.text', 'Charge adjustment (0.5 / 1)')
   })
 })

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-05.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-05.cy.js
@@ -120,7 +120,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="matched-return-total-0"]').should('contain.text', '32 ML / 32 ML')
     // Should be no issues on the return
-    cy.get('[data-test="matched-return-total-0"] > :nth-child(2)').should('contain.text', '')
+    cy.get('[data-test="matched-0-issue-0"]').should('not.exist')
 
     // Review Licence AT/TEST/01 ~ Check there are no other returns
     cy.get('[data-test="matched-return-action-1"] > .govuk-link').should('not.exist')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-09.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-09.cy.js
@@ -142,7 +142,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
 
     // Review Licence AT/TEST/01 ~ Check charge information details are correct
     cy.get('#charge-version-0 > .govuk-heading-l').should('contain.text', 'Charge periods 1 April 2022 to 31 March 2023')
-    cy.get('[data-test="charge-version-0-details"]').should('contain.text', '2 charge references  with 2 two-part tariff charge elements ')
+    cy.get('[data-test="charge-version-0-details"]').should('contain.text', '2 charge references with 2 two-part tariff charge elements')
     cy.get('[data-test="charge-version-0-reference-0"]').should('contain.text', 'Charge reference 4.6.19')
     // The first charge reference has a lower authorised volume than its charge element. This means we expect the return
     // to only allocate to the charge reference volume of 22ML
@@ -158,8 +158,8 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
 
     // View match details ~ For charge reference 1's element
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
-    cy.get('[data-test="billable-returns"]').should('contain.text', '22ML')
-    cy.get('[data-test="authorised-volume"]').should('contain.text', '42ML')
+    cy.get('[data-test="billable-returns"]').should('contain.text', '22 ML')
+    cy.get('[data-test="authorised-volume"]').should('contain.text', '42 ML')
     cy.get('[data-test="issues-0"]').should('contain.text', 'No returns received')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 October 2022 to 31 March 2023')
@@ -185,8 +185,8 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
 
     // View match details ~ For charge reference 2's element
     cy.get('[data-test="charge-version-0-charge-reference-1-charge-element-match-details-0"]').click()
-    cy.get('[data-test="billable-returns"]').should('contain.text', '32ML')
-    cy.get('[data-test="authorised-volume"]').should('contain.text', '32ML')
+    cy.get('[data-test="billable-returns"]').should('contain.text', '32 ML')
+    cy.get('[data-test="authorised-volume"]').should('contain.text', '32 ML')
     cy.get('[data-test="issues-0"]').should('contain.text', 'No returns received')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-10.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-10.cy.js
@@ -129,10 +129,10 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
 
     // View match details
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
-    cy.get('[data-test="billable-returns"]').should('contain.text', '32ML')
-    cy.get('[data-test="authorised-volume"]').should('contain.text', '32ML')
+    cy.get('[data-test="billable-returns"]').should('contain.text', '32 ML')
+    cy.get('[data-test="authorised-volume"]').should('contain.text', '32 ML')
     cy.get('[data-test="issues-0"]').should('contain.text', 'Unable to match return')
-    cy.get('#main-content > :nth-child(6)').should('contain.text', 'No two-part tariff returns')
+    cy.get('[data-test="no-returns-message"]').should('contain.text', 'No matching two-part tariff returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('not.exist')
     cy.get('[data-test="matched-return-summary-0"]').should('not.exist')
   })

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-11.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-11.cy.js
@@ -146,7 +146,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="charge-version-0-total-billable-returns-0"]').should('contain.text', '62 ML / 64 ML')
     // Without an aggregate of charge factor we shouldn't see the link "Change details" only "View details"
     cy.get('[data-test="charge-version-0-charge-reference-link-0"]').should('contain.text', 'View details')
-    cy.get('[data-test="charge-version-0-details"]').should('contain.text', '1 charge reference  with 2 two-part tariff charge elements')
+    cy.get('[data-test="charge-version-0-details"]').should('contain.text', '1 charge reference with 2 two-part tariff charge elements')
     // Charge element 1
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', 'SROC Charge Purpose 01')
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', '1 April 2022 to 31 March 2023')
@@ -166,8 +166,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
 
     // View match details ~ Charge element 1
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
-    cy.get('[data-test="billable-returns"]').should('contain.text', '32ML')
-    cy.get('[data-test="authorised-volume"]').should('contain.text', '32ML')
+    cy.get('[data-test="billable-returns"]').should('contain.text', '32 ML')
+    cy.get('[data-test="authorised-volume"]').should('contain.text', '32 ML')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
     cy.get('[data-test="matched-return-summary-0"]').contains('General Farming & Domestic A DRAIN SOMEWHERE')
@@ -178,8 +178,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
 
     // View match details ~ Charge element 2
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-1"]').click()
-    cy.get('[data-test="billable-returns"]').should('contain.text', '30ML')
-    cy.get('[data-test="authorised-volume"]').should('contain.text', '30ML')
+    cy.get('[data-test="billable-returns"]').should('contain.text', '30 ML')
+    cy.get('[data-test="authorised-volume"]').should('contain.text', '30 ML')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021669')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 May 2022 to 21 March 2023')
     cy.get('[data-test="matched-return-summary-0"]').contains('Mineral Washing A DRAIN SOMEWHERE')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-12.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-12.cy.js
@@ -129,7 +129,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
 
     // Review Licence AT/TEST/01 ~ Check charge Information details are correct for a licence with returns that are
     // split over charge references
-    cy.get('[data-test="charge-version-0-details"]').should('contain.text', '2 charge references  with 2 two-part tariff charge elements')
+    cy.get('[data-test="charge-version-0-details"]').should('contain.text', '2 charge references with 2 two-part tariff charge elements')
     // Charge reference 1 & 2
     cy.get('[data-test="charge-version-0-total-billable-returns-0"]').should('contain.text', '14 ML / 32 ML')
     cy.get('[data-test="charge-version-0-total-billable-returns-1"]').should('contain.text', '18 ML / 32 ML')
@@ -155,8 +155,8 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
 
     // View match details ~ Charge element 1
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
-    cy.get('[data-test="billable-returns"]').should('contain.text', '14ML')
-    cy.get('[data-test="authorised-volume"]').should('contain.text', '14ML')
+    cy.get('[data-test="billable-returns"]').should('contain.text', '14 ML')
+    cy.get('[data-test="authorised-volume"]').should('contain.text', '14 ML')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
     cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
     cy.get('[data-test="matched-return-summary-0"]').contains('General Farming & Domestic A DRAIN SOMEWHERE')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-13.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-13.cy.js
@@ -122,14 +122,14 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('[data-test="unmatched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="unmatched-return-total-0"] > :nth-child(2)').should('contain.text', 'Over abstraction')
     // When a return hasn't matched to a charge element we don't expect it to allocate
-    cy.get('[data-test="unmatched-return-total-0"] > :nth-child(1)').should('contain.text', '0 / 32 ML')
+    cy.get('[data-test="unmatched-return-total-0"] > :nth-child(1)').should('contain.text', '0 ML / 32 ML')
 
     // Review Licence AT/TEST/01 ~ Check there are no other returns
     cy.get('[data-test="unmatched-return-action-1"] > .govuk-link').should('not.exist')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('not.exist')
 
     // Review Licence AT/TEST/01 ~ Check charge Information details are correct for a charge element with no matching returns
-    cy.get('[data-test="charge-version-0-details"]').should('contain.text', '1 charge reference  with 1 two-part tariff charge element')
+    cy.get('[data-test="charge-version-0-details"]').should('contain.text', '1 charge reference with 1 two-part tariff charge element')
     cy.get('[data-test="charge-version-0-total-billable-returns-0"]').should('contain.text', '32 ML / 32 ML')
     // Without an aggregate of charge factor we shouldn't see the link "Change details" only "View details"
     cy.get('[data-test="charge-version-0-charge-reference-link-0"]').should('contain.text', 'View details')
@@ -144,10 +144,10 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
 
     // View match details
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
-    cy.get('[data-test="billable-returns"]').should('contain.text', '32ML')
-    cy.get('[data-test="authorised-volume"]').should('contain.text', '32ML')
+    cy.get('[data-test="billable-returns"]').should('contain.text', '32 ML')
+    cy.get('[data-test="authorised-volume"]').should('contain.text', '32 ML')
     cy.get('[data-test="issues-0"]').should('contain.text', 'Unable to match return')
-    cy.get('#main-content > :nth-child(6)').should('contain.text', 'No two-part tariff returns')
+    cy.get('[data-test="no-returns-message"]').should('contain.text', 'No matching two-part tariff returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('not.exist')
     cy.get('.govuk-back-link').click()
   })

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-14.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-14.cy.js
@@ -104,8 +104,8 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 April to 31 March')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
-   // Should be no issues on the return
-   cy.get('[data-test="matched-0-issue-0"]').should('not.exist')
+    // Should be no issues on the return
+    cy.get('[data-test="matched-0-issue-0"]').should('not.exist')
     // The return should be fully allocated over the two charge elements
     cy.get('[data-test="matched-return-total-0"] > :nth-child(1)').should('contain.text', '50 ML / 50 ML')
 

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-14.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-14.cy.js
@@ -92,7 +92,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
 
     // Review Licence AT/TEST/01 ~ Check the licence details
     cy.get('h1').should('contain.text', 'Licence AT/TEST/01')
-    cy.get('[data-test="licence-holder"]').should('contain.text', 'Licence holder Mr J J Testerson')
+    cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'ready')
     cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff bill run')
     cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
@@ -104,7 +104,8 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 April to 31 March')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
-    cy.get('[data-test="matched-return-total-0"] > :nth-child(2)').should('contain.text', '')
+   // Should be no issues on the return
+   cy.get('[data-test="matched-0-issue-0"]').should('not.exist')
     // The return should be fully allocated over the two charge elements
     cy.get('[data-test="matched-return-total-0"] > :nth-child(1)').should('contain.text', '50 ML / 50 ML')
 
@@ -114,7 +115,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
 
     // Review Licence AT/TEST/01 ~ Check charge Information details are correct for 2 charge elements with one matching
     // return
-    cy.get('[data-test="charge-version-0-details"]').should('contain.text', '1 charge reference  with 2 two-part tariff charge elements')
+    cy.get('[data-test="charge-version-0-details"]').should('contain.text', '1 charge reference with 2 two-part tariff charge elements')
     cy.get('[data-test="charge-version-0-total-billable-returns-0"]').should('contain.text', '50 ML / 50 ML')
     // Without an aggregate of charge factor we shouldn't see the link "Change details" only "View details"
     cy.get('[data-test="charge-version-0-charge-reference-link-0"]').should('contain.text', 'Change details')
@@ -145,13 +146,13 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     // authorised volume of the charge reference, triggering the warning.
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
     cy.get('.govuk-button').contains('Edit the billable returns').click()
-    cy.get('#custom-quantity').click()
-    cy.get('#custom-quantity-input').type('10')
+    cy.get('#custom-quantity-selector').click()
+    cy.get('#custom-quantity').type('10')
     cy.get('.govuk-button').contains('Confirm').click()
     cy.get('.govuk-back-link').click()
     cy.get('[data-test="charge-version-0-charge-reference-link-0"]').click()
     cy.get('.govuk-button').contains('Change the authorised volume').click()
-    cy.get('#authorised-volume').clear().type('40')
+    cy.get('#amended-authorised-volume').clear().type('40')
     cy.get('.govuk-button').contains('Confirm').click()
     cy.get('.govuk-back-link').click()
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4739

For a detailed explanation of the tidy-up work, see [Tidy up two-part tariff review code and routes](https://github.com/DEFRA/water-abstraction-system/pull/1443). In short, 12 months after starting the work, we'd have structured the code differently, knowing what we know now.

That tidy-up work has affected some of the views, which means some of the tests are failing because they can no longer identify the elements to select. This change updates the review tests to get them working again.