### PR TITLE
Update bill run setup to include new /check page

### DIFF
--- a/cypress/e2e/internal/billing/annual/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/annual/cancel-existing.cy.js
@@ -52,6 +52,9 @@ describe('Cancel an existing annual bill run (internal)', () => {
     cy.get('label.govuk-radios__label').contains('Test Region').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // Bill runs
     //
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few

--- a/cypress/e2e/internal/billing/annual/journey.cy.js
+++ b/cypress/e2e/internal/billing/annual/journey.cy.js
@@ -54,6 +54,9 @@ describe('Create and send annual bill run (internal)', () => {
     cy.get('label.govuk-radios__label').contains('Test Region').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // Bill runs
     //
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few

--- a/cypress/e2e/internal/billing/annual/remove-licence.cy.js
+++ b/cypress/e2e/internal/billing/annual/remove-licence.cy.js
@@ -61,6 +61,9 @@ describe('Remove bill from annual bill run (internal)', () => {
     cy.get('label.govuk-radios__label').contains('Test Region').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // Bill runs
     //
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few

--- a/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
@@ -54,6 +54,9 @@ describe('Cancel existing supplementary bill runs (internal)', () => {
     cy.get('label.govuk-radios__label').contains('Test Region').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // -------------------------------------------------------------------------
     cy.log('Deleting the PRESROC supplementary bill run')
 

--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
@@ -62,6 +62,9 @@ describe('Change billing account in current financial year (internal)', () => {
     cy.get('label.govuk-radios__label').contains('Test Region').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // Bill runs
     //
     // The bill run we created will be the second from top result. We expect it's status to be BUILDING. Building might
@@ -219,6 +222,9 @@ describe('Change billing account in current financial year (internal)', () => {
     // choose Test Region and continue
     cy.get('label.govuk-radios__label').contains('Test Region').click()
     cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
 
     // -------------------------------------------------------------------------
     cy.log('Confirming and sending the SROC supplementary bill run')

--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
@@ -62,6 +62,9 @@ describe('Change billing account in previous financial year (internal)', () => {
     cy.get('label.govuk-radios__label').contains('Test Region').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // Bill runs
     //
     // The bill run we created will be the second from top result. We expect it's status to be BUILDING. Building might
@@ -221,6 +224,9 @@ describe('Change billing account in previous financial year (internal)', () => {
     // choose Test Region and continue
     cy.get('label.govuk-radios__label').contains('Test Region').click()
     cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
 
     // -------------------------------------------------------------------------
     cy.log('Confirming and sending the SROC supplementary bill run')

--- a/cypress/e2e/internal/billing/supplementary/journey.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/journey.cy.js
@@ -71,6 +71,9 @@ describe('Create and send supplementary bill runs (internal)', () => {
     cy.get('label.govuk-radios__label').contains('Test Region').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // Bill runs
     //
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few

--- a/cypress/e2e/internal/billing/supplementary/no-annual-in-current-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/no-annual-in-current-year.cy.js
@@ -65,6 +65,9 @@ describe('Create and send supplementary bill runs (internal)', () => {
     cy.get('label.govuk-radios__label').contains('Test Region').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // Bill runs
     //
     // The bill run we created will be the second from top result. We expect it's status to be BUILDING. Building might

--- a/cypress/e2e/internal/billing/supplementary/non-charge-licence-credit.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/non-charge-licence-credit.cy.js
@@ -57,6 +57,9 @@ describe('Make licence non-chargeable then see credit in next bill run (internal
     cy.get('label.govuk-radios__label').contains('Test Region').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // Bill runs
     //
     // The bill run we created will be the second from top result. We expect it's status to be BUILDING. Building might
@@ -179,6 +182,9 @@ describe('Make licence non-chargeable then see credit in next bill run (internal
     // choose Test Region and continue
     cy.get('label.govuk-radios__label').contains('Test Region').click()
     cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
 
     // Bill runs
     //

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
@@ -138,6 +138,9 @@ describe('Replace charge version in the 2023 financial year with no changes (int
     cy.get('label.govuk-radios__label').contains('Test Region').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // Bill runs
     //
     // The bill run we created will be the second from top result. We expect it's status to be BUILDING. Building might
@@ -276,6 +279,9 @@ describe('Replace charge version in the 2023 financial year with no changes (int
     // choose Test Region and continue
     cy.get('label.govuk-radios__label').contains('Test Region').click()
     cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
 
     // -------------------------------------------------------------------------
     cy.log('Confirming and sending the SROC supplementary bill run')

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
@@ -138,6 +138,9 @@ describe('Replace charge version in current financial year change the charge ref
     cy.get('label.govuk-radios__label').contains('Test Region').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // Bill runs
     //
     // The bill run we created will be the second from top result. We expect it's status to be BUILDING. Building might
@@ -325,6 +328,9 @@ describe('Replace charge version in current financial year change the charge ref
     // choose Test Region and continue
     cy.get('label.govuk-radios__label').contains('Test Region').click()
     cy.get('form > .govuk-button').contains('Continue').click()
+
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
 
     // -------------------------------------------------------------------------
     cy.log('Confirming and sending the SROC supplementary bill run')

--- a/cypress/e2e/internal/billing/two-part-tariff/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/cancel-existing.cy.js
@@ -53,6 +53,9 @@ describe('Cancel an existing two-part tariff bill run (internal)', () => {
     cy.get('label.govuk-radios__label').contains('Winter and All year').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // Bill runs
     //
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few

--- a/cypress/e2e/internal/billing/two-part-tariff/empty-bill-run.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/empty-bill-run.cy.js
@@ -50,6 +50,9 @@ describe('Create a empty SROC two-part tariff bill run (internal)', () => {
     cy.get('label.govuk-radios__label').contains('2023 to 2024').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status EMPTY, and
     // if not found reload the page and try again. We then select it using the link on the date created

--- a/cypress/e2e/internal/billing/two-part-tariff/journey.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/journey.cy.js
@@ -56,6 +56,9 @@ describe('Create and send PRESROC two-part tariff bill run (internal)', () => {
     cy.get('label.govuk-radios__label').contains('Winter and All year').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // Bill runs
     //
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-01.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-01.cy.js
@@ -66,6 +66,9 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status REVIEW, and
     // if not found reload the page and try again. We then select it using the link on the date created

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-02.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-02.cy.js
@@ -58,6 +58,9 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status REVIEW, and
     // if not found reload the page and try again. We then select it using the link on the date created

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-03.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-03.cy.js
@@ -59,6 +59,9 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status REVIEW, and
     // if not found reload the page and try again. We then select it using the link on the date created

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-04.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-04.cy.js
@@ -59,6 +59,9 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status REVIEW, and
     // if not found reload the page and try again. We then select it using the link on the date created

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-05.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-05.cy.js
@@ -59,6 +59,9 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status REVIEW, and
     // if not found reload the page and try again. We then select it using the link on the date created

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-06.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-06.cy.js
@@ -59,6 +59,9 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status REVIEW, and
     // if not found reload the page and try again. We then select it using the link on the date created

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-07.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-07.cy.js
@@ -59,6 +59,9 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status REVIEW, and
     // if not found reload the page and try again. We then select it using the link on the date created

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-08.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-08.cy.js
@@ -60,6 +60,9 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status REVIEW, and
     // if not found reload the page and try again. We then select it using the link on the date created

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-09.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-09.cy.js
@@ -63,6 +63,9 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status REVIEW, and
     // if not found reload the page and try again. We then select it using the link on the date created

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-10.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-10.cy.js
@@ -60,6 +60,9 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status REVIEW, and
     // if not found reload the page and try again. We then select it using the link on the date created

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-11.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-11.cy.js
@@ -60,6 +60,9 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status REVIEW, and
     // if not found reload the page and try again. We then select it using the link on the date created

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-12.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-12.cy.js
@@ -60,6 +60,9 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status REVIEW, and
     // if not found reload the page and try again. We then select it using the link on the date created

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-13.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-13.cy.js
@@ -59,6 +59,9 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status REVIEW, and
     // if not found reload the page and try again. We then select it using the link on the date created

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-14.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-14.cy.js
@@ -58,6 +58,9 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
+    // Check the bill run
+    cy.get('.govuk-button').contains('Create bill run').click()
+
     // The bill run we created will be the top result. We expect it's status to be BUILDING. Building might take a few
     // seconds though so to avoid the test failing we use our custom Cypress command to look for the status REVIEW, and
     // if not found reload the page and try again. We then select it using the link on the date created


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4201

> Part of the work to support two-part tariff bill runs

As part of WATER-4200 we made a series of changes to the bill run setup journey to support Two-part tariff supplementary. What we didn't do was add in the checks to ensure we could create a two-part tariff supplementary.

We've come to do that now and realised two things.

- the checks to see if an existing bill run blocks the one being created are confusing
- the end of our bill run setup journey is confusing

We tackle the first issue in [Refactor bill run setup checks ready for 2PT supp.](https://github.com/DEFRA/water-abstraction-system/pull/1542)

We resolved the second issue in [Add /check into bill run setup ready for 2PT supp.](https://github.com/DEFRA/water-abstraction-system/pull/1550) by adding a new `/check` page to the bill run setup process.

That change breaks all our existing bill-run acceptance tests. So, this change updates them to handle the new page.

![Screenshot 2024-12-10 at 23 24 46](https://github.com/user-attachments/assets/c3ec97b4-b66b-437e-b810-87fca74e548d)

![Screenshot 2024-12-10 at 23 25 02](https://github.com/user-attachments/assets/1f627155-376e-4984-ade2-560dea6be95a)
