### PR TITLE
Update approving a charge version test

### DIFF
--- a/cypress/e2e/internal/supplementary-billing-flags/approving-a-charge-version.cy.js
+++ b/cypress/e2e/internal/supplementary-billing-flags/approving-a-charge-version.cy.js
@@ -151,6 +151,6 @@ describe('SROC charge information journey (internal)', () => {
     cy.contains('Review').should('not.exist')
 
     cy.get('.govuk-notification-banner__content')
-      .should('contain.text', 'This licence has been marked for the next two-part tariff supplementary bill run.')
+      .should('contain.text', 'This licence has been marked for the next two-part tariff supplementary bill run and the supplementary bill run.')
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4874

Following our last release, a live issue was reported where charge versions were not being flagged for supplementary billing. The issue stemmed from a misunderstanding in the flagging logic: when a two-part tariff charge version was approved, the service only flagged for two-part tariff years instead of also marking the licence for SROC supplementary billing. The fix was done in the system repo
https://github.com/DEFRA/water-abstraction-system/pull/1616

This PR corrects the acceptance test to now expect both the two-part tariff flag and the sroc supplementary billing flag.