### PR TITLE
Update abstraction alert tests after changes

### DIFF
--- a/cypress/e2e/internal/abstraction-alerts/journey.cy.js
+++ b/cypress/e2e/internal/abstraction-alerts/journey.cy.js
@@ -59,7 +59,7 @@ describe('mBOD abstraction alert journey (internal)', () => {
     cy.get('.govuk-link').contains('Return to monitoring station').click()
 
     // Issue a stop warning
-    cy.get('.govuk-grid-column-full').contains('Create a water abstraction alert').click()
+    cy.get('.govuk-button').contains('Create a water abstraction alert').click()
     cy.get('.govuk-radios__input[value="warning"]').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
@@ -86,8 +86,8 @@ describe('mBOD abstraction alert journey (internal)', () => {
 
     cy.get('form > .govuk-button').contains('Confirm').click()
 
-    cy.get('.govuk-heading-l').contains('Test Station 500').should('be.visible')
-    cy.get('.govuk-body').contains('There are no licences tagged with restrictions for this monitoring station').should('be.visible')
+    cy.get('.govuk-heading-xl').contains('Test Station 500').should('be.visible')
+    cy.get('p.govuk-body').contains('There are no licences tagged with restrictions for this monitoring station').should('be.visible')
     cy.get('.govuk-button').contains('Tag a licence').should('be.visible')
   })
 })

--- a/cypress/e2e/internal/abstraction-alerts/journey.cy.js
+++ b/cypress/e2e/internal/abstraction-alerts/journey.cy.js
@@ -30,6 +30,12 @@ describe('mBOD abstraction alert journey (internal)', () => {
     cy.contains('Monitoring stations')
     cy.get('.govuk-table__row').contains('Test Station 500').click()
 
+    // Confirm we are on the monitoring station page
+    cy.get('.govuk-heading-xl').contains('Test Station 500').should('be.visible')
+    cy.get('[data-test="meta-data-grid-reference"]').should('have.text', 'ST5820172718')
+    cy.get('[data-test="meta-data-wiski-id"]').should('be.empty')
+    cy.get('[data-test="meta-data-station-reference"]').should('be.empty')
+
     // Tag a licence to the monitoring station
     cy.get('.govuk-button').contains('Tag a licence').click()
 

--- a/cypress/e2e/internal/abstraction-alerts/validation.cy.js
+++ b/cypress/e2e/internal/abstraction-alerts/validation.cy.js
@@ -76,7 +76,7 @@ describe('mBOD abstraction alert validation (internal)', () => {
       .should('contain', 'mBOD')
 
     // Issue a stop warning
-    cy.get('.govuk-grid-column-full').contains('Create a water abstraction alert').click()
+    cy.get('.govuk-button').contains('Create a water abstraction alert').click()
 
     // Validations
     // Select the type of alert you need to send?
@@ -136,7 +136,7 @@ describe('mBOD abstraction alert validation (internal)', () => {
     cy.get('.govuk-fieldset__heading').contains('You are about to remove tags from this licence').should('be.visible')
     cy.get('form > .govuk-button').contains('Confirm').click()
 
-    cy.get('.govuk-heading-l').contains('Test Station 500').should('be.visible')
+    cy.get('.govuk-heading-xl').contains('Test Station 500').should('be.visible')
     cy.get('.govuk-body').contains('There are no licences tagged with restrictions for this monitoring station').should('be.visible')
     cy.get('.govuk-button').contains('Tag a licence').should('be.visible')
   })

--- a/cypress/fixtures/barebones.json
+++ b/cypress/fixtures/barebones.json
@@ -846,7 +846,8 @@
   ],
   "monitoringStations": [
     {
-      "label": "Test Station 500"
+      "label": "Test Station 500",
+      "gridReference": "ST5820172718"
     }
   ],
   "returnLogs": [


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4736

We have migrated the view monitoring stations page from the legacy code to [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system). We have updated the page design and used current GDS design components. However, these changes have caused some of the tests to break.

This change updates them so they can locate the updated elements on the page.