### PR TITLE
Update 2PT review tests to match actual titles

### DIFF
--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-01.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-01.cy.js
@@ -128,7 +128,7 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     cy.get('h1').should('contain.text', 'Licence AT/TEST/01')
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'ready')
-    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff bill run')
+    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
     cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
 
     // Review Licence AT/TEST/01 ~ Check the Licence links

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-02.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-02.cy.js
@@ -96,7 +96,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('h1').should('contain.text', 'Licence AT/TEST/01')
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'ready')
-    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff bill run')
+    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
     cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
 
     // Review Licence AT/TEST/01 ~ Check the first matched return details

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-03.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-03.cy.js
@@ -109,7 +109,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('h1').should('contain.text', 'Licence AT/TEST/01')
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'ready')
-    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff bill run')
+    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
     cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
 
     // Review Licence AT/TEST/01 ~ Check the first matched return details include the returns received late issue

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-04.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-04.cy.js
@@ -111,7 +111,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('h1').should('contain.text', 'Licence AT/TEST/01')
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'review')
-    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff bill run')
+    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
     cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
 
     // Review Licence AT/TEST/01 ~ Check the matched return details

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-05.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-05.cy.js
@@ -111,7 +111,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('h1').should('contain.text', 'Licence AT/TEST/01')
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'review')
-    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff bill run')
+    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
     cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
 
     // Review Licence AT/TEST/01 ~ Check the matched return details

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-06.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-06.cy.js
@@ -111,7 +111,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('h1').should('contain.text', 'Licence AT/TEST/01')
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'review')
-    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff bill run')
+    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
     cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
 
     // Review Licence AT/TEST/01 ~ Check the first matched return details

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-07.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-07.cy.js
@@ -111,7 +111,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('h1').should('contain.text', 'Licence AT/TEST/01')
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'review')
-    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff bill run')
+    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
     cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
 
     // Review Licence AT/TEST/01 ~ Check the first matched return details

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-08.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-08.cy.js
@@ -99,7 +99,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('h1').should('contain.text', 'Licence AT/TEST/01')
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'ready')
-    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff bill run')
+    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
     cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
 
     // Review Licence AT/TEST/01 ~ Check the first matched return details

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-09.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-09.cy.js
@@ -116,7 +116,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('h1').should('contain.text', 'Licence AT/TEST/01')
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'ready')
-    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff bill run')
+    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
     // On this licence there are two charge versions meaning we have two charge period links
     cy.get('[data-test="charge-period-0"]').should('contain.text', '1 April 2022 to 31 March 2023')
 

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-10.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-10.cy.js
@@ -112,7 +112,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('h1').should('contain.text', 'Licence AT/TEST/01')
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'review')
-    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff bill run')
+    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
     cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
 
     // Review Licence AT/TEST/01 ~ Check there are no returns

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-11.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-11.cy.js
@@ -113,7 +113,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('h1').should('contain.text', 'Licence AT/TEST/01')
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'ready')
-    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff bill run')
+    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
     cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
 
     // Review Licence AT/TEST/01 ~ Check the first matched return details

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-12.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-12.cy.js
@@ -112,7 +112,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('h1').should('contain.text', 'Licence AT/TEST/01')
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'review')
-    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff bill run')
+    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
     cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
 
     // Review Licence AT/TEST/01 ~ Check the first matched return details

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-13.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-13.cy.js
@@ -113,7 +113,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('h1').should('contain.text', 'Licence AT/TEST/01')
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'review')
-    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff bill run')
+    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
     cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
 
     // Review Licence AT/TEST/01 ~ Check the unmatched return details

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-14.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-14.cy.js
@@ -97,7 +97,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('h1').should('contain.text', 'Licence AT/TEST/01')
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'ready')
-    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff bill run')
+    cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
     cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
 
     // Review Licence AT/TEST/01 ~ Check the matched return details


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4201

> Part of the work to support two-part tariff bill runs

As part of updating the service to support two-part tariff supplementary bill runs, we needed to update the review pages to ensure the title reflected the two types of two-part tariff bill run.

That's when we spotted that the existing functionality is not using our bill run title helpers, ensuring titles are displayed consistently and correctly. We updated [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system/pull/1562) to use the new helpers. But this has meant the expected titles no longer match what we generate.

This change fixes the tests.