### PR TITLE
add historic returns acceptance test sceanorios

### DIFF
--- a/cypress/e2e/internal/return-logs/historic-corrections-01.cy.js
+++ b/cypress/e2e/internal/return-logs/historic-corrections-01.cy.js
@@ -1,0 +1,130 @@
+'use strict'
+
+describe('Submit winter and all year historic correction using abstraction data', () => {
+  let year = new Date().getFullYear()
+  if (new Date().getMonth() < 4) {
+    year = year - 1
+  }
+
+  beforeEach(() => {
+    cy.tearDown()
+
+    cy.fixture('return-logs-historic-01.json').then((fixture) => {
+      for (let i = 0; i < fixture.returnLogs.length; i++) {
+        fixture.returnLogs[i].id = `v1:9:AT/CURR/DAILY/01:9999990:${year - i}-04-01:${year + 1 - i}-03-31`
+        fixture.returnLogs[i].dueDate = `${year + 1 - i}-04-28`
+        fixture.returnLogs[i].endDate = `${year + 1 - i}-03-31`
+        fixture.returnLogs[i].startDate = `${year - i}-04-01`
+        fixture.returnLogs[i].returnCycleId.value = `${year - i}-04-01`
+      }
+      cy.load(fixture)
+    })
+
+    cy.fixture('users.json').its('billingAndData').as('userEmail')
+  })
+
+  it('creates a return requirement using abstraction data and approves the requirement', () => {
+    cy.visit('/')
+
+    // enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('#email').type(userEmail)
+    })
+
+    cy.get('#password').type(Cypress.env('defaultPassword'))
+
+    // click Sign in Button
+    cy.get('form > .govuk-button').click()
+
+    // assert the user signed in and we're on the search page
+    cy.contains('Search')
+
+    // search for a licence
+    cy.get('#query').type('AT/CURR/DAILY/01')
+    cy.get('.search__button').click()
+    cy.get('.govuk-table__row > :nth-child(1) > a').click()
+
+    // confirm we are on the licence page
+    cy.contains('AT/CURR/DAILY/01')
+
+    // click returns tab
+    cy.contains('Returns').click()
+
+    // confirm we are on the licence returns tab and that there are previous reuturn logs
+    cy.get('#returns > .govuk-heading-l').contains('Returns')
+    cy.get('[data-test="return-due-date-0"]').contains(`28 April ${year + 1}`)
+    cy.get('[data-test="return-status-0"] > .govuk-tag').contains('due')
+    cy.get('[data-test="return-due-date-1"]').contains(`28 April ${year}`)
+    cy.get('[data-test="return-status-1"] > .govuk-tag').contains('complete')
+    cy.get('[data-test="return-due-date-2"]').contains(`28 April ${year - 1}`)
+    cy.get('[data-test="return-status-2"] > .govuk-tag').contains('complete')
+    cy.get('[data-test="return-due-date-3"]').contains(`28 April ${year - 2}`)
+    cy.get('[data-test="return-status-3"] > .govuk-tag').contains('complete')
+    cy.get('[data-test="return-due-date-4"]').contains(`28 April ${year - 3}`)
+    cy.get('[data-test="return-status-4"] > .govuk-tag').contains('complete')
+
+    // click licence set up tab
+    cy.contains('Licence set up').click()
+
+    // confirm we are on the licence set up tab
+    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
+
+    // click set up new requirements
+    cy.contains('Set up new requirements').click()
+
+    // set the start date to be 2 years in the past
+    cy.get('#another-start-date').check()
+    cy.get('#other-start-date-day').type('01')
+    cy.get('#other-start-date-month').type('11')
+    cy.get('#other-start-date-year').type(year - 2)
+    cy.contains('Continue').click()
+
+    // confirm we are on the reason page
+    cy.get('.govuk-fieldset__heading').contains('Select the reason for the requirements for returns')
+
+    // choose reason (new licence) and click continue
+    cy.get('#reason-10').check()
+    cy.contains('Continue').click()
+
+    // confirm we are on the set up page
+    cy.get('.govuk-fieldset__heading').contains('How do you want to set up the requirements for returns?')
+
+    // choose the start by using abstraction data checkbox and continue
+    cy.get('#method').check()
+    cy.contains('Continue').click()
+
+    // confirm we are back on the check page
+    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+
+    // choose the approve return requirement button
+    cy.contains('Approve returns requirement').click()
+
+    // confirm we are on the approved page
+    cy.get('.govuk-panel__title').contains('Requirements for returns approved')
+
+    // click link to return to licence set up and the returns tabs
+    cy.contains('Return to licence set up').click()
+    cy.contains('Returns').click()
+
+    // confirm we are on the licence set up tab
+    cy.get('#returns > .govuk-heading-l').contains('Returns')
+    cy.get('[data-test="return-due-date-0"]').contains(`28 April ${year + 1}`)
+    cy.get('[data-test="return-status-0"] > .govuk-tag').contains('due')
+    cy.get('[data-test="return-due-date-1"]').contains(`28 April ${year + 1}`)
+    cy.get('[data-test="return-status-1"] > .govuk-tag').contains('void')
+    cy.get('[data-test="return-due-date-2"]').contains(`28 April ${year}`)
+    cy.get('[data-test="return-status-2"] > .govuk-tag').contains('overdue')
+    cy.get('[data-test="return-due-date-3"]').contains(`28 April ${year}`)
+    cy.get('[data-test="return-status-3"] > .govuk-tag').contains('void')
+    cy.get('[data-test="return-due-date-4"]').contains(`28 April ${year - 1}`)
+    cy.get('[data-test="return-status-4"] > .govuk-tag').contains('overdue')
+    cy.get('[data-test="return-due-date-5"]').contains(`28 April ${year - 1}`)
+    cy.get('[data-test="return-status-5"] > .govuk-tag').contains('overdue')
+    cy.get('[data-test="return-due-date-6"]').contains(`28 April ${year - 1}`)
+    cy.get('[data-test="return-status-6"] > .govuk-tag').contains('void')
+    cy.get('[data-test="return-due-date-7"]').contains(`28 April ${year - 2}`)
+    cy.get('[data-test="return-status-7"] > .govuk-tag').contains('complete')
+    cy.get('[data-test="return-due-date-8"]').contains(`28 April ${year - 3}`)
+    cy.get('[data-test="return-status-8"] > .govuk-tag').contains('complete')
+  })
+})

--- a/cypress/e2e/internal/return-logs/historic-corrections-02.cy.js
+++ b/cypress/e2e/internal/return-logs/historic-corrections-02.cy.js
@@ -1,0 +1,187 @@
+'use strict'
+
+const {
+  determineCycleDueDate,
+  determineCycleEndDate,
+  determineCycleStartDate
+} = require('../../../lib/return-cycle-dates.lib.js')
+const { formatLongDate } = require('../../../lib/formatters.lib.js')
+
+describe('Submit summer and winter and all year historic correction using abstraction data', () => {
+  let returnCycleDueDate
+  let longDueDate
+  let year = new Date().getFullYear()
+  let winterYear = new Date().getFullYear()
+  let summerYear = new Date().getFullYear()
+
+  if (new Date().getMonth() < 4) {
+    year = year - 1
+  }
+
+  beforeEach(() => {
+    cy.tearDown()
+
+    cy.fixture('return-logs-historic-02.json').then((fixture) => {
+      for (let i = 0; i < fixture.returnLogs.length; i++) {
+        if (i % 2 === 0) {
+          if (new Date().getMonth() < 4) {
+            winterYear = winterYear - 1
+          }
+          fixture.returnLogs[i].id = `v1:9:AT/CURR/DAILY/01:9999990:${winterYear}-04-01:${winterYear + 1}-03-31`
+          fixture.returnLogs[i].dueDate = `${winterYear + 1}-04-28`
+          fixture.returnLogs[i].endDate = `${winterYear + 1}-03-31`
+          fixture.returnLogs[i].startDate = `${winterYear}-04-01`
+          fixture.returnLogs[i].returnCycleId.value = `${winterYear}-04-01`
+        } else {
+          if (new Date().getMonth() < 11) {
+            summerYear = summerYear - 1
+          }
+
+          fixture.returnLogs[i].id = `v1:9:AT/CURR/DAILY/01:9999991:${summerYear}-11-01:${summerYear + 1}-10-31`
+          fixture.returnLogs[i].dueDate = `${summerYear + 1}-11-28`
+          fixture.returnLogs[i].endDate = `${summerYear + 1}-10-31`
+          fixture.returnLogs[i].startDate = `${summerYear}-11-01`
+          fixture.returnLogs[i].returnCycleId.value = `${summerYear}-11-01`
+        }
+
+      }
+      cy.load(fixture)
+    })
+
+    cy.fixture('users.json').its('billingAndData').as('userEmail')
+  })
+
+  it('creates a return requirement using abstraction data and approves the requirement', () => {
+    cy.visit('/')
+
+    // enter the user name and Password
+    cy.get('@userEmail').then((userEmail) => {
+      cy.get('#email').type(userEmail)
+    })
+
+    cy.get('#password').type(Cypress.env('defaultPassword'))
+
+    // click Sign in Button
+    cy.get('form > .govuk-button').click()
+
+    // assert the user signed in and we're on the search page
+    cy.contains('Search')
+
+    // search for a licence
+    cy.get('#query').type('AT/CURR/DAILY/01')
+    cy.get('.search__button').click()
+    cy.get('.govuk-table__row > :nth-child(1) > a').click()
+
+    // confirm we are on the licence page
+    cy.contains('AT/CURR/DAILY/01')
+
+    // click returns tab
+    cy.contains('Returns').click()
+
+    // confirm we are on the licence returns tab and that there are previous reuturn logs
+    cy.get('#returns > .govuk-heading-l').contains('Returns')
+
+    const determinationDate = new Date()
+    returnCycleDueDate = determineCycleDueDate(true, determinationDate)
+    cy.get('[data-test="return-due-date-0"]').contains(formatLongDate(returnCycleDueDate))
+    cy.get('[data-test="return-status-0"] > .govuk-tag').contains('due')
+
+    returnCycleDueDate = determineCycleDueDate(false, determinationDate)
+    cy.get('[data-test="return-due-date-1"]').contains(formatLongDate(returnCycleDueDate))
+    cy.get('[data-test="return-status-1"] > .govuk-tag').contains('due')
+
+    determinationDate.setFullYear(determinationDate.getFullYear() - 1)
+    returnCycleDueDate = determineCycleDueDate(true, determinationDate)
+    cy.get('[data-test="return-due-date-2"]').contains(formatLongDate(returnCycleDueDate))
+    cy.get('[data-test="return-status-2"] > .govuk-tag').contains('complete')
+
+    returnCycleDueDate = determineCycleDueDate(false, determinationDate)
+    cy.get('[data-test="return-due-date-3"]').contains(formatLongDate(returnCycleDueDate))
+    cy.get('[data-test="return-status-3"] > .govuk-tag').contains('complete')
+
+    // click licence set up tab
+    cy.contains('Licence set up').click()
+
+    // confirm we are on the licence set up tab
+    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
+
+    // click set up new requirements
+    cy.contains('Set up new requirements').click()
+
+    // set the start date to be the beginning of the current winter and all year cycle
+    const winterAndAllYearStartDate = determineCycleStartDate(false)
+    cy.get('#another-start-date').check()
+    cy.get('#other-start-date-day').type('01')
+    cy.get('#other-start-date-month').type('04')
+    cy.get('#other-start-date-year').type(winterAndAllYearStartDate.getFullYear())
+    cy.contains('Continue').click()
+
+    // confirm we are on the reason page
+    cy.get('.govuk-fieldset__heading').contains('Select the reason for the requirements for returns')
+
+    // choose reason (new licence) and click continue
+    cy.get('#reason-10').check()
+    cy.contains('Continue').click()
+
+    // confirm we are on the set up page
+    cy.get('.govuk-fieldset__heading').contains('How do you want to set up the requirements for returns?')
+
+    // choose copy from existing requirements and continue
+    cy.get('#method-2').check()
+    cy.contains('Continue').click()
+
+    // confirm we are on the existing requirements page
+    cy.get('.govuk-fieldset__heading').contains('Use previous requirements for returns')
+
+    // choose a previous requirements for returns and continue
+    cy.get('#existing').check()
+    cy.contains('Continue').click()
+
+    // confirm we are back on the check page
+    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+
+    // choose the approve return requirement button
+    cy.contains('Approve returns requirement').click()
+
+    // confirm we are on the approved page
+    cy.get('.govuk-panel__title').contains('Requirements for returns approved')
+
+    // click link to return to licence set up and the returns tabs
+    cy.contains('Return to licence set up').click()
+    cy.contains('Returns').click()
+
+    // confirm we are on the licence set up tab
+    cy.get('#returns > .govuk-heading-l').contains('Returns')
+
+    const dueDate = new Date()
+    returnCycleDueDate = determineCycleDueDate(true, dueDate)
+    longDueDate = formatLongDate(returnCycleDueDate)
+    cy.get('[data-test="return-due-date-0"]').contains(longDueDate)
+    cy.get('[data-test="return-status-0"] > .govuk-tag').contains('due')
+    cy.get('[data-test="return-due-date-1"]').contains(longDueDate)
+    cy.get('[data-test="return-status-1"] > .govuk-tag').contains('void')
+
+    returnCycleDueDate = determineCycleDueDate(false, dueDate)
+    longDueDate = formatLongDate(returnCycleDueDate)
+    cy.get('[data-test="return-due-date-2"]').contains(longDueDate)
+    cy.get('[data-test="return-status-2"] > .govuk-tag').contains('due')
+    cy.get('[data-test="return-due-date-3"]').contains(longDueDate)
+    cy.get('[data-test="return-status-3"] > .govuk-tag').contains('void')
+
+    dueDate.setFullYear(dueDate.getFullYear() - 1)
+    returnCycleDueDate = determineCycleDueDate(true, dueDate)
+    longDueDate = formatLongDate(returnCycleDueDate)
+    cy.get('[data-test="return-due-date-4"]').contains(longDueDate)
+    cy.get('[data-test="return-status-4"] > .govuk-tag').contains('due')
+    cy.get('[data-test="return-due-date-5"]').contains(longDueDate)
+    cy.get('[data-test="return-status-5"] > .govuk-tag').contains('due')
+    cy.get('[data-test="return-due-date-6"]').contains(longDueDate)
+    cy.get('[data-test="return-status-6"] > .govuk-tag').contains('void')
+
+    dueDate.setFullYear(dueDate.getFullYear())
+    returnCycleDueDate = determineCycleDueDate(false, dueDate)
+    longDueDate = formatLongDate(returnCycleDueDate)
+    cy.get('[data-test="return-due-date-7"]').contains(longDueDate)
+    cy.get('[data-test="return-status-7"] > .govuk-tag').contains('complete')
+  })
+})

--- a/cypress/e2e/internal/return-logs/historic-corrections-02.cy.js
+++ b/cypress/e2e/internal/return-logs/historic-corrections-02.cy.js
@@ -2,7 +2,6 @@
 
 const {
   determineCycleDueDate,
-  determineCycleEndDate,
   determineCycleStartDate
 } = require('../../../lib/return-cycle-dates.lib.js')
 const { formatLongDate } = require('../../../lib/formatters.lib.js')
@@ -10,13 +9,8 @@ const { formatLongDate } = require('../../../lib/formatters.lib.js')
 describe('Submit summer and winter and all year historic correction using abstraction data', () => {
   let returnCycleDueDate
   let longDueDate
-  let year = new Date().getFullYear()
   let winterYear = new Date().getFullYear()
   let summerYear = new Date().getFullYear()
-
-  if (new Date().getMonth() < 4) {
-    year = year - 1
-  }
 
   beforeEach(() => {
     cy.tearDown()
@@ -43,7 +37,6 @@ describe('Submit summer and winter and all year historic correction using abstra
           fixture.returnLogs[i].startDate = `${summerYear}-11-01`
           fixture.returnLogs[i].returnCycleId.value = `${summerYear}-11-01`
         }
-
       }
       cy.load(fixture)
     })

--- a/cypress/e2e/internal/returns/submit.cy.js
+++ b/cypress/e2e/internal/returns/submit.cy.js
@@ -38,10 +38,10 @@ describe('Submit a return (internal)', () => {
 
     // confirm we see the due return
     cy.get('#returns').within(() => {
-      cy.get('.govuk-table__row:nth-child(1)').should('be.visible').and('contain.text', '9999992')
-      cy.get('.govuk-table__row:nth-child(1)').should('be.visible').and('contain.text', 'Due')
+      cy.get('.govuk-table__row:nth-child(2)').should('be.visible').and('contain.text', '9999992')
+      cy.get('.govuk-table__row:nth-child(2)').should('be.visible').and('contain.text', 'overdue')
 
-      cy.get('.govuk-table__row:nth-child(1) a').contains('9999992').click()
+      cy.get('.govuk-table__row:nth-child(2) a').contains('9999992').click()
     })
 
     // What do you want to do with this return?

--- a/cypress/e2e/internal/returns/view-status.cy.js
+++ b/cypress/e2e/internal/returns/view-status.cy.js
@@ -38,11 +38,11 @@ describe('View returns and their status (internal)', () => {
 
     // confirm we see the expected returns and their statuses
     cy.get('#returns').within(() => {
-      cy.get('.govuk-table__row:nth-child(1)').should('be.visible').and('contain.text', '9999992')
-      cy.get('.govuk-table__row:nth-child(1)').should('be.visible').and('contain.text', 'due')
+      cy.get('.govuk-table__row:nth-child(1)').should('be.visible').and('contain.text', '9999993')
+      cy.get('.govuk-table__row:nth-child(1)').should('be.visible').and('contain.text', 'void')
 
-      cy.get('.govuk-table__row:nth-child(2)').should('be.visible').and('contain.text', '9999993')
-      cy.get('.govuk-table__row:nth-child(2)').should('be.visible').and('contain.text', 'void')
+      cy.get('.govuk-table__row:nth-child(2)').should('be.visible').and('contain.text', '9999992')
+      cy.get('.govuk-table__row:nth-child(2)').should('be.visible').and('contain.text', 'overdue')
 
       cy.get('.govuk-table__row:nth-child(3)').should('be.visible').and('contain.text', '9999991')
       cy.get('.govuk-table__row:nth-child(3)').should('be.visible').and('contain.text', 'overdue')

--- a/cypress/fixtures/return-logs-historic-01.json
+++ b/cypress/fixtures/return-logs-historic-01.json
@@ -1,0 +1,1165 @@
+{
+  "permitLicences": [
+    {
+      "licenceRef": "AT/CURR/DAILY/01",
+      "startDate": "2020-01-01",
+      "metadata": {
+        "source": "acceptance-test-setup"
+      }
+    },
+    {
+      "licenceRef": "AT/CURR/WEEKLY/01",
+      "startDate": "2020-01-01",
+      "metadata": {
+        "source": "acceptance-test-setup"
+      }
+    },
+    {
+      "licenceRef": "AT/CURR/MONTHLY/01",
+      "startDate": "2020-01-01",
+      "metadata": {
+        "source": "acceptance-test-setup"
+      }
+    },
+    {
+      "licenceRef": "AT/CURR/MONTHLY/02",
+      "startDate": "2020-01-01",
+      "metadata": {
+        "source": "acceptance-test-setup"
+      }
+    }
+  ],
+  "licenceEntities": [
+    {
+      "id": "1742895f-5e18-41e0-94bd-d5c9845cb558",
+      "name": "external@example.com",
+      "type": "individual"
+    },
+    {
+      "id": "e86c312b-222d-404f-ae08-eb90a80bec18",
+      "name": "Big Farm Co Ltd",
+      "type": "company"
+    }
+  ],
+  "licenceEntityRoles": [
+    {
+      "id": "f99998c5-0676-43c3-bf6c-41b1103111bf",
+      "licenceEntityId": "1742895f-5e18-41e0-94bd-d5c9845cb558",
+      "companyEntityId": "e86c312b-222d-404f-ae08-eb90a80bec18",
+      "role": "primary_user",
+      "createdBy": "acceptance-test-setup"
+    }
+  ],
+  "licenceDocumentHeaders": [
+    {
+      "id": "c86c9d49-e06f-4792-8307-8e2c38aa6838",
+      "regimeEntityId": {
+        "schema": "crm",
+        "table": "entity",
+        "lookup": "entityType",
+        "value": "regime",
+        "select": "entityId"
+      },
+      "licenceRef": "AT/CURR/DAILY/01",
+      "naldId": {
+        "schema": "public",
+        "table": "permitLicences",
+        "lookup": "licenceRef",
+        "value": "AT/CURR/DAILY/01",
+        "select": "id"
+      },
+      "metadata": {
+        "Name": "cupcake factory",
+        "dataType": "acceptance-test-setup",
+        "IsCurrent": true
+      },
+      "licence_name": "the daily cupcake licence",
+      "companyEntityId": "e86c312b-222d-404f-ae08-eb90a80bec18"
+    },
+    {
+      "id": "f5dbd812-4238-4b02-8eaa-8f7b3de467d4",
+      "regimeEntityId": {
+        "schema": "crm",
+        "table": "entity",
+        "lookup": "entityType",
+        "value": "regime",
+        "select": "entityId"
+      },
+      "licenceRef": "AT/CURR/WEEKLY/01",
+      "naldId": {
+        "schema": "public",
+        "table": "permitLicences",
+        "lookup": "licenceRef",
+        "value": "AT/CURR/WEEKLY/01",
+        "select": "id"
+      },
+      "metadata": {
+        "Name": "barber bakery",
+        "dataType": "acceptance-test-setup",
+        "IsCurrent": true
+      },
+      "licence_name": "the weekly crumpet licence",
+      "companyEntityId": "e86c312b-222d-404f-ae08-eb90a80bec18"
+    },
+    {
+      "id": "7660ae8b-d619-43ca-bead-5ff6e24e2d11",
+      "regimeEntityId": {
+        "schema": "crm",
+        "table": "entity",
+        "lookup": "entityType",
+        "value": "regime",
+        "select": "entityId"
+      },
+      "licenceRef": "AT/CURR/MONTHLY/01",
+      "naldId": {
+        "schema": "public",
+        "table": "permitLicences",
+        "lookup": "licenceRef",
+        "value": "AT/CURR/MONTHLY/01",
+        "select": "id"
+      },
+      "metadata": {
+        "Name": "shop",
+        "dataType": "acceptance-test-setup",
+        "IsCurrent": true
+      },
+      "licence_name": "the monthly pie licence",
+      "companyEntityId": "e86c312b-222d-404f-ae08-eb90a80bec18"
+    },
+    {
+      "id": "91b89b5d-ebf4-48be-ba92-a89e65118ba8",
+      "regimeEntityId": {
+        "schema": "crm",
+        "table": "entity",
+        "lookup": "entityType",
+        "value": "regime",
+        "select": "entityId"
+      },
+      "licenceRef": "AT/CURR/MONTHLY/02",
+      "naldId": {
+        "schema": "public",
+        "table": "permitLicences",
+        "lookup": "licenceRef",
+        "value": "AT/CURR/MONTHLY/02",
+        "select": "id"
+      },
+      "metadata": {
+        "Name": "doughnut store",
+        "dataType": "acceptance-test-setup",
+        "IsCurrent": true
+      },
+      "licence_name": "the monthly doughnut licence",
+      "companyEntityId": "e86c312b-222d-404f-ae08-eb90a80bec18"
+    }
+  ],
+  "companies": [
+    {
+      "id": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "name": "Big Farm Co Ltd",
+      "type": "organisation"
+    }
+  ],
+  "addresses": [
+    {
+      "id": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "address1": "Big Farm",
+      "address2": "Windy road",
+      "address3": "Buttercup meadow",
+      "address4": "Buttercup Village",
+      "address5": "Testington",
+      "address6": "Testingshire",
+      "postcode": "TT1 1TT",
+      "country": "UK",
+      "dataSource": "nald"
+    }
+  ],
+  "companyAddresses": [
+    {
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "startDate": "2008-04-01",
+      "licenceRoleId": {
+        "schema": "crm_v2",
+        "table": "roles",
+        "lookup": "name",
+        "value": "billing",
+        "select": "roleId"
+      }
+    }
+  ],
+  "contacts": [
+    {
+      "id": "6e05db31-39cd-4bb0-83a0-0d985037ad8f",
+      "salutation": "Mr",
+      "firstName": "John",
+      "lastName": "Testerson",
+      "middleInitials": "J",
+      "contactType": "person",
+      "dataSource": "nald"
+    }
+  ],
+  "companyContacts": [
+    {
+      "id": "e01e7717-719f-47ed-8431-362f6b4de422",
+      "contactId": "6e05db31-39cd-4bb0-83a0-0d985037ad8f",
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "licenceRoleId": {
+        "schema": "crm_v2",
+        "table": "roles",
+        "lookup": "name",
+        "value": "licenceHolder",
+        "select": "roleId"
+      },
+      "startDate": "2018-01-01"
+    }
+  ],
+  "billingAccounts": [
+    {
+      "id": "16cb50a5-e3e6-41f4-a42b-9dad6a69fc0c",
+      "accountNumber": "A99999999A",
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778"
+    }
+  ],
+  "billingAccountAddresses": [
+    {
+      "id": "ab9a24ec-80b8-40dc-82f8-7df3e885245a",
+      "billingAccountId": "16cb50a5-e3e6-41f4-a42b-9dad6a69fc0c",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "startDate": "2008-04-01"
+    }
+  ],
+  "licenceDocuments": [
+    {
+      "id": "1a274f3e-f891-43dd-8c25-8afac4e760ac",
+      "licenceRef": "AT/CURR/DAILY/01",
+      "startDate": "2018-01-01"
+    },
+    {
+      "id": "4fe682ac-c558-41fc-aead-85dca40efc89",
+      "licenceRef": "AT/CURR/WEEKLY/01",
+      "startDate": "2020-01-01"
+    },
+    {
+      "id": "1305f637-eea8-455c-92ae-f52015aa001b",
+      "licenceRef": "AT/CURR/MONTHLY/01",
+      "startDate": "2018-01-01"
+    },
+    {
+      "id": "74498584-b26b-405a-9111-743fc46a185e",
+      "licenceRef": "AT/CURR/MONTHLY/02",
+      "startDate": "2018-01-01"
+    }
+  ],
+  "licenceDocumentRoles": [
+    {
+      "licenceDocumentId": "1a274f3e-f891-43dd-8c25-8afac4e760ac",
+      "licenceRoleId": {
+        "schema": "public",
+        "table": "licenceRoles",
+        "lookup": "name",
+        "value": "licenceHolder",
+        "select": "id"
+      },
+      "startDate": "2018-01-01",
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "contactId": "6e05db31-39cd-4bb0-83a0-0d985037ad8f"
+    },
+    {
+      "licenceDocumentId": "4fe682ac-c558-41fc-aead-85dca40efc89",
+      "licenceRoleId": {
+        "schema": "public",
+        "table": "licenceRoles",
+        "lookup": "name",
+        "value": "licenceHolder",
+        "select": "id"
+      },
+      "startDate": "2018-01-01",
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "contactId": "6e05db31-39cd-4bb0-83a0-0d985037ad8f"
+    },
+    {
+      "licenceDocumentId": "1305f637-eea8-455c-92ae-f52015aa001b",
+      "licenceRoleId": {
+        "schema": "public",
+        "table": "licenceRoles",
+        "lookup": "name",
+        "value": "licenceHolder",
+        "select": "id"
+      },
+      "startDate": "2018-01-01",
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "contactId": "6e05db31-39cd-4bb0-83a0-0d985037ad8f"
+    },
+    {
+      "licenceDocumentId": "74498584-b26b-405a-9111-743fc46a185e",
+      "licenceRoleId": {
+        "schema": "public",
+        "table": "licenceRoles",
+        "lookup": "name",
+        "value": "licenceHolder",
+        "select": "id"
+      },
+      "startDate": "2018-01-01",
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "contactId": "6e05db31-39cd-4bb0-83a0-0d985037ad8f"
+    }
+  ],
+  "licences": [
+    {
+      "id": "8717da0e-28d4-4833-8e32-1da050b60055",
+      "licenceRef": "AT/CURR/DAILY/01",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
+      "regions": {
+        "historicalAreaCode": "SAAR",
+        "regionalChargeArea": "Southern"
+      },
+      "startDate": "2020-01-01",
+      "waterUndertaker": true
+    },
+    {
+      "id": "bcdf5049-fd2d-4e45-a3d6-37bcd443d431",
+      "licenceRef": "AT/CURR/WEEKLY/01",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
+      "regions": {
+        "historicalAreaCode": "SAAR",
+        "regionalChargeArea": "Southern"
+      },
+      "startDate": "2020-01-01",
+      "waterUndertaker": false
+    },
+    {
+      "id": "bb5605c9-5c28-43d3-a8b3-875013366b69",
+      "licenceRef": "AT/CURR/MONTHLY/01",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
+      "regions": {
+        "historicalAreaCode": "SAAR",
+        "regionalChargeArea": "Southern"
+      },
+      "startDate": "2020-01-01",
+      "waterUndertaker": false
+    },
+    {
+      "id": "844e5fd5-f21c-418e-8d64-0be4d283133a",
+      "licenceRef": "AT/CURR/MONTHLY/02",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
+      "regions": {
+        "historicalAreaCode": "SAAR",
+        "regionalChargeArea": "Southern"
+      },
+      "startDate": "2020-01-01",
+      "waterUndertaker": false
+    }
+  ],
+  "licenceVersions": [
+    {
+      "id": "7ac6be4b-b7a0-4e35-9cd4-bd1c783af32b",
+      "licenceId": "8717da0e-28d4-4833-8e32-1da050b60055",
+      "issue": 1,
+      "increment": 0,
+      "status": "current",
+      "startDate": "2020-01-01",
+      "externalId": "6:1234:1:0"
+    },
+    {
+      "id": "5649a988-3cdf-4a19-91ee-8a61355f8c9d",
+      "licenceId": "bcdf5049-fd2d-4e45-a3d6-37bcd443d431",
+      "issue": 1,
+      "increment": 0,
+      "status": "current",
+      "startDate": "2020-01-01",
+      "externalId": "6:1235:1:0"
+    },
+    {
+      "id": "eede57aa-f8d7-492a-bb6a-b5bccead5ce4",
+      "licenceId": "bb5605c9-5c28-43d3-a8b3-875013366b69",
+      "issue": 1,
+      "increment": 0,
+      "status": "current",
+      "startDate": "2020-01-01",
+      "externalId": "6:1236:1:0"
+    },
+    {
+      "id": "49bf4843-8d2c-4667-8950-56d472f02bf6",
+      "licenceId": "844e5fd5-f21c-418e-8d64-0be4d283133a",
+      "issue": 1,
+      "increment": 0,
+      "status": "current",
+      "startDate": "2020-01-01",
+      "externalId": "6:1237:1:0"
+    }
+  ],
+  "points": [
+    {
+      "id": "1cb602f8-6a01-4435-96b0-541e03f460da",
+      "description": "Example point 1",
+      "ngr1": "TQ 1234 5678",
+      "externalId": "9:9000031",
+      "sourceId": {
+        "schema": "public",
+        "table": "sources",
+        "lookup": "legacyId",
+        "value": "S",
+        "select": "id"
+      }
+    },
+    {
+      "id": "82fab927-ef31-45a2-a4e6-104315cb9764",
+      "description": "Example point 2",
+      "ngr1": "TT 9876 5432",
+      "externalId": "9:9000032",
+      "sourceId": {
+        "schema": "public",
+        "table": "sources",
+        "lookup": "legacyId",
+        "value": "S",
+        "select": "id"
+      }
+    }
+  ],
+  "licenceVersionPurposes": [
+    {
+      "id": "f264184b-22a7-4e26-bd90-d5738eb2e07e",
+      "licenceVersionId": "7ac6be4b-b7a0-4e35-9cd4-bd1c783af32b",
+      "primaryPurposeId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "secondaryPurposeId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      },
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 4,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 3,
+      "annualQuantity": 1554,
+      "externalId": "6:1234"
+    },
+    {
+      "id": "fb82d30d-49e5-4295-96f9-03abf126cbd7",
+      "licenceVersionId": "5649a988-3cdf-4a19-91ee-8a61355f8c9d",
+      "primaryPurposeId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "secondaryPurposeId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      },
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 4,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 3,
+      "annualQuantity": 1554,
+      "externalId": "6:1235"
+    },
+    {
+      "id": "b663bab5-9875-4823-9b3d-d0a66ef22b9a",
+      "licenceVersionId": "eede57aa-f8d7-492a-bb6a-b5bccead5ce4",
+      "primaryPurposeId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "secondaryPurposeId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      },
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 4,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 3,
+      "annualQuantity": 1554,
+      "externalId": "6:1236"
+    },
+    {
+      "id": "2088b5cd-3fd9-425c-a4bd-0331596e6d94",
+      "licenceVersionId": "49bf4843-8d2c-4667-8950-56d472f02bf6",
+      "primaryPurposeId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "secondaryPurposeId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      },
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 4,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 3,
+      "annualQuantity": 1554,
+      "externalId": "6:1237"
+    }
+  ],
+  "licenceVersionPurposePoints": [
+    {
+      "licenceVersionPurposeId": "f264184b-22a7-4e26-bd90-d5738eb2e07e",
+      "pointId": "1cb602f8-6a01-4435-96b0-541e03f460da"
+    },
+    {
+      "licenceVersionPurposeId": "fb82d30d-49e5-4295-96f9-03abf126cbd7",
+      "pointId": "82fab927-ef31-45a2-a4e6-104315cb9764"
+    },
+    {
+      "licenceVersionPurposeId": "b663bab5-9875-4823-9b3d-d0a66ef22b9a",
+      "pointId": "1cb602f8-6a01-4435-96b0-541e03f460da"
+    },
+    {
+      "licenceVersionPurposeId": "2088b5cd-3fd9-425c-a4bd-0331596e6d94",
+      "pointId": "82fab927-ef31-45a2-a4e6-104315cb9764"
+    }
+  ],
+  "returnVersions": [
+    {
+      "id": "bcd4e8c7-16ed-419c-915d-d8f184e45ed5",
+      "version": 101,
+      "startDate": "2019-01-01",
+      "endDate": null,
+      "status": "current",
+      "externalId": "6:9999990",
+      "licenceId": "8717da0e-28d4-4833-8e32-1da050b60055"
+    },
+    {
+      "id": "c1c06cf3-5f81-4ebd-b814-b60b782f795b",
+      "version": 101,
+      "startDate": "2020-01-01",
+      "endDate": null,
+      "status": "current",
+      "externalId": "6:9999991",
+      "licenceId": "bcdf5049-fd2d-4e45-a3d6-37bcd443d431"
+    },
+    {
+      "id": "5def1d92-0de9-4a31-aab6-b4373755c483",
+      "version": 101,
+      "startDate": "2021-01-01",
+      "endDate": null,
+      "status": "current",
+      "externalId": "6:9999992",
+      "licenceId": "bb5605c9-5c28-43d3-a8b3-875013366b69"
+    },
+    {
+      "id": "4bba499d-c68c-433f-8f4b-d495ab7c8b34",
+      "version": 102,
+      "startDate": "2021-01-01",
+      "endDate": null,
+      "status": "superseded",
+      "externalId": "6:9999993",
+      "licenceId": "844e5fd5-f21c-418e-8d64-0be4d283133a"
+    }
+  ],
+  "returnRequirements": [
+    {
+      "id": "c33b9e4d-4d0f-4686-b1ac-6449ab014fd5",
+      "returnsFrequency": "month",
+      "returnVersionId": "bcd4e8c7-16ed-419c-915d-d8f184e45ed5",
+      "summer": false,
+      "upload": false,
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 1,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 12,
+      "siteDescription": "WELL POINTS AT MARS",
+      "legacyId": 9999990,
+      "externalId": "9:9999990"
+    },
+    {
+      "id": "35eb023b-0911-4876-9093-5f10406c4a2d",
+      "returnsFrequency": "month",
+      "returnVersionId": "c1c06cf3-5f81-4ebd-b814-b60b782f795b",
+      "summer": false,
+      "upload": false,
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 1,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 12,
+      "siteDescription": "WELL POINTS AT MARS",
+      "legacyId": 9999991,
+      "externalId": "6:9999991"
+    },
+    {
+      "id": "7fe49b9d-4e6a-48da-9c7f-751689c7dd4f",
+      "returnsFrequency": "month",
+      "returnVersionId": "5def1d92-0de9-4a31-aab6-b4373755c483",
+      "summer": false,
+      "upload": false,
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 1,
+      "abstractionPeriodEndDay": 28,
+      "abstractionPeriodEndMonth": 2,
+      "siteDescription": "WELL POINTS AT MARS",
+      "legacyId": 9999992,
+      "externalId": "6:9999992"
+    },
+    {
+      "id": "f4bcab6f-906a-4929-9ce7-87480364331b",
+      "returnsFrequency": "month",
+      "returnVersionId": "4bba499d-c68c-433f-8f4b-d495ab7c8b34",
+      "summer": false,
+      "upload": false,
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 1,
+      "abstractionPeriodEndDay": 28,
+      "abstractionPeriodEndMonth": 2,
+      "siteDescription": "WELL POINTS AT MARS",
+      "legacyId": 9999993,
+      "externalId": "6:9999993"
+    }
+  ],
+  "returnRequirementPoints": [
+    {
+      "returnRequirementId": "c33b9e4d-4d0f-4686-b1ac-6449ab014fd5",
+      "pointId": "1cb602f8-6a01-4435-96b0-541e03f460da"
+    },
+    {
+      "returnRequirementId": "35eb023b-0911-4876-9093-5f10406c4a2d",
+      "pointId": "82fab927-ef31-45a2-a4e6-104315cb9764"
+    },
+    {
+      "returnRequirementId": "7fe49b9d-4e6a-48da-9c7f-751689c7dd4f",
+      "pointId": "1cb602f8-6a01-4435-96b0-541e03f460da"
+    },
+    {
+      "returnRequirementId": "f4bcab6f-906a-4929-9ce7-87480364331b",
+      "pointId": "82fab927-ef31-45a2-a4e6-104315cb9764"
+    }
+  ],
+  "returnRequirementPurposes": [
+    {
+      "returnRequirementId": "c33b9e4d-4d0f-4686-b1ac-6449ab014fd5",
+      "externalId": "6:9999990:A:AGR:420",
+      "alias": "SPRAY IRRIGATION STORAGE",
+      "primaryPurposeId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "secondaryPurposeId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      },
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      }
+    },
+    {
+      "returnRequirementId": "35eb023b-0911-4876-9093-5f10406c4a2d",
+      "externalId": "6:9999991:A:AGR:420",
+      "alias": "SPRAY IRRIGATION STORAGE",
+      "primaryPurposeId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "secondaryPurposeId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      },
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      }
+    },
+    {
+      "returnRequirementId": "7fe49b9d-4e6a-48da-9c7f-751689c7dd4f",
+      "externalId": "6:9999992:A:AGR:420",
+      "alias": "SPRAY IRRIGATION STORAGE",
+      "primaryPurposeId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "secondaryPurposeId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      },
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      }
+    },
+    {
+      "returnRequirementId": "f4bcab6f-906a-4929-9ce7-87480364331b",
+      "externalId": "6:9999993:A:AGR:420",
+      "alias": "SPRAY IRRIGATION STORAGE",
+      "primaryPurposeId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "secondaryPurposeId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      },
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      }
+    }
+  ],
+  "chargeVersions": [
+    {
+      "id": "fb1c7c5d-e723-4ab2-861e-5aae6d428019",
+      "licenceId": "8717da0e-28d4-4833-8e32-1da050b60055",
+      "licenceRef": "AT/CURR/DAILY/01",
+      "billingAccountId": "16cb50a5-e3e6-41f4-a42b-9dad6a69fc0c",
+      "regionCode": 9,
+      "scheme": "alcs",
+      "versionNumber": 1,
+      "startDate": "2018-01-01",
+      "status": "current",
+      "source": "wrls",
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778"
+    }
+  ],
+  "chargeReferences": [
+    {
+      "id": "69ea7fd9-961b-4d5d-be8b-ecd0e9cc8482",
+      "chargeVersionId": "fb1c7c5d-e723-4ab2-861e-5aae6d428019",
+      "factorsOverridden": false,
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 4,
+      "description": "Test Charge Element!",
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 3,
+      "authorisedAnnualQuantity": 15.54,
+      "season": "all year",
+      "seasonDerived": "all year",
+      "source": "unsupported",
+      "loss": "medium",
+      "purposePrimaryId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "purposeSecondaryId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      },
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "chargeCategoryId": null,
+      "additionalCharges": {},
+      "scheme": "alcs",
+      "adjustments": null,
+      "eiucRegion": null,
+      "section127Agreement": null,
+      "restrictedSource": false
+    }
+  ],
+  "monitoringStations": [
+    {
+      "label": "Test Station 500",
+      "gridReference": "ST5820172718"
+    }
+  ],
+  "returnLogs": [
+    {
+      "id": "v1:9:AT/CURR/DAILY/01:9999990:2020-01-01:2020-03-31",
+      "returnReference": "9999990",
+      "licenceRef": "AT/CURR/DAILY/01",
+      "metadata": {
+        "nald": {
+            "areaCode": "AREA",
+            "formatId": 9999990,
+            "regionCode": 9,
+            "periodEndDay": "31",
+            "periodEndMonth": "12",
+            "periodStartDay": "1",
+            "periodStartMonth": "1"
+        },
+        "points": [
+            {
+              "name": "The Name of this",
+              "ngr1": "TG 123 456",
+              "ngr2": null,
+              "ngr3": null,
+              "ngr4": null
+            }
+        ],
+        "isFinal": false,
+        "version": 1,
+        "isSummer": false,
+        "isUpload": false,
+        "purposes": [
+            {
+              "alias": "SPRAY IRRIGATION STORAGE",
+              "primary": {
+                  "code": "A",
+                  "description": "Agriculture"
+              },
+              "secondary": {
+                  "code": "AGR",
+                  "description": "General Agriculture"
+              },
+              "tertiary": {
+                  "code": "420",
+                  "description": "Spray Irrigation - Storage"
+              }
+            }
+        ],
+        "isCurrent": true,
+        "description": "Its all about the description",
+        "isTwoPartTariff": true
+      },
+      "returnsFrequency": "month",
+      "startDate": "2020-01-01",
+      "endDate": "2020-03-31",
+      "dueDate": "2020-04-28",
+      "status": "due",
+      "underQuery": false,
+      "returnCycleId": {
+        "schema": "returns",
+        "table": "returnCycles",
+        "lookup": "startDate",
+        "value": "2019-04-01",
+        "select": "returnCycleId"
+      }
+    },
+    {
+      "id": "v1:9:AT/CURR/DAILY/01:9999990:2020-04-01:2021-03-31",
+      "returnReference": "9999990",
+      "licenceRef": "AT/CURR/DAILY/01",
+      "metadata": {
+        "nald": {
+            "areaCode": "AREA",
+            "formatId": 9999990,
+            "regionCode": 9,
+            "periodEndDay": "31",
+            "periodEndMonth": "12",
+            "periodStartDay": "1",
+            "periodStartMonth": "1"
+        },
+        "points": [
+            {
+              "name": "The Name of this",
+              "ngr1": "TG 123 456",
+              "ngr2": null,
+              "ngr3": null,
+              "ngr4": null
+            }
+        ],
+        "isFinal": false,
+        "version": 1,
+        "isSummer": false,
+        "isUpload": false,
+        "purposes": [
+            {
+              "alias": "SPRAY IRRIGATION STORAGE",
+              "primary": {
+                  "code": "A",
+                  "description": "Agriculture"
+              },
+              "secondary": {
+                  "code": "AGR",
+                  "description": "General Agriculture"
+              },
+              "tertiary": {
+                  "code": "420",
+                  "description": "Spray Irrigation - Storage"
+              }
+            }
+        ],
+        "isCurrent": true,
+        "description": "Its all about the description",
+        "isTwoPartTariff": true
+      },
+      "returnsFrequency": "month",
+      "startDate": "2020-04-01",
+      "endDate": "2021-03-31",
+      "dueDate": "2021-04-28",
+      "status": "completed",
+      "underQuery": false,
+      "returnCycleId": {
+        "schema": "returns",
+        "table": "returnCycles",
+        "lookup": "startDate",
+        "value": "2020-04-01",
+        "select": "returnCycleId"
+      }
+    },
+    {
+      "id": "v1:9:AT/CURR/DAILY/01:9999990:2021-04-01:2022-03-31",
+      "returnReference": "9999990",
+      "licenceRef": "AT/CURR/DAILY/01",
+      "metadata": {
+        "nald": {
+            "areaCode": "AREA",
+            "formatId": 9999990,
+            "regionCode": 9,
+            "periodEndDay": "28",
+            "periodEndMonth": "02",
+            "periodStartDay": "1",
+            "periodStartMonth": "1"
+        },
+        "points": [
+            {
+              "name": "Winter",
+              "ngr1": "TG 123 456",
+              "ngr2": null,
+              "ngr3": null,
+              "ngr4": null
+            }
+        ],
+        "isFinal": false,
+        "version": 1,
+        "isSummer": false,
+        "isUpload": false,
+        "purposes": [
+            {
+              "alias": "SPRAY IRRIGATION STORAGE",
+              "primary": {
+                  "code": "A",
+                  "description": "Agriculture"
+              },
+              "secondary": {
+                  "code": "AGR",
+                  "description": "General Agriculture"
+              },
+              "tertiary": {
+                  "code": "420",
+                  "description": "Spray Irrigation - Storage"
+              }
+            }
+        ],
+        "isCurrent": true,
+        "description": "Its all about the description",
+        "isTwoPartTariff": true
+      },
+      "returnsFrequency": "month",
+      "startDate": "2021-04-01",
+      "endDate": "2022-03-31",
+      "dueDate": "2022-04-28",
+      "status": "completed",
+      "underQuery": false,
+      "returnCycleId": {
+        "schema": "returns",
+        "table": "returnCycles",
+        "lookup": "startDate",
+        "value": "2021-04-01",
+        "select": "returnCycleId"
+      }
+    },
+    {
+      "id": "v1:9:AT/CURR/DAILY/01:9999990:2022-04-01:2023-03-31",
+      "returnReference": "9999990",
+      "licenceRef": "AT/CURR/DAILY/01",
+      "metadata": {
+        "nald": {
+            "areaCode": "AREA",
+            "formatId": 9999990,
+            "regionCode": 9,
+            "periodEndDay": "28",
+            "periodEndMonth": "02",
+            "periodStartDay": "1",
+            "periodStartMonth": "1"
+        },
+        "points": [
+            {
+              "name": "Winter",
+              "ngr1": "TG 123 456",
+              "ngr2": null,
+              "ngr3": null,
+              "ngr4": null
+            }
+        ],
+        "isFinal": false,
+        "version": 2,
+        "isSummer": false,
+        "isUpload": false,
+        "purposes": [
+            {
+              "alias": "SPRAY IRRIGATION STORAGE",
+              "primary": {
+                  "code": "A",
+                  "description": "Agriculture"
+              },
+              "secondary": {
+                  "code": "AGR",
+                  "description": "General Agriculture"
+              },
+              "tertiary": {
+                  "code": "420",
+                  "description": "Spray Irrigation - Storage"
+              }
+            }
+        ],
+        "isCurrent": true,
+        "description": "Its all about the description",
+        "isTwoPartTariff": true
+      },
+      "returnsFrequency": "month",
+      "startDate": "2022-04-01",
+      "endDate": "2023-03-31",
+      "dueDate": "2023-04-28",
+      "status": "completed",
+      "underQuery": false,
+      "returnCycleId": {
+        "schema": "returns",
+        "table": "returnCycles",
+        "lookup": "startDate",
+        "value": "2022-04-01",
+        "select": "returnCycleId"
+      }
+    },
+    {
+      "id": "v1:9:AT/CURR/DAILY/01:9999990:2023-04-01:2024-03-31",
+      "returnReference": "9999990",
+      "licenceRef": "AT/CURR/DAILY/01",
+      "metadata": {
+        "nald": {
+            "areaCode": "AREA",
+            "formatId": 9999990,
+            "regionCode": 9,
+            "periodEndDay": "28",
+            "periodEndMonth": "02",
+            "periodStartDay": "1",
+            "periodStartMonth": "1"
+        },
+        "points": [
+            {
+              "name": "Winter",
+              "ngr1": "TG 123 456",
+              "ngr2": null,
+              "ngr3": null,
+              "ngr4": null
+            }
+        ],
+        "isFinal": false,
+        "version": 1,
+        "isSummer": false,
+        "isUpload": false,
+        "purposes": [
+            {
+              "alias": "SPRAY IRRIGATION STORAGE",
+              "primary": {
+                  "code": "A",
+                  "description": "Agriculture"
+              },
+              "secondary": {
+                  "code": "AGR",
+                  "description": "General Agriculture"
+              },
+              "tertiary": {
+                  "code": "420",
+                  "description": "Spray Irrigation - Storage"
+              }
+            }
+        ],
+        "isCurrent": true,
+        "description": "Its all about the description",
+        "isTwoPartTariff": true
+      },
+      "returnsFrequency": "month",
+      "startDate": "2023-04-01",
+      "endDate": "2024-03-31",
+      "dueDate": "2024-04-28",
+      "status": "completed",
+      "underQuery": false,
+      "returnCycleId": {
+        "schema": "returns",
+        "table": "returnCycles",
+        "lookup": "startDate",
+        "value": "2023-04-01",
+        "select": "returnCycleId"
+      }
+    }
+  ]
+}

--- a/cypress/fixtures/return-logs-historic-02.json
+++ b/cypress/fixtures/return-logs-historic-02.json
@@ -1,0 +1,1103 @@
+{
+  "permitLicences": [
+    {
+      "licenceRef": "AT/CURR/DAILY/01",
+      "startDate": "2020-01-01",
+      "metadata": {
+        "source": "acceptance-test-setup"
+      }
+    },
+    {
+      "licenceRef": "AT/CURR/WEEKLY/01",
+      "startDate": "2020-01-01",
+      "metadata": {
+        "source": "acceptance-test-setup"
+      }
+    },
+    {
+      "licenceRef": "AT/CURR/MONTHLY/01",
+      "startDate": "2020-01-01",
+      "metadata": {
+        "source": "acceptance-test-setup"
+      }
+    },
+    {
+      "licenceRef": "AT/CURR/MONTHLY/02",
+      "startDate": "2020-01-01",
+      "metadata": {
+        "source": "acceptance-test-setup"
+      }
+    }
+  ],
+  "licenceEntities": [
+    {
+      "id": "1742895f-5e18-41e0-94bd-d5c9845cb558",
+      "name": "external@example.com",
+      "type": "individual"
+    },
+    {
+      "id": "e86c312b-222d-404f-ae08-eb90a80bec18",
+      "name": "Big Farm Co Ltd",
+      "type": "company"
+    }
+  ],
+  "licenceEntityRoles": [
+    {
+      "id": "f99998c5-0676-43c3-bf6c-41b1103111bf",
+      "licenceEntityId": "1742895f-5e18-41e0-94bd-d5c9845cb558",
+      "companyEntityId": "e86c312b-222d-404f-ae08-eb90a80bec18",
+      "role": "primary_user",
+      "createdBy": "acceptance-test-setup"
+    }
+  ],
+  "licenceDocumentHeaders": [
+    {
+      "id": "c86c9d49-e06f-4792-8307-8e2c38aa6838",
+      "regimeEntityId": {
+        "schema": "crm",
+        "table": "entity",
+        "lookup": "entityType",
+        "value": "regime",
+        "select": "entityId"
+      },
+      "licenceRef": "AT/CURR/DAILY/01",
+      "naldId": {
+        "schema": "public",
+        "table": "permitLicences",
+        "lookup": "licenceRef",
+        "value": "AT/CURR/DAILY/01",
+        "select": "id"
+      },
+      "metadata": {
+        "Name": "cupcake factory",
+        "dataType": "acceptance-test-setup",
+        "IsCurrent": true
+      },
+      "licence_name": "the daily cupcake licence",
+      "companyEntityId": "e86c312b-222d-404f-ae08-eb90a80bec18"
+    },
+    {
+      "id": "f5dbd812-4238-4b02-8eaa-8f7b3de467d4",
+      "regimeEntityId": {
+        "schema": "crm",
+        "table": "entity",
+        "lookup": "entityType",
+        "value": "regime",
+        "select": "entityId"
+      },
+      "licenceRef": "AT/CURR/WEEKLY/01",
+      "naldId": {
+        "schema": "public",
+        "table": "permitLicences",
+        "lookup": "licenceRef",
+        "value": "AT/CURR/WEEKLY/01",
+        "select": "id"
+      },
+      "metadata": {
+        "Name": "barber bakery",
+        "dataType": "acceptance-test-setup",
+        "IsCurrent": true
+      },
+      "licence_name": "the weekly crumpet licence",
+      "companyEntityId": "e86c312b-222d-404f-ae08-eb90a80bec18"
+    },
+    {
+      "id": "7660ae8b-d619-43ca-bead-5ff6e24e2d11",
+      "regimeEntityId": {
+        "schema": "crm",
+        "table": "entity",
+        "lookup": "entityType",
+        "value": "regime",
+        "select": "entityId"
+      },
+      "licenceRef": "AT/CURR/MONTHLY/01",
+      "naldId": {
+        "schema": "public",
+        "table": "permitLicences",
+        "lookup": "licenceRef",
+        "value": "AT/CURR/MONTHLY/01",
+        "select": "id"
+      },
+      "metadata": {
+        "Name": "shop",
+        "dataType": "acceptance-test-setup",
+        "IsCurrent": true
+      },
+      "licence_name": "the monthly pie licence",
+      "companyEntityId": "e86c312b-222d-404f-ae08-eb90a80bec18"
+    },
+    {
+      "id": "91b89b5d-ebf4-48be-ba92-a89e65118ba8",
+      "regimeEntityId": {
+        "schema": "crm",
+        "table": "entity",
+        "lookup": "entityType",
+        "value": "regime",
+        "select": "entityId"
+      },
+      "licenceRef": "AT/CURR/MONTHLY/02",
+      "naldId": {
+        "schema": "public",
+        "table": "permitLicences",
+        "lookup": "licenceRef",
+        "value": "AT/CURR/MONTHLY/02",
+        "select": "id"
+      },
+      "metadata": {
+        "Name": "doughnut store",
+        "dataType": "acceptance-test-setup",
+        "IsCurrent": true
+      },
+      "licence_name": "the monthly doughnut licence",
+      "companyEntityId": "e86c312b-222d-404f-ae08-eb90a80bec18"
+    }
+  ],
+  "companies": [
+    {
+      "id": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "name": "Big Farm Co Ltd",
+      "type": "organisation"
+    }
+  ],
+  "addresses": [
+    {
+      "id": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "address1": "Big Farm",
+      "address2": "Windy road",
+      "address3": "Buttercup meadow",
+      "address4": "Buttercup Village",
+      "address5": "Testington",
+      "address6": "Testingshire",
+      "postcode": "TT1 1TT",
+      "country": "UK",
+      "dataSource": "nald"
+    }
+  ],
+  "companyAddresses": [
+    {
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "startDate": "2008-04-01",
+      "licenceRoleId": {
+        "schema": "crm_v2",
+        "table": "roles",
+        "lookup": "name",
+        "value": "billing",
+        "select": "roleId"
+      }
+    }
+  ],
+  "contacts": [
+    {
+      "id": "6e05db31-39cd-4bb0-83a0-0d985037ad8f",
+      "salutation": "Mr",
+      "firstName": "John",
+      "lastName": "Testerson",
+      "middleInitials": "J",
+      "contactType": "person",
+      "dataSource": "nald"
+    }
+  ],
+  "companyContacts": [
+    {
+      "id": "e01e7717-719f-47ed-8431-362f6b4de422",
+      "contactId": "6e05db31-39cd-4bb0-83a0-0d985037ad8f",
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "licenceRoleId": {
+        "schema": "crm_v2",
+        "table": "roles",
+        "lookup": "name",
+        "value": "licenceHolder",
+        "select": "roleId"
+      },
+      "startDate": "2018-01-01"
+    }
+  ],
+  "billingAccounts": [
+    {
+      "id": "16cb50a5-e3e6-41f4-a42b-9dad6a69fc0c",
+      "accountNumber": "A99999999A",
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778"
+    }
+  ],
+  "billingAccountAddresses": [
+    {
+      "id": "ab9a24ec-80b8-40dc-82f8-7df3e885245a",
+      "billingAccountId": "16cb50a5-e3e6-41f4-a42b-9dad6a69fc0c",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "startDate": "2008-04-01"
+    }
+  ],
+  "licenceDocuments": [
+    {
+      "id": "1a274f3e-f891-43dd-8c25-8afac4e760ac",
+      "licenceRef": "AT/CURR/DAILY/01",
+      "startDate": "2018-01-01"
+    },
+    {
+      "id": "4fe682ac-c558-41fc-aead-85dca40efc89",
+      "licenceRef": "AT/CURR/WEEKLY/01",
+      "startDate": "2020-01-01"
+    },
+    {
+      "id": "1305f637-eea8-455c-92ae-f52015aa001b",
+      "licenceRef": "AT/CURR/MONTHLY/01",
+      "startDate": "2018-01-01"
+    },
+    {
+      "id": "74498584-b26b-405a-9111-743fc46a185e",
+      "licenceRef": "AT/CURR/MONTHLY/02",
+      "startDate": "2018-01-01"
+    }
+  ],
+  "licenceDocumentRoles": [
+    {
+      "licenceDocumentId": "1a274f3e-f891-43dd-8c25-8afac4e760ac",
+      "licenceRoleId": {
+        "schema": "public",
+        "table": "licenceRoles",
+        "lookup": "name",
+        "value": "licenceHolder",
+        "select": "id"
+      },
+      "startDate": "2018-01-01",
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "contactId": "6e05db31-39cd-4bb0-83a0-0d985037ad8f"
+    },
+    {
+      "licenceDocumentId": "4fe682ac-c558-41fc-aead-85dca40efc89",
+      "licenceRoleId": {
+        "schema": "public",
+        "table": "licenceRoles",
+        "lookup": "name",
+        "value": "licenceHolder",
+        "select": "id"
+      },
+      "startDate": "2018-01-01",
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "contactId": "6e05db31-39cd-4bb0-83a0-0d985037ad8f"
+    },
+    {
+      "licenceDocumentId": "1305f637-eea8-455c-92ae-f52015aa001b",
+      "licenceRoleId": {
+        "schema": "public",
+        "table": "licenceRoles",
+        "lookup": "name",
+        "value": "licenceHolder",
+        "select": "id"
+      },
+      "startDate": "2018-01-01",
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "contactId": "6e05db31-39cd-4bb0-83a0-0d985037ad8f"
+    },
+    {
+      "licenceDocumentId": "74498584-b26b-405a-9111-743fc46a185e",
+      "licenceRoleId": {
+        "schema": "public",
+        "table": "licenceRoles",
+        "lookup": "name",
+        "value": "licenceHolder",
+        "select": "id"
+      },
+      "startDate": "2018-01-01",
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "contactId": "6e05db31-39cd-4bb0-83a0-0d985037ad8f"
+    }
+  ],
+  "licences": [
+    {
+      "id": "8717da0e-28d4-4833-8e32-1da050b60055",
+      "licenceRef": "AT/CURR/DAILY/01",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
+      "regions": {
+        "historicalAreaCode": "SAAR",
+        "regionalChargeArea": "Southern"
+      },
+      "startDate": "2020-01-01",
+      "waterUndertaker": true
+    },
+    {
+      "id": "bcdf5049-fd2d-4e45-a3d6-37bcd443d431",
+      "licenceRef": "AT/CURR/WEEKLY/01",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
+      "regions": {
+        "historicalAreaCode": "SAAR",
+        "regionalChargeArea": "Southern"
+      },
+      "startDate": "2020-01-01",
+      "waterUndertaker": false
+    },
+    {
+      "id": "bb5605c9-5c28-43d3-a8b3-875013366b69",
+      "licenceRef": "AT/CURR/MONTHLY/01",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
+      "regions": {
+        "historicalAreaCode": "SAAR",
+        "regionalChargeArea": "Southern"
+      },
+      "startDate": "2020-01-01",
+      "waterUndertaker": false
+    },
+    {
+      "id": "844e5fd5-f21c-418e-8d64-0be4d283133a",
+      "licenceRef": "AT/CURR/MONTHLY/02",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
+      "regions": {
+        "historicalAreaCode": "SAAR",
+        "regionalChargeArea": "Southern"
+      },
+      "startDate": "2020-01-01",
+      "waterUndertaker": false
+    }
+  ],
+  "licenceVersions": [
+    {
+      "id": "7ac6be4b-b7a0-4e35-9cd4-bd1c783af32b",
+      "licenceId": "8717da0e-28d4-4833-8e32-1da050b60055",
+      "issue": 1,
+      "increment": 0,
+      "status": "current",
+      "startDate": "2020-01-01",
+      "externalId": "6:1234:1:0"
+    },
+    {
+      "id": "5649a988-3cdf-4a19-91ee-8a61355f8c9d",
+      "licenceId": "bcdf5049-fd2d-4e45-a3d6-37bcd443d431",
+      "issue": 1,
+      "increment": 0,
+      "status": "current",
+      "startDate": "2020-01-01",
+      "externalId": "6:1235:1:0"
+    },
+    {
+      "id": "eede57aa-f8d7-492a-bb6a-b5bccead5ce4",
+      "licenceId": "bb5605c9-5c28-43d3-a8b3-875013366b69",
+      "issue": 1,
+      "increment": 0,
+      "status": "current",
+      "startDate": "2020-01-01",
+      "externalId": "6:1236:1:0"
+    },
+    {
+      "id": "49bf4843-8d2c-4667-8950-56d472f02bf6",
+      "licenceId": "844e5fd5-f21c-418e-8d64-0be4d283133a",
+      "issue": 1,
+      "increment": 0,
+      "status": "current",
+      "startDate": "2020-01-01",
+      "externalId": "6:1237:1:0"
+    }
+  ],
+  "points": [
+    {
+      "id": "1cb602f8-6a01-4435-96b0-541e03f460da",
+      "description": "Example point 1",
+      "ngr1": "TQ 1234 5678",
+      "externalId": "9:9000031",
+      "sourceId": {
+        "schema": "public",
+        "table": "sources",
+        "lookup": "legacyId",
+        "value": "S",
+        "select": "id"
+      }
+    },
+    {
+      "id": "82fab927-ef31-45a2-a4e6-104315cb9764",
+      "description": "Example point 2",
+      "ngr1": "TT 9876 5432",
+      "externalId": "9:9000032",
+      "sourceId": {
+        "schema": "public",
+        "table": "sources",
+        "lookup": "legacyId",
+        "value": "S",
+        "select": "id"
+      }
+    }
+  ],
+  "licenceVersionPurposes": [
+    {
+      "id": "f264184b-22a7-4e26-bd90-d5738eb2e07e",
+      "licenceVersionId": "7ac6be4b-b7a0-4e35-9cd4-bd1c783af32b",
+      "primaryPurposeId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "secondaryPurposeId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      },
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 4,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 3,
+      "annualQuantity": 1554,
+      "externalId": "6:1234"
+    },
+    {
+      "id": "fb82d30d-49e5-4295-96f9-03abf126cbd7",
+      "licenceVersionId": "7ac6be4b-b7a0-4e35-9cd4-bd1c783af32b",
+      "primaryPurposeId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "secondaryPurposeId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      },
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 4,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 3,
+      "annualQuantity": 1554,
+      "externalId": "6:1235"
+    },
+    {
+      "id": "b663bab5-9875-4823-9b3d-d0a66ef22b9a",
+      "licenceVersionId": "eede57aa-f8d7-492a-bb6a-b5bccead5ce4",
+      "primaryPurposeId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "secondaryPurposeId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      },
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 4,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 3,
+      "annualQuantity": 1554,
+      "externalId": "6:1236"
+    },
+    {
+      "id": "2088b5cd-3fd9-425c-a4bd-0331596e6d94",
+      "licenceVersionId": "49bf4843-8d2c-4667-8950-56d472f02bf6",
+      "primaryPurposeId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "secondaryPurposeId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      },
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 4,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 3,
+      "annualQuantity": 1554,
+      "externalId": "6:1237"
+    }
+  ],
+  "licenceVersionPurposePoints": [
+    {
+      "licenceVersionPurposeId": "f264184b-22a7-4e26-bd90-d5738eb2e07e",
+      "pointId": "1cb602f8-6a01-4435-96b0-541e03f460da"
+    },
+    {
+      "licenceVersionPurposeId": "fb82d30d-49e5-4295-96f9-03abf126cbd7",
+      "pointId": "82fab927-ef31-45a2-a4e6-104315cb9764"
+    },
+    {
+      "licenceVersionPurposeId": "b663bab5-9875-4823-9b3d-d0a66ef22b9a",
+      "pointId": "1cb602f8-6a01-4435-96b0-541e03f460da"
+    },
+    {
+      "licenceVersionPurposeId": "2088b5cd-3fd9-425c-a4bd-0331596e6d94",
+      "pointId": "82fab927-ef31-45a2-a4e6-104315cb9764"
+    }
+  ],
+  "returnVersions": [
+    {
+      "id": "bcd4e8c7-16ed-419c-915d-d8f184e45ed5",
+      "version": 101,
+      "startDate": "2019-01-01",
+      "endDate": null,
+      "status": "current",
+      "externalId": "6:9999990",
+      "licenceId": "8717da0e-28d4-4833-8e32-1da050b60055"
+    },
+    {
+      "id": "c1c06cf3-5f81-4ebd-b814-b60b782f795b",
+      "version": 101,
+      "startDate": "2020-01-01",
+      "endDate": null,
+      "status": "current",
+      "externalId": "6:9999991",
+      "licenceId": "bcdf5049-fd2d-4e45-a3d6-37bcd443d431"
+    },
+    {
+      "id": "5def1d92-0de9-4a31-aab6-b4373755c483",
+      "version": 101,
+      "startDate": "2021-01-01",
+      "endDate": null,
+      "status": "current",
+      "externalId": "6:9999992",
+      "licenceId": "bb5605c9-5c28-43d3-a8b3-875013366b69"
+    },
+    {
+      "id": "4bba499d-c68c-433f-8f4b-d495ab7c8b34",
+      "version": 102,
+      "startDate": "2021-01-01",
+      "endDate": null,
+      "status": "superseded",
+      "externalId": "6:9999993",
+      "licenceId": "844e5fd5-f21c-418e-8d64-0be4d283133a"
+    }
+  ],
+  "returnRequirements": [
+    {
+      "id": "c33b9e4d-4d0f-4686-b1ac-6449ab014fd5",
+      "returnsFrequency": "month",
+      "returnVersionId": "bcd4e8c7-16ed-419c-915d-d8f184e45ed5",
+      "summer": false,
+      "upload": false,
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 1,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 12,
+      "siteDescription": "WELL POINTS AT MARS",
+      "legacyId": 9999990,
+      "externalId": "9:9999990"
+    },
+    {
+      "id": "35eb023b-0911-4876-9093-5f10406c4a2d",
+      "returnsFrequency": "month",
+      "returnVersionId": "bcd4e8c7-16ed-419c-915d-d8f184e45ed5",
+      "summer": true,
+      "upload": false,
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 1,
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 12,
+      "siteDescription": "WELL POINTS AT MARS",
+      "legacyId": 9999991,
+      "externalId": "9:9999991"
+    },
+    {
+      "id": "7fe49b9d-4e6a-48da-9c7f-751689c7dd4f",
+      "returnsFrequency": "month",
+      "returnVersionId": "5def1d92-0de9-4a31-aab6-b4373755c483",
+      "summer": false,
+      "upload": false,
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 1,
+      "abstractionPeriodEndDay": 28,
+      "abstractionPeriodEndMonth": 2,
+      "siteDescription": "WELL POINTS AT MARS",
+      "legacyId": 9999992,
+      "externalId": "6:9999992"
+    },
+    {
+      "id": "f4bcab6f-906a-4929-9ce7-87480364331b",
+      "returnsFrequency": "month",
+      "returnVersionId": "4bba499d-c68c-433f-8f4b-d495ab7c8b34",
+      "summer": false,
+      "upload": false,
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 1,
+      "abstractionPeriodEndDay": 28,
+      "abstractionPeriodEndMonth": 2,
+      "siteDescription": "WELL POINTS AT MARS",
+      "legacyId": 9999993,
+      "externalId": "6:9999993"
+    }
+  ],
+  "returnRequirementPoints": [
+    {
+      "returnRequirementId": "c33b9e4d-4d0f-4686-b1ac-6449ab014fd5",
+      "pointId": "1cb602f8-6a01-4435-96b0-541e03f460da"
+    },
+    {
+      "returnRequirementId": "35eb023b-0911-4876-9093-5f10406c4a2d",
+      "pointId": "82fab927-ef31-45a2-a4e6-104315cb9764"
+    },
+    {
+      "returnRequirementId": "7fe49b9d-4e6a-48da-9c7f-751689c7dd4f",
+      "pointId": "1cb602f8-6a01-4435-96b0-541e03f460da"
+    },
+    {
+      "returnRequirementId": "f4bcab6f-906a-4929-9ce7-87480364331b",
+      "pointId": "82fab927-ef31-45a2-a4e6-104315cb9764"
+    }
+  ],
+  "returnRequirementPurposes": [
+    {
+      "returnRequirementId": "c33b9e4d-4d0f-4686-b1ac-6449ab014fd5",
+      "externalId": "6:9999990:A:AGR:420",
+      "alias": "SPRAY IRRIGATION STORAGE",
+      "primaryPurposeId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "secondaryPurposeId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      },
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      }
+    },
+    {
+      "returnRequirementId": "35eb023b-0911-4876-9093-5f10406c4a2d",
+      "externalId": "6:9999991:A:AGR:420",
+      "alias": "SPRAY IRRIGATION STORAGE",
+      "primaryPurposeId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "secondaryPurposeId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      },
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      }
+    },
+    {
+      "returnRequirementId": "7fe49b9d-4e6a-48da-9c7f-751689c7dd4f",
+      "externalId": "6:9999992:A:AGR:420",
+      "alias": "SPRAY IRRIGATION STORAGE",
+      "primaryPurposeId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "secondaryPurposeId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      },
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      }
+    },
+    {
+      "returnRequirementId": "f4bcab6f-906a-4929-9ce7-87480364331b",
+      "externalId": "6:9999993:A:AGR:420",
+      "alias": "SPRAY IRRIGATION STORAGE",
+      "primaryPurposeId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "secondaryPurposeId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      },
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      }
+    }
+  ],
+  "chargeVersions": [
+    {
+      "id": "fb1c7c5d-e723-4ab2-861e-5aae6d428019",
+      "licenceId": "8717da0e-28d4-4833-8e32-1da050b60055",
+      "licenceRef": "AT/CURR/DAILY/01",
+      "billingAccountId": "16cb50a5-e3e6-41f4-a42b-9dad6a69fc0c",
+      "regionCode": 9,
+      "scheme": "alcs",
+      "versionNumber": 1,
+      "startDate": "2018-01-01",
+      "status": "current",
+      "source": "wrls",
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778"
+    }
+  ],
+  "chargeReferences": [
+    {
+      "id": "69ea7fd9-961b-4d5d-be8b-ecd0e9cc8482",
+      "chargeVersionId": "fb1c7c5d-e723-4ab2-861e-5aae6d428019",
+      "factorsOverridden": false,
+      "abstractionPeriodStartDay": 1,
+      "abstractionPeriodStartMonth": 4,
+      "description": "Test Charge Element!",
+      "abstractionPeriodEndDay": 31,
+      "abstractionPeriodEndMonth": 3,
+      "authorisedAnnualQuantity": 15.54,
+      "season": "all year",
+      "seasonDerived": "all year",
+      "source": "unsupported",
+      "loss": "medium",
+      "purposePrimaryId": {
+        "schema": "water",
+        "table": "purposesPrimary",
+        "lookup": "legacyId",
+        "value": "A",
+        "select": "purposePrimaryId"
+      },
+      "purposeSecondaryId": {
+        "schema": "water",
+        "table": "purposesSecondary",
+        "lookup": "legacyId",
+        "value": "AGR",
+        "select": "purposeSecondaryId"
+      },
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "140",
+        "select": "id"
+      },
+      "chargeCategoryId": null,
+      "additionalCharges": {},
+      "scheme": "alcs",
+      "adjustments": null,
+      "eiucRegion": null,
+      "section127Agreement": null,
+      "restrictedSource": false
+    }
+  ],
+  "monitoringStations": [
+    {
+      "label": "Test Station 500",
+      "gridReference": "ST5820172718"
+    }
+  ],
+  "returnLogs": [
+    {
+      "id": "v1:9:AT/CURR/DAILY/01:9999990:2023-04-01:2024-03-31",
+      "returnReference": "9999990",
+      "licenceRef": "AT/CURR/DAILY/01",
+      "metadata": {
+        "nald": {
+            "areaCode": "AREA",
+            "formatId": 9999990,
+            "regionCode": 9,
+            "periodEndDay": "31",
+            "periodEndMonth": "12",
+            "periodStartDay": "1",
+            "periodStartMonth": "1"
+        },
+        "points": [
+            {
+              "name": "The Name of this",
+              "ngr1": "TG 123 456",
+              "ngr2": null,
+              "ngr3": null,
+              "ngr4": null
+            }
+        ],
+        "isFinal": false,
+        "version": 1,
+        "isSummer": false,
+        "isUpload": false,
+        "purposes": [
+            {
+              "alias": "SPRAY IRRIGATION STORAGE",
+              "primary": {
+                  "code": "A",
+                  "description": "Agriculture"
+              },
+              "secondary": {
+                  "code": "AGR",
+                  "description": "General Agriculture"
+              },
+              "tertiary": {
+                  "code": "420",
+                  "description": "Spray Irrigation - Storage"
+              }
+            }
+        ],
+        "isCurrent": true,
+        "description": "Its all about the description",
+        "isTwoPartTariff": true
+      },
+      "returnsFrequency": "month",
+      "startDate": "2023-04-01",
+      "endDate": "2024-03-31",
+      "dueDate": "2024-04-28",
+      "status": "due",
+      "underQuery": false,
+      "returnCycleId": {
+        "schema": "returns",
+        "table": "returnCycles",
+        "lookup": "startDate",
+        "value": "2023-04-01",
+        "select": "returnCycleId"
+      }
+    },
+    {
+      "id": "v1:9:AT/CURR/DAILY/01:9999991:2024-11-01:2025-10-31",
+      "returnReference": "9999991",
+      "licenceRef": "AT/CURR/DAILY/01",
+      "metadata": {
+        "nald": {
+            "areaCode": "AREA",
+            "formatId": 9999991,
+            "regionCode": 9,
+            "periodEndDay": "31",
+            "periodEndMonth": "12",
+            "periodStartDay": "1",
+            "periodStartMonth": "1"
+        },
+        "points": [
+            {
+              "name": "The Name of this",
+              "ngr1": "TG 123 456",
+              "ngr2": null,
+              "ngr3": null,
+              "ngr4": null
+            }
+        ],
+        "isFinal": false,
+        "version": 1,
+        "isSummer": true,
+        "isUpload": false,
+        "purposes": [
+            {
+              "alias": "SPRAY IRRIGATION STORAGE",
+              "primary": {
+                  "code": "A",
+                  "description": "Agriculture"
+              },
+              "secondary": {
+                  "code": "AGR",
+                  "description": "General Agriculture"
+              },
+              "tertiary": {
+                  "code": "420",
+                  "description": "Spray Irrigation - Storage"
+              }
+            }
+        ],
+        "isCurrent": true,
+        "description": "Its all about the description",
+        "isTwoPartTariff": true
+      },
+      "returnsFrequency": "month",
+      "startDate": "2024-11-01",
+      "endDate": "2025-10-31",
+      "dueDate": "2021-11-28",
+      "status": "due",
+      "underQuery": false,
+      "returnCycleId": {
+        "schema": "returns",
+        "table": "returnCycles",
+        "lookup": "startDate",
+        "value": "2024-11-01",
+        "select": "returnCycleId"
+      }
+    },
+    {
+      "id": "v1:9:AT/CURR/DAILY/01:9999990:2022-04-01:2023-03-31",
+      "returnReference": "9999990",
+      "licenceRef": "AT/CURR/DAILY/01",
+      "metadata": {
+        "nald": {
+            "areaCode": "AREA",
+            "formatId": 9999990,
+            "regionCode": 9,
+            "periodEndDay": "28",
+            "periodEndMonth": "02",
+            "periodStartDay": "1",
+            "periodStartMonth": "1"
+        },
+        "points": [
+            {
+              "name": "Winter",
+              "ngr1": "TG 123 456",
+              "ngr2": null,
+              "ngr3": null,
+              "ngr4": null
+            }
+        ],
+        "isFinal": false,
+        "version": 1,
+        "isSummer": false,
+        "isUpload": false,
+        "purposes": [
+            {
+              "alias": "SPRAY IRRIGATION STORAGE",
+              "primary": {
+                  "code": "A",
+                  "description": "Agriculture"
+              },
+              "secondary": {
+                  "code": "AGR",
+                  "description": "General Agriculture"
+              },
+              "tertiary": {
+                  "code": "420",
+                  "description": "Spray Irrigation - Storage"
+              }
+            }
+        ],
+        "isCurrent": true,
+        "description": "Its all about the description",
+        "isTwoPartTariff": true
+      },
+      "returnsFrequency": "month",
+      "startDate": "2022-04-01",
+      "endDate": "2023-03-31",
+      "dueDate": "2023-04-28",
+      "status": "completed",
+      "underQuery": false,
+      "returnCycleId": {
+        "schema": "returns",
+        "table": "returnCycles",
+        "lookup": "startDate",
+        "value": "2022-04-01",
+        "select": "returnCycleId"
+      }
+    },
+    {
+      "id": "v1:9:AT/CURR/DAILY/01:9999991:2024-11-01:2025-10-31",
+      "returnReference": "9999991",
+      "licenceRef": "AT/CURR/DAILY/01",
+      "metadata": {
+        "nald": {
+            "areaCode": "AREA",
+            "formatId": 9999991,
+            "regionCode": 9,
+            "periodEndDay": "31",
+            "periodEndMonth": "12",
+            "periodStartDay": "1",
+            "periodStartMonth": "1"
+        },
+        "points": [
+            {
+              "name": "The Name of this",
+              "ngr1": "TG 123 456",
+              "ngr2": null,
+              "ngr3": null,
+              "ngr4": null
+            }
+        ],
+        "isFinal": false,
+        "version": 1,
+        "isSummer": true,
+        "isUpload": false,
+        "purposes": [
+            {
+              "alias": "SPRAY IRRIGATION STORAGE",
+              "primary": {
+                  "code": "A",
+                  "description": "Agriculture"
+              },
+              "secondary": {
+                  "code": "AGR",
+                  "description": "General Agriculture"
+              },
+              "tertiary": {
+                  "code": "420",
+                  "description": "Spray Irrigation - Storage"
+              }
+            }
+        ],
+        "isCurrent": true,
+        "description": "Its all about the description",
+        "isTwoPartTariff": true
+      },
+      "returnsFrequency": "month",
+      "startDate": "2024-11-01",
+      "endDate": "2025-10-31",
+      "dueDate": "2021-11-28",
+      "status": "completed",
+      "underQuery": false,
+      "returnCycleId": {
+        "schema": "returns",
+        "table": "returnCycles",
+        "lookup": "startDate",
+        "value": "2024-11-01",
+        "select": "returnCycleId"
+      }
+    }
+  ]
+}

--- a/cypress/fixtures/return-logs.json
+++ b/cypress/fixtures/return-logs.json
@@ -1,0 +1,341 @@
+{
+  "addresses": [
+    {
+      "id": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "address1": "Big Farm",
+      "address2": "Windy road",
+      "address3": "Buttercup meadow",
+      "address4": "Buttercup Village",
+      "address5": "Testington",
+      "address6": "Testingshire",
+      "postcode": "TT1 1TT",
+      "country": "UK",
+      "dataSource": "nald"
+    }
+  ],
+  "companies": [
+    {
+      "id": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "name": "Big Farm Co Ltd 01",
+      "type": "organisation",
+      "companyNumber": "999000999"
+    }
+  ],
+  "contacts": [
+    {
+      "id": "6e05db31-39cd-4bb0-83a0-0d985037ad8f",
+      "salutation": "Mr",
+      "firstName": "John",
+      "lastName": "Testerson",
+      "middleInitials": "J",
+      "contactType": "person",
+      "dataSource": "nald"
+    }
+  ],
+  "licenceDocuments": [
+    {
+      "id": "1a274f3e-f891-43dd-8c25-8afac4e760ac",
+      "licenceRef": "AT/TEST/01",
+      "startDate": "2022-04-01"
+    }
+  ],
+  "licenceDocumentRoles": [
+    {
+      "licenceDocumentId": "1a274f3e-f891-43dd-8c25-8afac4e760ac",
+      "licenceRoleId": {
+        "schema": "public",
+        "table": "licenceRoles",
+        "lookup": "name",
+        "value": "licenceHolder",
+        "select": "id"
+      },
+      "startDate": "2022-04-01",
+      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
+      "contactId": "6e05db31-39cd-4bb0-83a0-0d985037ad8f"
+    }
+  ],
+  "permitLicences": [
+    {
+      "licenceRef": "AT/TEST/01",
+      "startDate": "2022-04-01",
+      "metadata": {
+        "source": "acceptance-test-setup"
+      }
+    }
+  ],
+  "licenceDocumentHeaders": [
+    {
+      "id": "282b226e-c47b-4dcc-bbb0-94648fb6b242",
+      "regimeEntityId": {
+        "schema": "crm",
+        "table": "entity",
+        "lookup": "entityType",
+        "value": "regime",
+        "select": "entityId"
+      },
+      "licenceRef": "AT/TEST/01",
+      "naldId": {
+        "schema": "public",
+        "table": "permitLicences",
+        "lookup": "licenceRef",
+        "value": "AT/TEST/01",
+        "select": "id"
+      },
+      "metadata": {
+        "Name": "Big Farm 01",
+        "dataType": "acceptance-test-setup",
+        "IsCurrent": true
+      }
+    }
+  ],
+  "licences": [
+    {
+      "id": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
+      "licenceRef": "AT/TEST/01",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" },
+      "regions": {
+        "historicalAreaCode": "SAAR",
+        "regionalChargeArea": "Test Region"
+      },
+      "startDate": "2022-04-01",
+      "waterUndertaker": false
+    }
+  ],
+  "licenceVersions": [
+    {
+      "id": "b846afb6-9334-42c4-8da3-1d559a6e3ea7",
+      "licenceId": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
+      "issue": 100,
+      "increment": 0,
+      "status": "superseded",
+      "startDate": "2022-04-01",
+      "endDate": "2023-06-11",
+      "externalId": "9:1234:100:0"
+    },
+    {
+      "id": "2f9362e8-4fdc-4018-880a-31bba8d9b23b",
+      "licenceId": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
+      "issue": 101,
+      "increment": 0,
+      "status": "current",
+      "startDate": "2023-06-12",
+      "externalId": "9:1234:102:0"
+    }
+  ],
+  "licenceVersionPurposes": [
+    {
+      "id": "a4f9b0b5-11ac-4aa2-98c9-61c6c12088bb",
+      "licenceVersionId": "2f9362e8-4fdc-4018-880a-31bba8d9b23b",
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "240",
+        "select": "id"
+      },
+      "primaryPurposeId": {
+        "schema": "public",
+        "table": "primaryPurposes",
+        "lookup": "legacyId",
+        "value": "P",
+        "select": "id"
+      },
+      "secondaryPurposeId": {
+        "schema": "public",
+        "table": "secondaryPurposes",
+        "lookup": "legacyId",
+        "value": "ELC",
+        "select": "id"
+      },
+      "abstractionPeriodEndDay": "31",
+      "abstractionPeriodEndMonth": "12",
+      "abstractionPeriodStartDay": "1",
+      "abstractionPeriodStartMonth": "3",
+      "externalId": "9:1234:1:0",
+      "dailyQuantity": "100"
+    },
+    {
+      "id": "e1f22696-6a86-4b95-b8e5-6abb68fcf5e0",
+      "licenceVersionId": "2f9362e8-4fdc-4018-880a-31bba8d9b23b",
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "270",
+        "select": "id"
+      },
+      "primaryPurposeId": {
+        "schema": "public",
+        "table": "primaryPurposes",
+        "lookup": "legacyId",
+        "value": "P",
+        "select": "id"
+      },
+      "secondaryPurposeId": {
+        "schema": "public",
+        "table": "secondaryPurposes",
+        "lookup": "legacyId",
+        "value": "CHE",
+        "select": "id"
+      },
+      "abstractionPeriodEndDay": "29",
+      "abstractionPeriodEndMonth": "11",
+      "abstractionPeriodStartDay": "12",
+      "abstractionPeriodStartMonth": "06",
+      "externalId": "9:1234:2:0",
+      "dailyQuantity": "101"
+    }
+  ],
+  "points": [
+    {
+      "id": "1cb602f8-6a01-4435-96b0-541e03f460da",
+      "description": "Example point 1",
+      "ngr1": "TQ 1234 5678",
+      "externalId": "9:9000031",
+      "sourceId": {
+        "schema": "public",
+        "table": "sources",
+        "lookup": "legacyId",
+        "value": "S",
+        "select": "id"
+      }
+    },
+    {
+      "id": "82fab927-ef31-45a2-a4e6-104315cb9764",
+      "description": "Example point 2",
+      "ngr1": "TT 9876 5432",
+      "externalId": "9:9000032",
+      "sourceId": {
+        "schema": "public",
+        "table": "sources",
+        "lookup": "legacyId",
+        "value": "S",
+        "select": "id"
+      }
+    }
+  ],
+  "licenceVersionPurposePoints": [
+    {
+      "id": "cda7facf-0dab-4e9b-9215-999ac9c24fbd",
+      "licenceVersionPurposeId": "a4f9b0b5-11ac-4aa2-98c9-61c6c12088bb",
+      "pointId": "1cb602f8-6a01-4435-96b0-541e03f460da"
+    },
+    {
+      "id": "2ab25adb-78e6-4504-a8eb-641e4bf99db7",
+      "licenceVersionPurposeId": "e1f22696-6a86-4b95-b8e5-6abb68fcf5e0",
+      "pointId": "82fab927-ef31-45a2-a4e6-104315cb9764"
+    }
+  ],
+  "returnVersions": [
+    {
+      "id": "a63cd63f-64b2-4adf-9bd0-b6d4a13f04e3",
+      "licenceId": "f8702a6a-f61d-4b0a-9af3-9a53768ee516",
+      "externalId": "9:5674:100",
+      "version":"100",
+      "startDate": "2023-06-12",
+      "status": "current",
+      "multipleUpload": false
+    }
+  ],
+  "returnRequirements": [
+    {
+      "id": "afa416d5-9b44-4ac5-a717-ead4e769c75f",
+      "returnVersionId": "a63cd63f-64b2-4adf-9bd0-b6d4a13f04e3",
+      "twoPartTariff": true,
+      "externalId": "9:100",
+      "siteDescription": "Borehole in top field"
+    }
+  ],
+  "returnRequirementPurposes": [
+    {
+      "id": "96340b33-3173-4007-9a1d-28664b334e5c",
+      "returnRequirementId": "afa416d5-9b44-4ac5-a717-ead4e769c75f",
+      "purposeId": {
+        "schema": "public",
+        "table": "purposes",
+        "lookup": "legacyId",
+        "value": "240",
+        "select": "id"
+      },
+      "primaryPurposeId": {
+        "schema": "public",
+        "table": "primaryPurposes",
+        "lookup": "legacyId",
+        "value": "P",
+        "select": "id"
+      },
+      "secondaryPurposeId": {
+        "schema": "public",
+        "table": "secondaryPurposes",
+        "lookup": "legacyId",
+        "value": "ELC",
+        "select": "id"
+      },
+      "alias": "This is a test purpose alias"
+    }
+  ],
+  "returnRequirementPoints": [
+    {
+      "returnRequirementId": "afa416d5-9b44-4ac5-a717-ead4e769c75f",
+      "pointId": "1cb602f8-6a01-4435-96b0-541e03f460da"
+    },
+    {
+      "returnRequirementId": "afa416d5-9b44-4ac5-a717-ead4e769c75f",
+      "pointId": "82fab927-ef31-45a2-a4e6-104315cb9764"
+    }
+  ],
+  "returnCycles": [
+    {
+      "id": "1d08dbd6-0630-4e5a-90e4-460f873842e5",
+      "dueDate": "2025-04-28",
+      "endDate": "2025-03-31",
+      "summer": false,
+      "submittedInWrls": true,
+      "startDate": "2024-04-01"
+    } , {
+      "id": "0d08dbd6-0630-4e5a-90e4-460f873842e3",
+      "dueDate": "2024-04-28",
+      "endDate": "2024-03-31",
+      "summer": false,
+      "submittedInWrls": true,
+      "startDate": "2023-04-01"
+    } , {
+      "id": "79bef3b6-2a0b-46fb-933c-de4c90bc89bf",
+      "dueDate": "2023-04-28",
+      "endDate": "2023-03-31",
+      "summer": false,
+      "submittedInWrls": true,
+      "startDate": "2022-04-01"
+    }
+  ],
+  "returnLogs": [
+    {
+      "id": "v1:9:AT/TEST/01:100:2022-04-01:2023-03-31",
+      "returnCycleId": "79bef3b6-2a0b-46fb-933c-de4c90bc89bf",
+      "licenceRef": "AT/TEST/01",
+      "startDate": "2022-04-01",
+      "endDate": "2023-03-31",
+      "dueDate": "2023-04-28",
+      "returnRequirement": "100",
+      "status": "completed"
+    }, {
+      "id": "v1:9:AT/TEST/01:100:2023-04-01:2024-03-31",
+      "returnCycleId": "79bef3b6-2a0b-46fb-933c-de4c90bc89bf",
+      "licenceRef": "AT/TEST/01",
+      "startDate": "2023-04-01",
+      "endDate": "2024-03-31",
+      "dueDate": "2024-04-28",
+      "returnRequirement": "100",
+      "status": "completed"
+    }, {
+      "id": "v1:9:AT/TEST/01:100:2024-04-01:2025-03-31",
+      "returnCycleId": "79bef3b6-2a0b-46fb-933c-de4c90bc89bf",
+      "licenceRef": "AT/TEST/01",
+      "startDate": "2024-04-01",
+      "endDate": "2025-03-31",
+      "dueDate": "2025-04-28",
+      "returnRequirement": "100"
+    }
+  ]
+}

--- a/cypress/lib/formatters.lib.js
+++ b/cypress/lib/formatters.lib.js
@@ -1,0 +1,14 @@
+/**
+ * Formats a date into a human readable day, month and year string, for example, '12 September 2021'
+ *
+ * @param {Date} date - The date to be formatted
+ *
+ * @returns {string} The date formatted as a 'DD MMMM YYYY' string
+ */
+function formatLongDate(date) {
+  return date.toLocaleDateString('en-GB', { year: 'numeric', month: 'long', day: 'numeric' })
+}
+
+module.exports = {
+  formatLongDate
+}

--- a/cypress/lib/formatters.lib.js
+++ b/cypress/lib/formatters.lib.js
@@ -5,7 +5,7 @@
  *
  * @returns {string} The date formatted as a 'DD MMMM YYYY' string
  */
-function formatLongDate(date) {
+function formatLongDate (date) {
   return date.toLocaleDateString('en-GB', { year: 'numeric', month: 'long', day: 'numeric' })
 }
 

--- a/cypress/lib/return-cycle-dates.lib.js
+++ b/cypress/lib/return-cycle-dates.lib.js
@@ -1,0 +1,96 @@
+'use strict'
+
+/**
+ * Helper methods to deal with return cycle dates
+ * @module ReturnCycleDatesLib
+ */
+
+const { returnCycleDates } = require('./static-lookups.lib.js')
+
+/**
+ * Determine the due date of next provided cycle, either summer or winter and all year
+ *
+ * @param {boolean} summer - true for summer, false for winter and all year
+ * @param {Date} [determinationDate] - the date by which to determine the cycle's 'due date' (defaults to current date)
+ *
+ * @returns {Date} the due date of the next cycle
+ */
+function determineCycleDueDate(summer, determinationDate = new Date()) {
+  if (summer) {
+    return _dueDate(determinationDate, returnCycleDates.summer)
+  }
+
+  return _dueDate(determinationDate, returnCycleDates.allYear)
+}
+
+/**
+ * Determine the end date of next provided cycle, either summer and winter or all year
+ *
+ * @param {boolean} summer - true for summer, false for winter and all year
+ * @param {Date} [determinationDate] - the date by which to determine the cycle's 'end date' (defaults to current date)
+ *
+ * @returns {Date} the end date of the next cycle
+ */
+function determineCycleEndDate(summer, determinationDate = new Date()) {
+  if (summer) {
+    return _endDate(determinationDate, returnCycleDates.summer)
+  }
+
+  return _endDate(determinationDate, returnCycleDates.allYear)
+}
+
+/**
+ * Determine the start date of next provided cycle, either summer or winter and all year
+ *
+ * @param {boolean} summer - true for summer, false for winter and all year
+ * @param {Date} [determinationDate] - the date by which to determine the cycle's 'start date' (defaults to current
+ * date)
+ *
+ * @returns {Date} the start date of the next cycle.
+ */
+function determineCycleStartDate(summer, determinationDate = new Date()) {
+  if (summer) {
+    return _startDate(determinationDate, returnCycleDates.summer)
+  }
+
+  return _startDate(determinationDate, returnCycleDates.allYear)
+}
+
+function _dueDate(determinationDate, cycle) {
+  const year = determinationDate.getFullYear()
+  const month = determinationDate.getMonth()
+
+  const cycleDueDay = cycle.dueDate.day
+  const cycleDueMonth = cycle.dueDate.month + 1
+  const cycleDueYear = month > cycle.endDate.month ? year + 1 : year
+
+  return new Date(`${cycleDueYear}-${cycleDueMonth}-${cycleDueDay}`)
+}
+
+function _endDate(determinationDate, cycle) {
+  const year = determinationDate.getFullYear()
+  const month = determinationDate.getMonth()
+
+  const cycleEndDay = cycle.endDate.day
+  const cycleEndMonth = cycle.endDate.month + 1
+  const cycleEndYear = month > cycle.endDate.month ? year + 1 : year
+
+  return new Date(`${cycleEndYear}-${cycleEndMonth}-${cycleEndDay}`)
+}
+
+function _startDate(determinationDate, cycle) {
+  const year = determinationDate.getFullYear()
+  const month = determinationDate.getMonth()
+
+  const cycleStartDay = cycle.startDate.day
+  const cycleStartMonth = cycle.startDate.month + 1
+  const cycleStartYear = month < cycle.startDate.month ? year - 1 : year
+
+  return new Date(`${cycleStartYear}-${cycleStartMonth}-${cycleStartDay}`)
+}
+
+module.exports = {
+  determineCycleDueDate,
+  determineCycleEndDate,
+  determineCycleStartDate
+}

--- a/cypress/lib/return-cycle-dates.lib.js
+++ b/cypress/lib/return-cycle-dates.lib.js
@@ -15,7 +15,7 @@ const { returnCycleDates } = require('./static-lookups.lib.js')
  *
  * @returns {Date} the due date of the next cycle
  */
-function determineCycleDueDate(summer, determinationDate = new Date()) {
+function determineCycleDueDate (summer, determinationDate = new Date()) {
   if (summer) {
     return _dueDate(determinationDate, returnCycleDates.summer)
   }
@@ -31,7 +31,7 @@ function determineCycleDueDate(summer, determinationDate = new Date()) {
  *
  * @returns {Date} the end date of the next cycle
  */
-function determineCycleEndDate(summer, determinationDate = new Date()) {
+function determineCycleEndDate (summer, determinationDate = new Date()) {
   if (summer) {
     return _endDate(determinationDate, returnCycleDates.summer)
   }
@@ -48,7 +48,7 @@ function determineCycleEndDate(summer, determinationDate = new Date()) {
  *
  * @returns {Date} the start date of the next cycle.
  */
-function determineCycleStartDate(summer, determinationDate = new Date()) {
+function determineCycleStartDate (summer, determinationDate = new Date()) {
   if (summer) {
     return _startDate(determinationDate, returnCycleDates.summer)
   }
@@ -56,7 +56,7 @@ function determineCycleStartDate(summer, determinationDate = new Date()) {
   return _startDate(determinationDate, returnCycleDates.allYear)
 }
 
-function _dueDate(determinationDate, cycle) {
+function _dueDate (determinationDate, cycle) {
   const year = determinationDate.getFullYear()
   const month = determinationDate.getMonth()
 
@@ -67,7 +67,7 @@ function _dueDate(determinationDate, cycle) {
   return new Date(`${cycleDueYear}-${cycleDueMonth}-${cycleDueDay}`)
 }
 
-function _endDate(determinationDate, cycle) {
+function _endDate (determinationDate, cycle) {
   const year = determinationDate.getFullYear()
   const month = determinationDate.getMonth()
 
@@ -78,7 +78,7 @@ function _endDate(determinationDate, cycle) {
   return new Date(`${cycleEndYear}-${cycleEndMonth}-${cycleEndDay}`)
 }
 
-function _startDate(determinationDate, cycle) {
+function _startDate (determinationDate, cycle) {
   const year = determinationDate.getFullYear()
   const month = determinationDate.getMonth()
 

--- a/cypress/lib/static-lookups.lib.js
+++ b/cypress/lib/static-lookups.lib.js
@@ -1,0 +1,19 @@
+/**
+ * The start, end and due dates for each return cycle
+ */
+const returnCycleDates = {
+  allYear: {
+    dueDate: { day: 28, month: 3 },
+    endDate: { day: 31, month: 2 },
+    startDate: { day: 1, month: 3 }
+  },
+  summer: {
+    dueDate: { day: 28, month: 10 },
+    endDate: { day: 31, month: 9 },
+    startDate: { day: 1, month: 10 }
+  }
+}
+
+module.exports = {
+  returnCycleDates
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4892

This PR adds two test scenarios for historic returns. One is to check a winter and all year only change and the other is a test for both summer and winter and all year return cycles.

This PR adds some of the logic for determining the due dates from the system repo so that when the tests are ran they always use current return cycle details. 