### PR TITLE
Fix broken billing tests caused by year change

### DIFF
--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
@@ -127,7 +127,12 @@ describe('Change billing account in current financial year (internal)', () => {
     })
     cy.get('[data-test="region-1"]').should('contain.text', 'Test Region')
     cy.get('[data-test="bill-run-type-1"]').should('contain.text', 'Supplementary')
-    cy.get('[data-test="number-of-bills-1"]').should('contain.text', '3')
+
+    cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
+      const { billingPeriodCount } = currentFinancialYearInfo
+      cy.get('[data-test="number-of-bills-1"]').should('contain.text', billingPeriodCount)
+    })
+
     cy.get('[data-test="bill-run-status-1"] > .govuk-tag').should('contain.text', 'sent')
 
     // -------------------------------------------------------------------------

--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
@@ -8,8 +8,8 @@ describe('Change billing account in current financial year (internal)', () => {
     // day and month we'll get back 20XX-03-31. We then use that date to work out how many SROC billing periods we
     // expect to be calculated. We combine these results into one value for use in our tests
     cy.currentFinancialYearDate().then((currentFinancialYearInfo) => {
-      cy.numberOfSrocBillingPeriods(currentFinancialYearInfo.year).then((numberOfBillingPeriods) => {
-        currentFinancialYearInfo.billingPeriodCount = numberOfBillingPeriods
+      cy.billingPeriodCounts(currentFinancialYearInfo.year).then((billingPeriodCount) => {
+        currentFinancialYearInfo.billingPeriodCounts = billingPeriodCount
         cy.wrap(currentFinancialYearInfo).as('currentFinancialYearInfo')
       })
 
@@ -82,7 +82,7 @@ describe('Change billing account in current financial year (internal)', () => {
     // check the details before sending the bill run
     cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
-      const { billingPeriodCount } = currentFinancialYearInfo
+      const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.sroc
       if (billingPeriodCount === 1) {
         cy.get('[data-test="bills-count"]')
           .should('contain.text', '1 Supplementary bill')
@@ -129,7 +129,7 @@ describe('Change billing account in current financial year (internal)', () => {
     cy.get('[data-test="bill-run-type-1"]').should('contain.text', 'Supplementary')
 
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
-      const { billingPeriodCount } = currentFinancialYearInfo
+      const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.sroc
       cy.get('[data-test="number-of-bills-1"]').should('contain.text', billingPeriodCount)
     })
 

--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
@@ -8,8 +8,8 @@ describe('Change billing account in previous financial year (internal)', () => {
     // day and month we'll get back 20XX-03-31. We then use that date to work out how many SROC billing periods we
     // expect to be calculated. We combine these results into one value for use in our tests
     cy.currentFinancialYearDate().then((currentFinancialYearInfo) => {
-      cy.numberOfSrocBillingPeriods(currentFinancialYearInfo.year).then((numberOfBillingPeriods) => {
-        currentFinancialYearInfo.billingPeriodCount = numberOfBillingPeriods
+      cy.billingPeriodCounts(currentFinancialYearInfo.year).then((billingPeriodCount) => {
+        currentFinancialYearInfo.billingPeriodCounts = billingPeriodCount
         cy.wrap(currentFinancialYearInfo).as('currentFinancialYearInfo')
       })
 
@@ -82,7 +82,7 @@ describe('Change billing account in previous financial year (internal)', () => {
     // check the details before sending the bill run
     cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
-      const { billingPeriodCount } = currentFinancialYearInfo
+      const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.sroc
       if (billingPeriodCount === 1) {
         cy.get('[data-test="bills-count"]')
           .should('contain.text', '1 Supplementary bill')
@@ -128,7 +128,8 @@ describe('Change billing account in previous financial year (internal)', () => {
     cy.get('[data-test="region-1"]').should('contain.text', 'Test Region')
     cy.get('[data-test="bill-run-type-1"]').should('contain.text', 'Supplementary')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
-      cy.get('[data-test="number-of-bills-1"]').should('contain.text', currentFinancialYearInfo.billingPeriodCount)
+      const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.sroc
+      cy.get('[data-test="number-of-bills-1"]').should('contain.text', billingPeriodCount)
     })
     cy.get('[data-test="bill-run-status-1"] > .govuk-tag').should('contain.text', 'sent')
 

--- a/cypress/e2e/internal/billing/supplementary/journey.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/journey.cy.js
@@ -8,8 +8,8 @@ describe('Create and send supplementary bill runs (internal)', () => {
     // day and month we'll get back 20XX-03-31. We then use that date to work out how many SROC billing periods we
     // expect to be calculated. We combine these results into one value for use in our tests
     cy.currentFinancialYearDate().then((currentFinancialYearInfo) => {
-      cy.numberOfSrocBillingPeriods(currentFinancialYearInfo.year).then((numberOfBillingPeriods) => {
-        currentFinancialYearInfo.billingPeriodCount = numberOfBillingPeriods
+      cy.billingPeriodCounts(currentFinancialYearInfo.year).then((billingPeriodCount) => {
+        currentFinancialYearInfo.billingPeriodCounts = billingPeriodCount
         cy.wrap(currentFinancialYearInfo).as('currentFinancialYearInfo')
       })
 
@@ -93,7 +93,16 @@ describe('Create and send supplementary bill runs (internal)', () => {
     // Test Region supplementary bill run
     // quick test that the display is as expected and then click Send bill run
     cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
-    cy.get('[data-test="bills-count"]').should('contain.text', '3 Supplementary bills')
+    cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
+      const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.presroc
+      if (billingPeriodCount === 1) {
+        cy.get('[data-test="bills-count"]')
+          .should('contain.text', '1 Supplementary bill')
+      } else {
+        cy.get('[data-test="bills-count"]')
+          .should('contain.text', `${billingPeriodCount} Supplementary bills`)
+      }
+    })
     cy.get('.govuk-button').contains('Send bill run').click()
 
     // You're about to send this bill run
@@ -130,7 +139,10 @@ describe('Create and send supplementary bill runs (internal)', () => {
     })
     cy.get('[data-test="region-0"]').should('contain.text', 'Test Region')
     cy.get('[data-test="bill-run-type-0"]').should('contain.text', 'Supplementary')
-    cy.get('[data-test="number-of-bills-0"]').should('contain.text', '3')
+    cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
+      const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.presroc
+      cy.get('[data-test="number-of-bills-0"]').should('contain.text', billingPeriodCount)
+    })
     cy.get('[data-test="bill-run-status-0"] > .govuk-tag').should('contain.text', 'sent')
 
     // -------------------------------------------------------------------------
@@ -143,7 +155,7 @@ describe('Create and send supplementary bill runs (internal)', () => {
     // check the details before sending the bill run
     cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
-      const { billingPeriodCount } = currentFinancialYearInfo
+      const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.sroc
       if (billingPeriodCount === 1) {
         cy.get('[data-test="bills-count"]')
           .should('contain.text', '1 Supplementary bill')
@@ -189,7 +201,8 @@ describe('Create and send supplementary bill runs (internal)', () => {
     cy.get('[data-test="region-1"]').should('contain.text', 'Test Region')
     cy.get('[data-test="bill-run-type-1"]').should('contain.text', 'Supplementary')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
-      cy.get('[data-test="number-of-bills-1"]').should('contain.text', currentFinancialYearInfo.billingPeriodCount)
+      const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.sroc
+      cy.get('[data-test="number-of-bills-1"]').should('contain.text', billingPeriodCount)
     })
     cy.get('[data-test="bill-run-status-1"] > .govuk-tag').should('contain.text', 'sent')
 

--- a/cypress/e2e/internal/billing/supplementary/no-annual-in-current-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/no-annual-in-current-year.cy.js
@@ -11,8 +11,10 @@ describe('Create and send supplementary bill runs (internal)', () => {
     // this test we use a fixture that creates it in the previous year. We then combine these results into one value for
     // use in our tests.
     cy.currentFinancialYearDate().then((currentFinancialYearInfo) => {
-      cy.numberOfSrocBillingPeriods(currentFinancialYearInfo.year).then((numberOfBillingPeriods) => {
-        currentFinancialYearInfo.billingPeriodCount = numberOfBillingPeriods - 1
+      // NOTE: We minus 1 here to reflect that, for example, 2025/26 might be the current financial year, but because
+      // the annual has not been generated the financial year to use for the counts is 2024/25
+      cy.billingPeriodCounts(currentFinancialYearInfo.year - 1).then((billingPeriodCount) => {
+        currentFinancialYearInfo.billingPeriodCounts = billingPeriodCount
         cy.wrap(currentFinancialYearInfo).as('currentFinancialYearInfo')
       })
 
@@ -85,7 +87,7 @@ describe('Create and send supplementary bill runs (internal)', () => {
     // check the the financial end year is not the current year
     cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
-      const { billingPeriodCount } = currentFinancialYearInfo
+      const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.sroc
       if (billingPeriodCount === 1) {
         cy.get('[data-test="bills-count"]')
           .should('contain.text', '1 Supplementary bill')

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
@@ -8,8 +8,8 @@ describe('Replace charge version in the 2023 financial year with no changes (int
     // day and month we'll get back 20XX-03-31. We then use that date to work out how many SROC billing periods we
     // expect to be calculated. We combine these results into one value for use in our tests
     cy.currentFinancialYearDate().then((currentFinancialYearInfo) => {
-      cy.numberOfSrocBillingPeriods(currentFinancialYearInfo.year).then((numberOfBillingPeriods) => {
-        currentFinancialYearInfo.billingPeriodCount = numberOfBillingPeriods
+      cy.billingPeriodCounts(currentFinancialYearInfo.year).then((billingPeriodCount) => {
+        currentFinancialYearInfo.billingPeriodCounts = billingPeriodCount
         cy.wrap(currentFinancialYearInfo).as('currentFinancialYearInfo')
       })
 
@@ -158,7 +158,7 @@ describe('Replace charge version in the 2023 financial year with no changes (int
     // check the details before sending the bill run
     cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
-      const { billingPeriodCount } = currentFinancialYearInfo
+      const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.sroc
       if (billingPeriodCount === 1) {
         cy.get('[data-test="bills-count"]')
           .should('contain.text', '1 Supplementary bill')
@@ -204,7 +204,8 @@ describe('Replace charge version in the 2023 financial year with no changes (int
     cy.get('[data-test="region-1"]').should('contain.text', 'Test Region')
     cy.get('[data-test="bill-run-type-1"]').should('contain.text', 'Supplementary')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
-      cy.get('[data-test="number-of-bills-1"]').should('contain.text', currentFinancialYearInfo.billingPeriodCount)
+      const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.sroc
+      cy.get('[data-test="number-of-bills-1"]').should('contain.text', billingPeriodCount)
     })
     cy.get('[data-test="bill-run-status-1"] > .govuk-tag').should('contain.text', 'sent')
 

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
@@ -8,8 +8,8 @@ describe('Replace charge version in current financial year change the charge ref
     // day and month we'll get back 20XX-03-31. We then use that date to work out how many SROC billing periods we
     // expect to be calculated. We combine these results into one value for use in our tests
     cy.currentFinancialYearDate().then((currentFinancialYearInfo) => {
-      cy.numberOfSrocBillingPeriods(currentFinancialYearInfo.year).then((numberOfBillingPeriods) => {
-        currentFinancialYearInfo.billingPeriodCount = numberOfBillingPeriods
+      cy.billingPeriodCounts(currentFinancialYearInfo.year).then((billingPeriodCount) => {
+        currentFinancialYearInfo.billingPeriodCounts = billingPeriodCount
         cy.wrap(currentFinancialYearInfo).as('currentFinancialYearInfo')
       })
 
@@ -158,7 +158,7 @@ describe('Replace charge version in current financial year change the charge ref
     // check the details before sending the bill run
     cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
-      const { billingPeriodCount } = currentFinancialYearInfo
+      const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.sroc
       if (billingPeriodCount === 1) {
         cy.get('[data-test="bills-count"]')
           .should('contain.text', '1 Supplementary bill')
@@ -204,7 +204,8 @@ describe('Replace charge version in current financial year change the charge ref
     cy.get('[data-test="region-1"]').should('contain.text', 'Test Region')
     cy.get('[data-test="bill-run-type-1"]').should('contain.text', 'Supplementary')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
-      cy.get('[data-test="number-of-bills-1"]').should('contain.text', currentFinancialYearInfo.billingPeriodCount)
+      const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.sroc
+      cy.get('[data-test="number-of-bills-1"]').should('contain.text', billingPeriodCount)
     })
     cy.get('[data-test="bill-run-status-1"] > .govuk-tag').should('contain.text', 'sent')
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -196,15 +196,19 @@ Cypress.Commands.add('currentFinancialYearDate', (day = 31, month = 3, yearAdjus
 // bill run will be generating bills for, we know it will be for the number of years from 2023 to whatever
 // financialYearToBaseItOn is. For example
 //
-// - financialYearToBaseItOn is 2024 (2023-04-01 to 2024-03-31) so result will be 2
-// - financialYearToBaseItOn is 2029 (2028-04-01 to 2029-03-31) so result will be 5
-Cypress.Commands.add('numberOfSrocBillingPeriods', (financialYearToBaseItOn) => {
+// - financialYearToBaseItOn is 2024 (2023-04-01 to 2024-03-31) so result will be 2 SROC and 3 PRESROC
+// - financialYearToBaseItOn is 2025 (2024-04-01 to 2025-03-31) so result will be 3 SROC and 2 PRESROC
+// - financialYearToBaseItOn is 2026 (2025-04-01 to 2026-03-31) so result will be 4 SROC and 1 PRESROC
+// - financialYearToBaseItOn is 2027 (2026-04-01 to 2027-03-31) so result will be 5 SROC and 0 PRESROC
+// - financialYearToBaseItOn is 2028 (2027-04-01 to 2028-03-31) so result will be 5 SROC and 0 PRESROC
+Cypress.Commands.add('billingPeriodCounts', (financialYearToBaseItOn) => {
   if (isNaN(financialYearToBaseItOn)) {
-    throw new Error('numberOfSrocBillingPeriods: financialYearToBaseItOn must be set and a number')
+    throw new Error('billingPeriodCounts: financialYearToBaseItOn must be set and a number')
   }
 
   const earliestPossibleFinancialYear = Math.max(2023, financialYearToBaseItOn - 5)
-  const numberOfBillingPeriods = Math.min((financialYearToBaseItOn - earliestPossibleFinancialYear) + 1, 5)
+  const srocBillingPeriods = Math.min((financialYearToBaseItOn - earliestPossibleFinancialYear) + 1, 5)
+  const presrocBillingPeriods = 6 - srocBillingPeriods
 
-  return cy.wrap(numberOfBillingPeriods)
+  return cy.wrap({ presroc: presrocBillingPeriods, sroc: srocBillingPeriods})
 })

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -210,5 +210,5 @@ Cypress.Commands.add('billingPeriodCounts', (financialYearToBaseItOn) => {
   const srocBillingPeriods = Math.min((financialYearToBaseItOn - earliestPossibleFinancialYear) + 1, 5)
   const presrocBillingPeriods = 6 - srocBillingPeriods
 
-  return cy.wrap({ presroc: presrocBillingPeriods, sroc: srocBillingPeriods})
+  return cy.wrap({ presroc: presrocBillingPeriods, sroc: srocBillingPeriods })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4974

We've gone to run our acceptance tests and found that some have failed. All are connected to the switch into the next financial year, and these changes are for failing supplementary tests.

As we move away from 2022, the number of bills expected in supplementary bills runs will increase, whilst PRE-SROC will reduce. We're handling this with calculated assertions in some places, but we missed some.

This change fixes those omissions.