### PR TITLE
Update SROC based 2PT bill run tests for 2024/25

### DIFF
--- a/cypress/e2e/internal/billing/two-part-tariff/empty-bill-run.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/empty-bill-run.cy.js
@@ -46,8 +46,8 @@ describe('Create a empty SROC two-part tariff bill run (internal)', () => {
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // choose 2021 to 2022 and continue
-    cy.get('label.govuk-radios__label').contains('2023 to 2024').click()
+    // choose top option and continue
+    cy.get('#year').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-01.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-01.cy.js
@@ -62,8 +62,8 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // Choose 2021 to 2022 and continue
-    cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
+    // choose top option and continue
+    cy.get('#year').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run
@@ -90,7 +90,7 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     cy.get('[data-test="meta-data-region"]').should('contain.text', 'Test Region')
     cy.get('[data-test="meta-data-type"]').should('contain.text', 'Two-part tariff')
     cy.get('[data-test="meta-data-scheme"]').should('contain.text', 'Current')
-    cy.get('[data-test="meta-data-year"]').should('contain.text', '2022 to 2023')
+    cy.get('[data-test="meta-data-year"]').should('contain.text', '2024 to 2025')
 
     // Review licences ~ Test you can filter by licence ref
     cy.get('.govuk-details__summary').click()
@@ -129,7 +129,7 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'ready')
     cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
-    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2024 to 31 March 2025')
 
     // Review Licence AT/TEST/01 ~ Check the Licence links
     cy.get('[data-test="summary-link"]').should('exist')
@@ -141,7 +141,7 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     // Review Licence AT/TEST/01 ~ Check the return details
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
@@ -152,8 +152,8 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     cy.get('[data-test="unmatched-return-action-0"] > .govuk-link').should('not.exist')
 
     // Review Licence AT/TEST/01 ~ Check charge Information details
-    cy.get('[data-test="financial-year"]').should('contain.text', 'Financial year 2022 to 2023')
-    cy.get('#charge-version-0 > .govuk-heading-l').should('contain.text', 'Charge periods 1 April 2022 to 31 March 2023')
+    cy.get('[data-test="financial-year"]').should('contain.text', 'Financial year 2024 to 2025')
+    cy.get('#charge-version-0 > .govuk-heading-l').should('contain.text', 'Charge periods 1 April 2024 to 31 March 2025')
     cy.get('[data-test="charge-version-0-details"]').should('contain.text', '1 charge reference with 1 two-part tariff charge element')
     cy.get('.govuk-details__summary-text').should('contain.text', 'Big Farm Co Ltd 01 billing account details')
     cy.get('.govuk-details__summary').click()
@@ -166,7 +166,7 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     cy.get('[data-test="charge-version-0-charge-reference-0-element-count-0"]').should('contain.text', 'Element 1 of 1')
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', 'SROC Charge Purpose 01')
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', 'General Farming & Domestic')
-    cy.get('[data-test="charge-version-0-charge-reference-0-element-dates-0"]').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-dates-0"]').should('contain.text', '1 April 2024 to 31 March 2025')
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-issues-0"]').should('contain.text', '')
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-billable-returns-0"]').should('contain.text', '32 ML / 32 ML')
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-return-volumes-0"]').should('contain.text', '32 ML (10021668)')
@@ -180,8 +180,8 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     // Charge reference details
     cy.get('[data-test="charge-reference"]').should('contain.text', 'Charge reference 4.6.12')
     cy.get('[data-test="charge-reference-description"]').should('contain.text', 'High loss, non-tidal, restricted water, greater than 15 up to and including 50 ML/yr, Tier 2 model')
-    cy.get('[data-test="financial-year"]').should('contain.text', 'Financial Year 2022 to 2023')
-    cy.get('[data-test="charge-period"]').should('contain.text', 'Charge period 1 April 2022 to 31 March 2023')
+    cy.get('[data-test="financial-year"]').should('contain.text', 'Financial Year 2024 to 2025')
+    cy.get('[data-test="charge-period"]').should('contain.text', 'Charge period 1 April 2024 to 31 March 2025')
     cy.get('[data-test="total-billable-returns"]').should('contain.text', '32 ML')
     cy.get('[data-test="authorised-volume"]').should('contain.text', '32 ML')
     cy.get('[data-test="additional-charges"]').should('contain.text', 'Public Water Supply')
@@ -195,15 +195,15 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     // View match details
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
     cy.get('.govuk-heading-l').should('contain.text', 'SROC Charge Purpose 01')
-    cy.get('[data-test="charge-period-0"]').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('[data-test="charge-period-0"]').should('contain.text', '1 April 2024 to 31 March 2025')
     cy.get('.govuk-grid-column-full > .govuk-tag').should('contain.text', 'ready')
-    cy.get('[data-test="financial-year"]').should('contain.text', 'Financial year 2022 to 2023')
-    cy.get('[data-test="charge-period"]').should('contain.text', 'Charge period 1 April 2022 to 31 March 2023')
+    cy.get('[data-test="financial-year"]').should('contain.text', 'Financial year 2024 to 2025')
+    cy.get('[data-test="charge-period"]').should('contain.text', 'Charge period 1 April 2024 to 31 March 2025')
     cy.get('[data-test="billable-returns"]').should('contain.text', '32 ML')
     cy.get('[data-test="authorised-volume"]').should('contain.text', '32 ML')
     cy.get('[data-test="issues-0"]').should('not.exist')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-summary-0"]').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-summary-0"]').should('contain.text', 'A DRAIN SOMEWHERE')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
@@ -212,10 +212,10 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     // View match details ~ Edit the billable returns
     cy.get('.govuk-button').click()
     cy.get('.govuk-caption-l').should('contain.text', 'SROC Charge Purpose 01')
-    cy.get('[data-test="charge-period-0"]').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('[data-test="charge-period-0"]').should('contain.text', '1 April 2024 to 31 March 2025')
     cy.get('h1').should('contain.text', 'Set the billable returns quantity for this bill run')
-    cy.get('[data-test="financial-year"]').should('contain.text', 'Financial year 2022 to 2023')
-    cy.get('[data-test="charge-period"]').should('contain.text', 'Charge period 1 April 2022 to 31 March 2023')
+    cy.get('[data-test="financial-year"]').should('contain.text', 'Financial year 2024 to 2025')
+    cy.get('[data-test="charge-period"]').should('contain.text', 'Charge period 1 April 2024 to 31 March 2025')
     cy.get('[data-test="authorised-quantity"]').should('contain.text', 'Authorised 32ML')
     cy.get('#custom-quantity-selector').click()
     cy.get('#custom-quantity').type('20.123')
@@ -253,7 +253,7 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     cy.get('[data-test="meta-data-region"]').should('contain.text', 'Test Region')
     cy.get('[data-test="meta-data-type"]').should('contain.text', 'Two-part tariff')
     cy.get('[data-test="meta-data-scheme"]').should('contain.text', 'Current')
-    cy.get('[data-test="meta-data-year"]').should('contain.text', '2022 to 2023')
+    cy.get('[data-test="meta-data-year"]').should('contain.text', '2024 to 2025')
     cy.get('.govuk-button').click()
 
     // Bill runs ~ Check the bill run is now empty as the licence has been removed

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-02.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-02.cy.js
@@ -54,8 +54,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // Choose 2021 to 2022 and continue
-    cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
+    // choose top option and continue
+    cy.get('#year').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run
@@ -81,7 +81,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="meta-data-region"]').should('contain.text', 'Test Region')
     cy.get('[data-test="meta-data-type"]').should('contain.text', 'Two-part tariff')
     cy.get('[data-test="meta-data-scheme"]').should('contain.text', 'Current')
-    cy.get('[data-test="meta-data-year"]').should('contain.text', '2022 to 2023')
+    cy.get('[data-test="meta-data-year"]').should('contain.text', '2024 to 2025')
 
     // Review licences ~ Test it has the correct licence
     cy.get('[data-test="licence-1"]').should('contain.text', 'AT/TEST/01')
@@ -97,12 +97,12 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'ready')
     cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
-    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2024 to 31 March 2025')
 
     // Review Licence AT/TEST/01 ~ Check the first matched return details
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-03.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-03.cy.js
@@ -55,8 +55,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // Choose 2021 to 2022 and continue
-    cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
+    // choose top option and continue
+    cy.get('#year').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run
@@ -82,7 +82,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="meta-data-region"]').should('contain.text', 'Test Region')
     cy.get('[data-test="meta-data-type"]').should('contain.text', 'Two-part tariff')
     cy.get('[data-test="meta-data-scheme"]').should('contain.text', 'Current')
-    cy.get('[data-test="meta-data-year"]').should('contain.text', '2022 to 2023')
+    cy.get('[data-test="meta-data-year"]').should('contain.text', '2024 to 2025')
 
     // Review licences ~ Test you can filter by licence issue
     cy.get('.govuk-details__summary').click()
@@ -110,12 +110,12 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'ready')
     cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
-    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2024 to 31 March 2025')
 
     // Review Licence AT/TEST/01 ~ Check the first matched return details include the returns received late issue
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
@@ -134,7 +134,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     // View match details
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-summary-0"]').contains('General Farming & Domestic A DRAIN SOMEWHERE')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="matched-return-total-0"] > :nth-child(1)').should('contain.text', '32 ML / 32 ML')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-04.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-04.cy.js
@@ -55,8 +55,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // Choose 2021 to 2022 and continue
-    cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
+    // choose top option and continue
+    cy.get('#year').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run
@@ -82,7 +82,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="meta-data-region"]').should('contain.text', 'Test Region')
     cy.get('[data-test="meta-data-type"]').should('contain.text', 'Two-part tariff')
     cy.get('[data-test="meta-data-scheme"]').should('contain.text', 'Current')
-    cy.get('[data-test="meta-data-year"]').should('contain.text', '2022 to 2023')
+    cy.get('[data-test="meta-data-year"]').should('contain.text', '2024 to 2025')
 
     // Review licences ~ Test you can filter by licence issue
     cy.get('.govuk-details__summary').click()
@@ -112,12 +112,12 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'review')
     cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
-    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2024 to 31 March 2025')
 
     // Review Licence AT/TEST/01 ~ Check the matched return details
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
@@ -138,7 +138,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     // View match details
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-summary-0"]').contains('General Farming & Domestic A DRAIN SOMEWHERE')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="matched-return-total-0"] > :nth-child(1)').should('contain.text', '32 ML / 32 ML')
@@ -154,8 +154,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     // Charge reference details
     cy.get('[data-test="charge-reference"]').should('contain.text', 'Charge reference 4.6.12')
     cy.get('[data-test="charge-reference-description"]').should('contain.text', 'High loss, non-tidal, restricted water, greater than 15 up to and including 50 ML/yr, Tier 2 model')
-    cy.get('[data-test="financial-year"]').should('contain.text', 'Financial Year 2022 to 2023')
-    cy.get('[data-test="charge-period"]').should('contain.text', 'Charge period 1 April 2022 to 31 March 2023')
+    cy.get('[data-test="financial-year"]').should('contain.text', 'Financial Year 2024 to 2025')
+    cy.get('[data-test="charge-period"]').should('contain.text', 'Charge period 1 April 2024 to 31 March 2025')
     cy.get('[data-test="total-billable-returns"]').should('contain.text', '32 ML')
     cy.get('[data-test="authorised-volume"]').should('contain.text', '32 ML')
     cy.get('[data-test="additional-charges"]').should('contain.text', 'Public Water Supply')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-05.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-05.cy.js
@@ -55,8 +55,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // Choose 2021 to 2022 and continue
-    cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
+    // choose top option and continue
+    cy.get('#year').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run
@@ -82,7 +82,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="meta-data-region"]').should('contain.text', 'Test Region')
     cy.get('[data-test="meta-data-type"]').should('contain.text', 'Two-part tariff')
     cy.get('[data-test="meta-data-scheme"]').should('contain.text', 'Current')
-    cy.get('[data-test="meta-data-year"]').should('contain.text', '2022 to 2023')
+    cy.get('[data-test="meta-data-year"]').should('contain.text', '2024 to 2025')
 
     // Review licences ~ Test you can filter by licence issue
     cy.get('.govuk-details__summary').click()
@@ -112,12 +112,12 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'review')
     cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
-    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2024 to 31 March 2025')
 
     // Review Licence AT/TEST/01 ~ Check the matched return details
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
@@ -141,7 +141,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     // View match details
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-summary-0"]').contains('General Farming & Domestic A DRAIN SOMEWHERE')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="matched-return-total-0"] > :nth-child(1)').should('contain.text', '32 ML / 32 ML')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-06.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-06.cy.js
@@ -55,8 +55,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // Choose 2021 to 2022 and continue
-    cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
+    // choose top option and continue
+    cy.get('#year').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run
@@ -82,7 +82,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="meta-data-region"]').should('contain.text', 'Test Region')
     cy.get('[data-test="meta-data-type"]').should('contain.text', 'Two-part tariff')
     cy.get('[data-test="meta-data-scheme"]').should('contain.text', 'Current')
-    cy.get('[data-test="meta-data-year"]').should('contain.text', '2022 to 2023')
+    cy.get('[data-test="meta-data-year"]').should('contain.text', '2024 to 2025')
 
     // Review licences ~ Test you can filter by licence issue
     cy.get('.govuk-details__summary').click()
@@ -112,12 +112,12 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'review')
     cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
-    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2024 to 31 March 2025')
 
     // Review Licence AT/TEST/01 ~ Check the first matched return details
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'query')
@@ -143,7 +143,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     // View match details
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-summary-0"]').contains('General Farming & Domestic A DRAIN SOMEWHERE')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'query')
     cy.get('[data-test="matched-return-total-0"] > :nth-child(1)').should('contain.text', '0 ML / 32 ML')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-07.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-07.cy.js
@@ -55,8 +55,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // Choose 2021 to 2022 and continue
-    cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
+    // choose top option and continue
+    cy.get('#year').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run
@@ -82,7 +82,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="meta-data-region"]').should('contain.text', 'Test Region')
     cy.get('[data-test="meta-data-type"]').should('contain.text', 'Two-part tariff')
     cy.get('[data-test="meta-data-scheme"]').should('contain.text', 'Current')
-    cy.get('[data-test="meta-data-year"]').should('contain.text', '2022 to 2023')
+    cy.get('[data-test="meta-data-year"]').should('contain.text', '2024 to 2025')
 
     // Review licences ~ Test you can filter by licence issue
     cy.get('.govuk-details__summary').click()
@@ -112,12 +112,12 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'review')
     cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
-    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2024 to 31 March 2025')
 
     // Review Licence AT/TEST/01 ~ Check the first matched return details
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'received')
@@ -143,7 +143,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     // View match details
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-summary-0"]').contains('General Farming & Domestic A DRAIN SOMEWHERE')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'received')
     cy.get('[data-test="matched-return-total-0"] > :nth-child(1)').should('contain.text', '/')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-08.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-08.cy.js
@@ -56,8 +56,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // Choose 2021 to 2022 and continue
-    cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
+    // choose top option and continue
+    cy.get('#year').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run
@@ -83,7 +83,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="meta-data-region"]').should('contain.text', 'Test Region')
     cy.get('[data-test="meta-data-type"]').should('contain.text', 'Two-part tariff')
     cy.get('[data-test="meta-data-scheme"]').should('contain.text', 'Current')
-    cy.get('[data-test="meta-data-year"]').should('contain.text', '2022 to 2023')
+    cy.get('[data-test="meta-data-year"]').should('contain.text', '2024 to 2025')
 
     // Review licences ~ Test it has the correct licence
     cy.get('[data-test="licence-1"]').should('contain.text', 'AT/TEST/01')
@@ -100,12 +100,12 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'ready')
     cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
-    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2024 to 31 March 2025')
 
     // Review Licence AT/TEST/01 ~ Check the first matched return details
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
@@ -127,7 +127,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     // View match details
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-match-details-0"]').click()
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-summary-0"]').contains('General Farming & Domestic A DRAIN SOMEWHERE')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="matched-return-total-0"]').should('contain.text', '0 ML / 0 ML')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-09.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-09.cy.js
@@ -59,8 +59,8 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // Choose 2021 to 2022 and continue
-    cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
+    // choose top option and continue
+    cy.get('#year').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run
@@ -86,7 +86,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('[data-test="meta-data-region"]').should('contain.text', 'Test Region')
     cy.get('[data-test="meta-data-type"]').should('contain.text', 'Two-part tariff')
     cy.get('[data-test="meta-data-scheme"]').should('contain.text', 'Current')
-    cy.get('[data-test="meta-data-year"]').should('contain.text', '2022 to 2023')
+    cy.get('[data-test="meta-data-year"]').should('contain.text', '2024 to 2025')
 
     // Review licences ~ Test you can filter by licence issue
     cy.get('.govuk-details__summary').click()
@@ -118,12 +118,12 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('div > .govuk-tag').should('contain.text', 'ready')
     cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
     // On this licence there are two charge versions meaning we have two charge period links
-    cy.get('[data-test="charge-period-0"]').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('[data-test="charge-period-0"]').should('contain.text', '1 April 2024 to 31 March 2025')
 
     // Review Licence AT/TEST/01 ~ Check the first matched return details
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'overdue')
@@ -133,7 +133,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     // Review Licence AT/TEST/01 ~ Check the second matched return details
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-1"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-1"] > div').should('contain.text', '1 October 2022 to 31 March 2023')
+    cy.get('[data-test="matched-return-action-1"] > div').should('contain.text', '1 October 2024 to 31 March 2025')
     cy.get('[data-test="matched-return-summary-1"] > div').should('contain.text', 'Mineral Washing')
     cy.get('[data-test="matched-return-status-1"] > .govuk-tag').should('contain.text', 'overdue')
     cy.get('[data-test="matched-return-total-1"] > :nth-child(1)').should('contain.text', '/')
@@ -144,7 +144,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('[data-test="unmatched-return-action-0"] > .govuk-link').should('not.exist')
 
     // Review Licence AT/TEST/01 ~ Check charge information details are correct
-    cy.get('#charge-version-0 > .govuk-heading-l').should('contain.text', 'Charge periods 1 April 2022 to 31 March 2023')
+    cy.get('#charge-version-0 > .govuk-heading-l').should('contain.text', 'Charge periods 1 April 2024 to 31 March 2025')
     cy.get('[data-test="charge-version-0-details"]').should('contain.text', '2 charge references with 2 two-part tariff charge elements')
     cy.get('[data-test="charge-version-0-reference-0"]').should('contain.text', 'Charge reference 4.6.19')
     // The first charge reference has a lower authorised volume than its charge element. This means we expect the return
@@ -153,7 +153,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     // Without an aggregate of charge factor we shouldn't see the link "Change details" only "View details"
     cy.get('[data-test="charge-version-0-charge-reference-link-0"]').should('contain.text', 'View details')
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', 'SROC Charge Purpose 02')
-    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', '1 April 2024 to 31 March 2025')
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', 'Mineral Washing')
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-issues-0"]').should('contain.text', 'No returns received')
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-billable-returns-0"]').should('contain.text', '22 ML / 42 ML')
@@ -165,7 +165,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('[data-test="authorised-volume"]').should('contain.text', '42 ML')
     cy.get('[data-test="issues-0"]').should('contain.text', 'No returns received')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 October 2022 to 31 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 October 2024 to 31 March 2025')
     cy.get('[data-test="matched-return-summary-0"]').contains('Mineral Washing A DRAIN SOMEWHERE')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'overdue')
     cy.get('[data-test="matched-return-total-0"] > :nth-child(1)').should('contain.text', '/')
@@ -180,7 +180,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     // Without an aggregate of charge factor we shouldn't see the link "Change details" only "View details"
     cy.get('[data-test="charge-version-0-charge-reference-link-1"]').should('contain.text', 'View details')
     cy.get('[data-test="charge-version-0-charge-reference-1-element-description-0"]').should('contain.text', 'SROC Charge Purpose 01')
-    cy.get('[data-test="charge-version-0-charge-reference-1-element-description-0"]').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('[data-test="charge-version-0-charge-reference-1-element-description-0"]').should('contain.text', '1 April 2024 to 31 March 2025')
     cy.get('[data-test="charge-version-0-charge-reference-1-element-description-0"]').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="charge-version-0-charge-reference-1-charge-element-issues-0"]').should('contain.text', 'No returns received')
     cy.get('[data-test="charge-version-0-charge-reference-1-charge-element-billable-returns-0"]').should('contain.text', '32 ML / 32 ML')
@@ -192,7 +192,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('[data-test="authorised-volume"]').should('contain.text', '32 ML')
     cy.get('[data-test="issues-0"]').should('contain.text', 'No returns received')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-summary-0"]').contains('General Farming & Domestic A DRAIN SOMEWHERE')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'overdue')
     cy.get('[data-test="matched-return-total-0"] > :nth-child(1)').should('contain.text', '/')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-10.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-10.cy.js
@@ -56,8 +56,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // Choose 2021 to 2022 and continue
-    cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
+    // choose top option and continue
+    cy.get('#year').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run
@@ -83,7 +83,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="meta-data-region"]').should('contain.text', 'Test Region')
     cy.get('[data-test="meta-data-type"]').should('contain.text', 'Two-part tariff')
     cy.get('[data-test="meta-data-scheme"]').should('contain.text', 'Current')
-    cy.get('[data-test="meta-data-year"]').should('contain.text', '2022 to 2023')
+    cy.get('[data-test="meta-data-year"]').should('contain.text', '2024 to 2025')
 
     // Review licences ~ Test you can filter by licence issue
     cy.get('.govuk-details__summary').click()
@@ -113,7 +113,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'review')
     cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
-    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2024 to 31 March 2025')
 
     // Review Licence AT/TEST/01 ~ Check there are no returns
     cy.get('h2.govuk-heading-m').should('contain.text', 'No two-part tariff returns')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-11.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-11.cy.js
@@ -56,8 +56,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // Choose 2021 to 2022 and continue
-    cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
+    // choose top option and continue
+    cy.get('#year').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run
@@ -83,7 +83,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="meta-data-region"]').should('contain.text', 'Test Region')
     cy.get('[data-test="meta-data-type"]').should('contain.text', 'Two-part tariff')
     cy.get('[data-test="meta-data-scheme"]').should('contain.text', 'Current')
-    cy.get('[data-test="meta-data-year"]').should('contain.text', '2022 to 2023')
+    cy.get('[data-test="meta-data-year"]').should('contain.text', '2024 to 2025')
 
     // Review licences ~ Test you can filter by licence issue
     cy.get('.govuk-details__summary').click()
@@ -114,12 +114,12 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'ready')
     cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
-    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2024 to 31 March 2025')
 
     // Review Licence AT/TEST/01 ~ Check the first matched return details
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
@@ -131,7 +131,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     // Review Licence AT/TEST/01 ~ Check the second matched return details
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-1"] > .govuk-link').should('contain.text', '10021669')
-    cy.get('[data-test="matched-return-action-1"] > div').should('contain.text', '1 May 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-1"] > div').should('contain.text', '1 May 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-summary-1"] > div').should('contain.text', 'Mineral Washing')
     cy.get('[data-test="matched-return-status-1"] > .govuk-tag').should('contain.text', 'completed')
     // When a return is over abstracted the return should still allocate up to the charge element volume or
@@ -152,7 +152,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="charge-version-0-details"]').should('contain.text', '1 charge reference with 2 two-part tariff charge elements')
     // Charge element 1
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', 'SROC Charge Purpose 01')
-    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', '1 April 2024 to 31 March 2025')
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-issues-0"]').should('contain.text', '')
     cy.get(':nth-child(2) > .float-right > .govuk-tag').should('contain.text', 'ready')
@@ -160,7 +160,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-return-volumes-0"]').should('contain.text', '38 ML (10021668)')
     // Charge element 2
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-1"]').should('contain.text', 'SROC Charge Purpose 02')
-    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-1"]').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-1"]').should('contain.text', '1 April 2024 to 31 March 2025')
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-1"]').should('contain.text', 'Mineral Washing')
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-issues-1"]').should('contain.text', '')
     cy.get(':nth-child(3) > .float-right > .govuk-tag').should('contain.text', 'ready')
@@ -172,7 +172,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="billable-returns"]').should('contain.text', '32 ML')
     cy.get('[data-test="authorised-volume"]').should('contain.text', '32 ML')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-summary-0"]').contains('General Farming & Domestic A DRAIN SOMEWHERE')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="matched-return-total-0"] > :nth-child(1)').should('contain.text', '32 ML / 38 ML')
@@ -184,7 +184,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('[data-test="billable-returns"]').should('contain.text', '30 ML')
     cy.get('[data-test="authorised-volume"]').should('contain.text', '30 ML')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021669')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 May 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 May 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-summary-0"]').contains('Mineral Washing A DRAIN SOMEWHERE')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="matched-return-total-0"] > :nth-child(1)').should('contain.text', '30 ML / 36 ML')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-12.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-12.cy.js
@@ -56,8 +56,8 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // Choose 2021 to 2022 and continue
-    cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
+    // choose top option and continue
+    cy.get('#year').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run
@@ -83,7 +83,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('[data-test="meta-data-region"]').should('contain.text', 'Test Region')
     cy.get('[data-test="meta-data-type"]').should('contain.text', 'Two-part tariff')
     cy.get('[data-test="meta-data-scheme"]').should('contain.text', 'Current')
-    cy.get('[data-test="meta-data-year"]').should('contain.text', '2022 to 2023')
+    cy.get('[data-test="meta-data-year"]').should('contain.text', '2024 to 2025')
 
     // Review licences ~ Test you can filter by licence issue
     cy.get('.govuk-details__summary').click()
@@ -113,12 +113,12 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'review')
     cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
-    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2024 to 31 March 2025')
 
     // Review Licence AT/TEST/01 ~ Check the first matched return details
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 April to 31 March')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
@@ -141,7 +141,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('[data-test="charge-version-0-charge-reference-link-1"]').should('contain.text', 'View details')
     // Charge element 1
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', 'SROC Charge Purpose 02')
-    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', '1 November 2022 to 31 March 2023')
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', '1 November 2024 to 31 March 2025')
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-issues-0"]').should('contain.text', '')
     cy.get(':nth-child(2) > .float-right > .govuk-tag').should('contain.text', 'ready')
@@ -149,7 +149,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-return-volumes-0"]').should('contain.text', '32 ML (10021668)')
     // Charge element 2
     cy.get('[data-test="charge-version-0-charge-reference-1-element-description-0"]').should('contain.text', 'SROC Charge Purpose 01')
-    cy.get('[data-test="charge-version-0-charge-reference-1-element-description-0"]').should('contain.text', '1 April 2022 to 31 October 2022')
+    cy.get('[data-test="charge-version-0-charge-reference-1-element-description-0"]').should('contain.text', '1 April 2024 to 31 October 2024')
     cy.get('[data-test="charge-version-0-charge-reference-1-element-description-0"]').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="charge-version-0-charge-reference-1-charge-element-issues-0"]').should('contain.text', '')
     cy.get('[data-test="charge-version-0-charge-reference-0-element-status-0"] > .govuk-tag').should('contain.text', 'ready')
@@ -161,7 +161,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('[data-test="billable-returns"]').should('contain.text', '14 ML')
     cy.get('[data-test="authorised-volume"]').should('contain.text', '14 ML')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-summary-0"]').contains('General Farming & Domestic A DRAIN SOMEWHERE')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
     cy.get('[data-test="matched-return-total-0"] > :nth-child(1)').should('contain.text', '32 ML / 32 ML')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-13.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-13.cy.js
@@ -55,8 +55,8 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // Choose 2021 to 2022 and continue
-    cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
+    // choose top option and continue
+    cy.get('#year').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run
@@ -82,7 +82,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('[data-test="meta-data-region"]').should('contain.text', 'Test Region')
     cy.get('[data-test="meta-data-type"]').should('contain.text', 'Two-part tariff')
     cy.get('[data-test="meta-data-scheme"]').should('contain.text', 'Current')
-    cy.get('[data-test="meta-data-year"]').should('contain.text', '2022 to 2023')
+    cy.get('[data-test="meta-data-year"]').should('contain.text', '2024 to 2025')
 
     // Review licences ~ Test you can filter by licence issue
     cy.get('.govuk-details__summary').click()
@@ -114,12 +114,12 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'review')
     cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
-    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2024 to 31 March 2025')
 
     // Review Licence AT/TEST/01 ~ Check the unmatched return details
     cy.get('.govuk-table__caption').should('contain.text', 'Unmatched returns')
     cy.get('[data-test="unmatched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="unmatched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="unmatched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="unmatched-return-action-0"] > :nth-child(3)').should('contain.text', '1 March to 31 October')
     cy.get('[data-test="unmatched-return-summary-0"] > div').should('contain.text', 'Mineral Washing')
     cy.get('[data-test="unmatched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
@@ -137,7 +137,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     // Without an aggregate of charge factor we shouldn't see the link "Change details" only "View details"
     cy.get('[data-test="charge-version-0-charge-reference-link-0"]').should('contain.text', 'View details')
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', 'SROC Charge Purpose 01')
-    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', '1 April 2024 to 31 March 2025')
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-issues-0"]').should('contain.text', 'Unable to match return')
     cy.get(':nth-child(2) > .float-right > .govuk-tag').should('contain.text', 'review')

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-14.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-14.cy.js
@@ -54,8 +54,8 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // Choose 2021 to 2022 and continue
-    cy.get('label.govuk-radios__label').contains('2022 to 2023').click()
+    // choose top option and continue
+    cy.get('#year').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run
@@ -81,7 +81,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('[data-test="meta-data-region"]').should('contain.text', 'Test Region')
     cy.get('[data-test="meta-data-type"]').should('contain.text', 'Two-part tariff')
     cy.get('[data-test="meta-data-scheme"]').should('contain.text', 'Current')
-    cy.get('[data-test="meta-data-year"]').should('contain.text', '2022 to 2023')
+    cy.get('[data-test="meta-data-year"]').should('contain.text', '2024 to 2025')
 
     // Review licences ~ Test it has the correct licence
     cy.get('[data-test="licence-1"]').should('contain.text', 'AT/TEST/01')
@@ -98,12 +98,12 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('[data-test="licence-holder"]').should('contain.text', 'Mr J J Testerson')
     cy.get('div > .govuk-tag').should('contain.text', 'ready')
     cy.get(':nth-child(1) > .govuk-grid-column-full > .govuk-caption-l').should('contain.text', 'Test Region two-part tariff')
-    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2022 to 31 March 2023')
+    cy.get('.govuk-list > li > .govuk-link').should('contain.text', '1 April 2024 to 31 March 2025')
 
     // Review Licence AT/TEST/01 ~ Check the matched return details
     cy.get('.govuk-table__caption').should('contain.text', 'Matched returns')
     cy.get('[data-test="matched-return-action-0"] > .govuk-link').should('contain.text', '10021668')
-    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2022 to 21 March 2023')
+    cy.get('[data-test="matched-return-action-0"] > div').should('contain.text', '1 April 2024 to 21 March 2025')
     cy.get('[data-test="matched-return-action-0"] > :nth-child(3)').should('contain.text', '1 April to 31 March')
     cy.get('[data-test="matched-return-summary-0"] > div').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="matched-return-status-0"] > .govuk-tag').should('contain.text', 'completed')
@@ -124,7 +124,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('[data-test="charge-version-0-charge-reference-link-0"]').should('contain.text', 'Change details')
     //  Charge element 1
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', 'SROC Charge Purpose 01')
-    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', '1 April 2022 to 31 October 2022')
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', '1 April 2024 to 31 October 2024')
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-0"]').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-issues-0"]').should('contain.text', '')
     cy.get(':nth-child(2) > .float-right > .govuk-tag').should('contain.text', 'ready')
@@ -133,7 +133,7 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-return-volumes-0"]').should('contain.text', '50 ML (10021668)')
     // Charge element 2
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-1"]').should('contain.text', 'SROC Charge Purpose 02')
-    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-1"]').should('contain.text', '1 November 2022 to 31 March 2023')
+    cy.get('[data-test="charge-version-0-charge-reference-0-element-description-1"]').should('contain.text', '1 November 2024 to 31 March 2025')
     cy.get('[data-test="charge-version-0-charge-reference-0-element-description-1"]').should('contain.text', 'General Farming & Domestic')
     cy.get('[data-test="charge-version-0-charge-reference-0-charge-element-issues-1"]').should('contain.text', '')
     cy.get(':nth-child(2) > .float-right > .govuk-tag').should('contain.text', 'ready')

--- a/cypress/fixtures/review-scenario-01.json
+++ b/cypress/fixtures/review-scenario-01.json
@@ -85,7 +85,7 @@
   ],
   "returnLogs": [
     {
-      "id": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "id": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "returnReference": "10021668",
       "licenceRef": "AT/TEST/01",
       "metadata": {
@@ -114,10 +114,10 @@
           "periodEndMonth": "10"
         }
       },
-      "startDate": "2022-04-01",
-      "endDate": "2023-03-21",
-      "receivedDate": "2023-03-01",
-      "dueDate": "2023-04-28",
+      "startDate": "2024-04-01",
+      "endDate": "2025-03-21",
+      "receivedDate": "2025-03-01",
+      "dueDate": "2025-04-28",
       "status": "completed",
       "underQuery": false
     }
@@ -125,7 +125,7 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }
@@ -134,57 +134,57 @@
     {
       "id": "89966f6f-bc62-40bf-97a5-3c7bfeeb2a3b",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-04-01",
-      "endDate": "2022-04-30",
+      "startDate": "2024-04-01",
+      "endDate": "2024-04-30",
       "quantity": "4000"
     },
     {
       "id": "7e503eb2-323e-4b17-9d0c-2c8ad1ebe575",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-05-01",
-      "endDate": "2022-05-31",
+      "startDate": "2024-05-01",
+      "endDate": "2024-05-31",
       "quantity": "4000"
     },
     {
       "id": "0438b460-52d6-40b5-9dfd-963a63ada23d",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-06-01",
-      "endDate": "2022-06-30",
+      "startDate": "2024-06-01",
+      "endDate": "2024-06-30",
       "quantity": "4000"
     },
     {
       "id": "e6a493df-241a-47de-ae62-b976d2ff9941",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-07-01",
-      "endDate": "2022-07-31",
+      "startDate": "2024-07-01",
+      "endDate": "2024-07-31",
       "quantity": "4000"
     },
     {
       "id": "fb9d239e-0428-4ca4-a7fd-49ae9ac1d6c7",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-08-01",
-      "endDate": "2022-08-31",
+      "startDate": "2024-08-01",
+      "endDate": "2024-08-31",
       "quantity": "4000"
     },
     {
       "id": "85216196-0191-4fa3-9d3d-c1dba7d167ab",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-09-01",
-      "endDate": "2022-09-30",
+      "startDate": "2024-09-01",
+      "endDate": "2024-09-30",
       "quantity": "4000"
     },
     {
       "id": "802c7690-0006-4267-af3e-7dcf29dda03c",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-10-01",
-      "endDate": "2022-10-31",
+      "startDate": "2024-10-01",
+      "endDate": "2024-10-31",
       "quantity": "4000"
     },
     {
       "id": "30854030-2b23-4a3a-b4e4-1a30d3d6d260",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2023-03-01",
-      "endDate": "2023-03-31",
+      "startDate": "2025-03-01",
+      "endDate": "2025-03-31",
       "quantity": "4000"
     }
   ]

--- a/cypress/fixtures/review-scenario-02.json
+++ b/cypress/fixtures/review-scenario-02.json
@@ -117,7 +117,7 @@
   ],
   "returnLogs": [
     {
-      "id": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "id": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "returnReference": "10021668",
       "licenceRef": "AT/TEST/01",
       "metadata": {
@@ -146,10 +146,10 @@
           "periodEndMonth": "10"
         }
       },
-      "startDate": "2022-04-01",
-      "endDate": "2023-03-21",
-      "receivedDate": "2023-03-01",
-      "dueDate": "2023-04-28",
+      "startDate": "2024-04-01",
+      "endDate": "2025-03-21",
+      "receivedDate": "2025-03-01",
+      "dueDate": "2025-04-28",
       "status": "completed",
       "underQuery": false
     },
@@ -194,7 +194,7 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     },
@@ -209,57 +209,57 @@
     {
       "id": "89966f6f-bc62-40bf-97a5-3c7bfeeb2a3b",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-04-01",
-      "endDate": "2022-04-30",
+      "startDate": "2024-04-01",
+      "endDate": "2024-04-30",
       "quantity": "4000"
     },
     {
       "id": "7e503eb2-323e-4b17-9d0c-2c8ad1ebe575",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-05-01",
-      "endDate": "2022-05-31",
+      "startDate": "2024-05-01",
+      "endDate": "2024-05-31",
       "quantity": "4000"
     },
     {
       "id": "0438b460-52d6-40b5-9dfd-963a63ada23d",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-06-01",
-      "endDate": "2022-06-30",
+      "startDate": "2024-06-01",
+      "endDate": "2024-06-30",
       "quantity": "4000"
     },
     {
       "id": "e6a493df-241a-47de-ae62-b976d2ff9941",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-07-01",
-      "endDate": "2022-07-31",
+      "startDate": "2024-07-01",
+      "endDate": "2024-07-31",
       "quantity": "4000"
     },
     {
       "id": "fb9d239e-0428-4ca4-a7fd-49ae9ac1d6c7",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-08-01",
-      "endDate": "2022-08-31",
+      "startDate": "2024-08-01",
+      "endDate": "2024-08-31",
       "quantity": "4000"
     },
     {
       "id": "85216196-0191-4fa3-9d3d-c1dba7d167ab",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-09-01",
-      "endDate": "2022-09-30",
+      "startDate": "2024-09-01",
+      "endDate": "2024-09-30",
       "quantity": "4000"
     },
     {
       "id": "802c7690-0006-4267-af3e-7dcf29dda03c",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-10-01",
-      "endDate": "2022-10-31",
+      "startDate": "2024-10-01",
+      "endDate": "2024-10-31",
       "quantity": "4000"
     },
     {
       "id": "30854030-2b23-4a3a-b4e4-1a30d3d6d260",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2023-03-01",
-      "endDate": "2023-03-31",
+      "startDate": "2025-03-01",
+      "endDate": "2025-03-31",
       "quantity": "4000"
     },
     {

--- a/cypress/fixtures/review-scenario-03.json
+++ b/cypress/fixtures/review-scenario-03.json
@@ -85,7 +85,7 @@
   ],
   "returnLogs": [
     {
-      "id": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "id": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "returnReference": "10021668",
       "licenceRef": "AT/TEST/01",
       "metadata": {
@@ -114,10 +114,10 @@
           "periodEndMonth": "10"
         }
       },
-      "startDate": "2022-04-01",
-      "endDate": "2023-03-21",
-      "receivedDate": "2023-05-01",
-      "dueDate": "2023-04-28",
+      "startDate": "2024-04-01",
+      "endDate": "2025-03-21",
+      "receivedDate": "2025-05-01",
+      "dueDate": "2025-04-28",
       "status": "completed",
       "underQuery": false
     }
@@ -125,7 +125,7 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }
@@ -134,57 +134,57 @@
     {
       "id": "89966f6f-bc62-40bf-97a5-3c7bfeeb2a3b",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-04-01",
-      "endDate": "2022-04-30",
+      "startDate": "2024-04-01",
+      "endDate": "2024-04-30",
       "quantity": "4000"
     },
     {
       "id": "7e503eb2-323e-4b17-9d0c-2c8ad1ebe575",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-05-01",
-      "endDate": "2022-05-31",
+      "startDate": "2024-05-01",
+      "endDate": "2024-05-31",
       "quantity": "4000"
     },
     {
       "id": "0438b460-52d6-40b5-9dfd-963a63ada23d",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-06-01",
-      "endDate": "2022-06-30",
+      "startDate": "2024-06-01",
+      "endDate": "2024-06-30",
       "quantity": "4000"
     },
     {
       "id": "e6a493df-241a-47de-ae62-b976d2ff9941",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-07-01",
-      "endDate": "2022-07-31",
+      "startDate": "2024-07-01",
+      "endDate": "2024-07-31",
       "quantity": "4000"
     },
     {
       "id": "fb9d239e-0428-4ca4-a7fd-49ae9ac1d6c7",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-08-01",
-      "endDate": "2022-08-31",
+      "startDate": "2024-08-01",
+      "endDate": "2024-08-31",
       "quantity": "4000"
     },
     {
       "id": "85216196-0191-4fa3-9d3d-c1dba7d167ab",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-09-01",
-      "endDate": "2022-09-30",
+      "startDate": "2024-09-01",
+      "endDate": "2024-09-30",
       "quantity": "4000"
     },
     {
       "id": "802c7690-0006-4267-af3e-7dcf29dda03c",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-10-01",
-      "endDate": "2022-10-31",
+      "startDate": "2024-10-01",
+      "endDate": "2024-10-31",
       "quantity": "4000"
     },
     {
       "id": "30854030-2b23-4a3a-b4e4-1a30d3d6d260",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2023-03-01",
-      "endDate": "2023-03-31",
+      "startDate": "2025-03-01",
+      "endDate": "2025-03-31",
       "quantity": "4000"
     }
   ]

--- a/cypress/fixtures/review-scenario-04.json
+++ b/cypress/fixtures/review-scenario-04.json
@@ -85,7 +85,7 @@
   ],
   "returnLogs": [
     {
-      "id": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "id": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "returnReference": "10021668",
       "licenceRef": "AT/TEST/01",
       "metadata": {
@@ -114,10 +114,10 @@
           "periodEndMonth": "10"
         }
       },
-      "startDate": "2022-04-01",
-      "endDate": "2023-03-21",
-      "receivedDate": "2023-03-01",
-      "dueDate": "2023-04-28",
+      "startDate": "2024-04-01",
+      "endDate": "2025-03-21",
+      "receivedDate": "2025-03-01",
+      "dueDate": "2025-04-28",
       "status": "completed",
       "underQuery": false
     }
@@ -125,7 +125,7 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }
@@ -134,57 +134,57 @@
     {
       "id": "89966f6f-bc62-40bf-97a5-3c7bfeeb2a3b",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-04-01",
-      "endDate": "2022-04-30",
+      "startDate": "2024-04-01",
+      "endDate": "2024-04-30",
       "quantity": "4000"
     },
     {
       "id": "7e503eb2-323e-4b17-9d0c-2c8ad1ebe575",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-05-01",
-      "endDate": "2022-05-31",
+      "startDate": "2024-05-01",
+      "endDate": "2024-05-31",
       "quantity": "4000"
     },
     {
       "id": "0438b460-52d6-40b5-9dfd-963a63ada23d",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-06-01",
-      "endDate": "2022-06-30",
+      "startDate": "2024-06-01",
+      "endDate": "2024-06-30",
       "quantity": "4000"
     },
     {
       "id": "e6a493df-241a-47de-ae62-b976d2ff9941",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-07-01",
-      "endDate": "2022-07-31",
+      "startDate": "2024-07-01",
+      "endDate": "2024-07-31",
       "quantity": "4000"
     },
     {
       "id": "fb9d239e-0428-4ca4-a7fd-49ae9ac1d6c7",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-08-01",
-      "endDate": "2022-08-31",
+      "startDate": "2024-08-01",
+      "endDate": "2024-08-31",
       "quantity": "4000"
     },
     {
       "id": "85216196-0191-4fa3-9d3d-c1dba7d167ab",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-09-01",
-      "endDate": "2022-09-30",
+      "startDate": "2024-09-01",
+      "endDate": "2024-09-30",
       "quantity": "4000"
     },
     {
       "id": "802c7690-0006-4267-af3e-7dcf29dda03c",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-10-01",
-      "endDate": "2022-10-31",
+      "startDate": "2024-10-01",
+      "endDate": "2024-10-31",
       "quantity": "4000"
     },
     {
       "id": "30854030-2b23-4a3a-b4e4-1a30d3d6d260",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2023-03-01",
-      "endDate": "2023-03-31",
+      "startDate": "2025-03-01",
+      "endDate": "2025-03-31",
       "quantity": "4000"
     }
   ]

--- a/cypress/fixtures/review-scenario-05.json
+++ b/cypress/fixtures/review-scenario-05.json
@@ -85,7 +85,7 @@
   ],
   "returnLogs": [
     {
-      "id": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "id": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "returnReference": "10021668",
       "licenceRef": "AT/TEST/01",
       "metadata": {
@@ -114,10 +114,10 @@
           "periodEndMonth": "10"
         }
       },
-      "startDate": "2022-04-01",
-      "endDate": "2023-03-21",
-      "receivedDate": "2023-03-01",
-      "dueDate": "2023-04-28",
+      "startDate": "2024-04-01",
+      "endDate": "2025-03-21",
+      "receivedDate": "2025-03-01",
+      "dueDate": "2025-04-28",
       "status": "completed",
       "underQuery": false
     }
@@ -125,7 +125,7 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }
@@ -134,57 +134,57 @@
     {
       "id": "89966f6f-bc62-40bf-97a5-3c7bfeeb2a3b",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-03-27",
-      "endDate": "2022-04-30",
+      "startDate": "2024-03-27",
+      "endDate": "2024-04-30",
       "quantity": "4000"
     },
     {
       "id": "7e503eb2-323e-4b17-9d0c-2c8ad1ebe575",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-05-01",
-      "endDate": "2022-05-31",
+      "startDate": "2024-05-01",
+      "endDate": "2024-05-31",
       "quantity": "4000"
     },
     {
       "id": "0438b460-52d6-40b5-9dfd-963a63ada23d",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-06-01",
-      "endDate": "2022-06-30",
+      "startDate": "2024-06-01",
+      "endDate": "2024-06-30",
       "quantity": "4000"
     },
     {
       "id": "e6a493df-241a-47de-ae62-b976d2ff9941",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-07-01",
-      "endDate": "2022-07-31",
+      "startDate": "2024-07-01",
+      "endDate": "2024-07-31",
       "quantity": "4000"
     },
     {
       "id": "fb9d239e-0428-4ca4-a7fd-49ae9ac1d6c7",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-08-01",
-      "endDate": "2022-08-31",
+      "startDate": "2024-08-01",
+      "endDate": "2024-08-31",
       "quantity": "4000"
     },
     {
       "id": "85216196-0191-4fa3-9d3d-c1dba7d167ab",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-09-01",
-      "endDate": "2022-09-30",
+      "startDate": "2024-09-01",
+      "endDate": "2024-09-30",
       "quantity": "4000"
     },
     {
       "id": "802c7690-0006-4267-af3e-7dcf29dda03c",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-10-01",
-      "endDate": "2022-10-31",
+      "startDate": "2024-10-01",
+      "endDate": "2024-10-31",
       "quantity": "4000"
     },
     {
       "id": "30854030-2b23-4a3a-b4e4-1a30d3d6d260",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2023-03-01",
-      "endDate": "2023-03-31",
+      "startDate": "2025-03-01",
+      "endDate": "2025-03-31",
       "quantity": "4000"
     }
   ]

--- a/cypress/fixtures/review-scenario-06.json
+++ b/cypress/fixtures/review-scenario-06.json
@@ -85,7 +85,7 @@
   ],
   "returnLogs": [
     {
-      "id": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "id": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "returnReference": "10021668",
       "licenceRef": "AT/TEST/01",
       "metadata": {
@@ -114,10 +114,10 @@
           "periodEndMonth": "10"
         }
       },
-      "startDate": "2022-04-01",
-      "endDate": "2023-03-21",
-      "receivedDate": "2023-03-01",
-      "dueDate": "2023-04-28",
+      "startDate": "2024-04-01",
+      "endDate": "2025-03-21",
+      "receivedDate": "2025-03-01",
+      "dueDate": "2025-04-28",
       "status": "completed",
       "underQuery": true
     }
@@ -125,7 +125,7 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }
@@ -134,57 +134,57 @@
     {
       "id": "89966f6f-bc62-40bf-97a5-3c7bfeeb2a3b",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-04-01",
-      "endDate": "2022-04-30",
+      "startDate": "2024-04-01",
+      "endDate": "2024-04-30",
       "quantity": "4000"
     },
     {
       "id": "7e503eb2-323e-4b17-9d0c-2c8ad1ebe575",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-05-01",
-      "endDate": "2022-05-31",
+      "startDate": "2024-05-01",
+      "endDate": "2024-05-31",
       "quantity": "4000"
     },
     {
       "id": "0438b460-52d6-40b5-9dfd-963a63ada23d",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-06-01",
-      "endDate": "2022-06-30",
+      "startDate": "2024-06-01",
+      "endDate": "2024-06-30",
       "quantity": "4000"
     },
     {
       "id": "e6a493df-241a-47de-ae62-b976d2ff9941",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-07-01",
-      "endDate": "2022-07-31",
+      "startDate": "2024-07-01",
+      "endDate": "2024-07-31",
       "quantity": "4000"
     },
     {
       "id": "fb9d239e-0428-4ca4-a7fd-49ae9ac1d6c7",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-08-01",
-      "endDate": "2022-08-31",
+      "startDate": "2024-08-01",
+      "endDate": "2024-08-31",
       "quantity": "4000"
     },
     {
       "id": "85216196-0191-4fa3-9d3d-c1dba7d167ab",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-09-01",
-      "endDate": "2022-09-30",
+      "startDate": "2024-09-01",
+      "endDate": "2024-09-30",
       "quantity": "4000"
     },
     {
       "id": "802c7690-0006-4267-af3e-7dcf29dda03c",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-10-01",
-      "endDate": "2022-10-31",
+      "startDate": "2024-10-01",
+      "endDate": "2024-10-31",
       "quantity": "4000"
     },
     {
       "id": "30854030-2b23-4a3a-b4e4-1a30d3d6d260",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2023-03-01",
-      "endDate": "2023-03-31",
+      "startDate": "2025-03-01",
+      "endDate": "2025-03-31",
       "quantity": "4000"
     }
   ]

--- a/cypress/fixtures/review-scenario-07.json
+++ b/cypress/fixtures/review-scenario-07.json
@@ -85,7 +85,7 @@
   ],
   "returnLogs": [
     {
-      "id": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "id": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "returnReference": "10021668",
       "licenceRef": "AT/TEST/01",
       "metadata": {
@@ -114,10 +114,10 @@
           "periodEndMonth": "10"
         }
       },
-      "startDate": "2022-04-01",
-      "endDate": "2023-03-21",
-      "receivedDate": "2023-03-01",
-      "dueDate": "2023-04-28",
+      "startDate": "2024-04-01",
+      "endDate": "2025-03-21",
+      "receivedDate": "2025-03-01",
+      "dueDate": "2025-04-28",
       "status": "received",
       "underQuery": false
     }
@@ -125,7 +125,7 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }
@@ -134,57 +134,57 @@
     {
       "id": "89966f6f-bc62-40bf-97a5-3c7bfeeb2a3b",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-04-01",
-      "endDate": "2022-04-30",
+      "startDate": "2024-04-01",
+      "endDate": "2024-04-30",
       "quantity": "4000"
     },
     {
       "id": "7e503eb2-323e-4b17-9d0c-2c8ad1ebe575",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-05-01",
-      "endDate": "2022-05-31",
+      "startDate": "2024-05-01",
+      "endDate": "2024-05-31",
       "quantity": "4000"
     },
     {
       "id": "0438b460-52d6-40b5-9dfd-963a63ada23d",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-06-01",
-      "endDate": "2022-06-30",
+      "startDate": "2024-06-01",
+      "endDate": "2024-06-30",
       "quantity": "4000"
     },
     {
       "id": "e6a493df-241a-47de-ae62-b976d2ff9941",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-07-01",
-      "endDate": "2022-07-31",
+      "startDate": "2024-07-01",
+      "endDate": "2024-07-31",
       "quantity": "4000"
     },
     {
       "id": "fb9d239e-0428-4ca4-a7fd-49ae9ac1d6c7",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-08-01",
-      "endDate": "2022-08-31",
+      "startDate": "2024-08-01",
+      "endDate": "2024-08-31",
       "quantity": "4000"
     },
     {
       "id": "85216196-0191-4fa3-9d3d-c1dba7d167ab",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-09-01",
-      "endDate": "2022-09-30",
+      "startDate": "2024-09-01",
+      "endDate": "2024-09-30",
       "quantity": "4000"
     },
     {
       "id": "802c7690-0006-4267-af3e-7dcf29dda03c",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-10-01",
-      "endDate": "2022-10-31",
+      "startDate": "2024-10-01",
+      "endDate": "2024-10-31",
       "quantity": "4000"
     },
     {
       "id": "30854030-2b23-4a3a-b4e4-1a30d3d6d260",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2023-03-01",
-      "endDate": "2023-03-31",
+      "startDate": "2025-03-01",
+      "endDate": "2025-03-31",
       "quantity": "4000"
     }
   ]

--- a/cypress/fixtures/review-scenario-08.json
+++ b/cypress/fixtures/review-scenario-08.json
@@ -85,7 +85,7 @@
   ],
   "returnLogs": [
     {
-      "id": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "id": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "returnReference": "10021668",
       "licenceRef": "AT/TEST/01",
       "metadata": {
@@ -114,10 +114,10 @@
           "periodEndMonth": "10"
         }
       },
-      "startDate": "2022-04-01",
-      "endDate": "2023-03-21",
-      "receivedDate": "2023-03-01",
-      "dueDate": "2023-04-28",
+      "startDate": "2024-04-01",
+      "endDate": "2025-03-21",
+      "receivedDate": "2025-03-01",
+      "dueDate": "2025-04-28",
       "status": "completed",
       "underQuery": false
     }
@@ -125,7 +125,7 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": true,
       "current": true
     }

--- a/cypress/fixtures/review-scenario-09.json
+++ b/cypress/fixtures/review-scenario-09.json
@@ -143,7 +143,7 @@
   ],
   "returnLogs": [
     {
-      "id": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "id": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "returnReference": "10021668",
       "licenceRef": "AT/TEST/01",
       "metadata": {
@@ -172,15 +172,15 @@
           "periodEndMonth": "10"
         }
       },
-      "startDate": "2022-04-01",
-      "endDate": "2023-03-21",
-      "receivedDate": "2023-03-01",
-      "dueDate": "2023-04-28",
+      "startDate": "2024-04-01",
+      "endDate": "2025-03-21",
+      "receivedDate": "2025-03-01",
+      "dueDate": "2025-04-28",
       "status": "due",
       "underQuery": false
     },
     {
-      "id": "v2:1:AT/TEST/01:10021668:2022-10-01:2023-03-31",
+      "id": "v2:1:AT/TEST/01:10021668:2024-10-01:2025-03-31",
       "returnReference": "10021668",
       "licenceRef": "AT/TEST/01",
       "metadata": {
@@ -209,10 +209,10 @@
           "periodEndMonth": "10"
         }
       },
-      "startDate": "2022-10-01",
-      "endDate": "2023-03-31",
-      "receivedDate": "2023-03-01",
-      "dueDate": "2023-04-28",
+      "startDate": "2024-10-01",
+      "endDate": "2025-03-31",
+      "receivedDate": "2025-03-01",
+      "dueDate": "2025-04-28",
       "status": "due",
       "underQuery": false
     }

--- a/cypress/fixtures/review-scenario-10.json
+++ b/cypress/fixtures/review-scenario-10.json
@@ -85,7 +85,7 @@
   ],
   "returnLogs": [
     {
-      "id": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "id": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "returnReference": "10021668",
       "licenceRef": "AT/TEST/01",
       "metadata": {
@@ -114,10 +114,10 @@
           "periodEndMonth": "10"
         }
       },
-      "startDate": "2022-04-01",
-      "endDate": "2023-03-21",
-      "receivedDate": "2023-03-01",
-      "dueDate": "2023-04-28",
+      "startDate": "2024-04-01",
+      "endDate": "2025-03-21",
+      "receivedDate": "2025-03-01",
+      "dueDate": "2025-04-28",
       "status": "completed",
       "underQuery": false
     }
@@ -125,7 +125,7 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }
@@ -134,57 +134,57 @@
     {
       "id": "89966f6f-bc62-40bf-97a5-3c7bfeeb2a3b",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-04-01",
-      "endDate": "2022-04-30",
+      "startDate": "2024-04-01",
+      "endDate": "2024-04-30",
       "quantity": "4000"
     },
     {
       "id": "7e503eb2-323e-4b17-9d0c-2c8ad1ebe575",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-05-01",
-      "endDate": "2022-05-31",
+      "startDate": "2024-05-01",
+      "endDate": "2024-05-31",
       "quantity": "4000"
     },
     {
       "id": "0438b460-52d6-40b5-9dfd-963a63ada23d",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-06-01",
-      "endDate": "2022-06-30",
+      "startDate": "2024-06-01",
+      "endDate": "2024-06-30",
       "quantity": "4000"
     },
     {
       "id": "e6a493df-241a-47de-ae62-b976d2ff9941",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-07-01",
-      "endDate": "2022-07-31",
+      "startDate": "2024-07-01",
+      "endDate": "2024-07-31",
       "quantity": "4000"
     },
     {
       "id": "fb9d239e-0428-4ca4-a7fd-49ae9ac1d6c7",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-08-01",
-      "endDate": "2022-08-31",
+      "startDate": "2024-08-01",
+      "endDate": "2024-08-31",
       "quantity": "4000"
     },
     {
       "id": "85216196-0191-4fa3-9d3d-c1dba7d167ab",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-09-01",
-      "endDate": "2022-09-30",
+      "startDate": "2024-09-01",
+      "endDate": "2024-09-30",
       "quantity": "4000"
     },
     {
       "id": "802c7690-0006-4267-af3e-7dcf29dda03c",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-10-01",
-      "endDate": "2022-10-31",
+      "startDate": "2024-10-01",
+      "endDate": "2024-10-31",
       "quantity": "4000"
     },
     {
       "id": "30854030-2b23-4a3a-b4e4-1a30d3d6d260",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2023-03-01",
-      "endDate": "2023-03-31",
+      "startDate": "2025-03-01",
+      "endDate": "2025-03-31",
       "quantity": "4000"
     }
   ]

--- a/cypress/fixtures/review-scenario-11.json
+++ b/cypress/fixtures/review-scenario-11.json
@@ -117,7 +117,7 @@
   ],
   "returnLogs": [
     {
-      "id": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "id": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "returnReference": "10021668",
       "licenceRef": "AT/TEST/01",
       "metadata": {
@@ -146,15 +146,15 @@
           "periodEndMonth": "10"
         }
       },
-      "startDate": "2022-04-01",
-      "endDate": "2023-03-21",
-      "receivedDate": "2023-03-01",
-      "dueDate": "2023-04-28",
+      "startDate": "2024-04-01",
+      "endDate": "2025-03-21",
+      "receivedDate": "2025-03-01",
+      "dueDate": "2025-04-28",
       "status": "completed",
       "underQuery": false
     },
     {
-      "id": "v1:1:AT/TEST/01:10021669:2022-05-01:2023-03-31",
+      "id": "v1:1:AT/TEST/01:10021669:2024-05-01:2025-03-31",
       "returnReference": "10021669",
       "licenceRef": "AT/TEST/01",
       "metadata": {
@@ -183,10 +183,10 @@
           "periodEndMonth": "10"
         }
       },
-      "startDate": "2022-05-01",
-      "endDate": "2023-03-21",
-      "receivedDate": "2023-03-01",
-      "dueDate": "2023-04-28",
+      "startDate": "2024-05-01",
+      "endDate": "2025-03-21",
+      "receivedDate": "2025-03-01",
+      "dueDate": "2025-04-28",
       "status": "completed",
       "underQuery": false
     }
@@ -194,13 +194,13 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     },
     {
       "id": "615251b9-eac9-40db-9212-ee4b7260a3a9",
-      "returnLogId": "v1:1:AT/TEST/01:10021669:2022-05-01:2023-03-31",
+      "returnLogId": "v1:1:AT/TEST/01:10021669:2024-05-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }
@@ -209,120 +209,120 @@
     {
       "id": "89966f6f-bc62-40bf-97a5-3c7bfeeb2a3b",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-04-01",
-      "endDate": "2022-04-30",
+      "startDate": "2024-04-01",
+      "endDate": "2024-04-30",
       "quantity": "10000"
     },
     {
       "id": "7e503eb2-323e-4b17-9d0c-2c8ad1ebe575",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-05-01",
-      "endDate": "2022-05-31",
+      "startDate": "2024-05-01",
+      "endDate": "2024-05-31",
       "quantity": "4000"
     },
     {
       "id": "0438b460-52d6-40b5-9dfd-963a63ada23d",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-06-01",
-      "endDate": "2022-06-30",
+      "startDate": "2024-06-01",
+      "endDate": "2024-06-30",
       "quantity": "4000"
     },
     {
       "id": "e6a493df-241a-47de-ae62-b976d2ff9941",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-07-01",
-      "endDate": "2022-07-31",
+      "startDate": "2024-07-01",
+      "endDate": "2024-07-31",
       "quantity": "4000"
     },
     {
       "id": "fb9d239e-0428-4ca4-a7fd-49ae9ac1d6c7",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-08-01",
-      "endDate": "2022-08-31",
+      "startDate": "2024-08-01",
+      "endDate": "2024-08-31",
       "quantity": "4000"
     },
     {
       "id": "85216196-0191-4fa3-9d3d-c1dba7d167ab",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-09-01",
-      "endDate": "2022-09-30",
+      "startDate": "2024-09-01",
+      "endDate": "2024-09-30",
       "quantity": "4000"
     },
     {
       "id": "802c7690-0006-4267-af3e-7dcf29dda03c",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-10-01",
-      "endDate": "2022-10-31",
+      "startDate": "2024-10-01",
+      "endDate": "2024-10-31",
       "quantity": "4000"
     },
     {
       "id": "30854030-2b23-4a3a-b4e4-1a30d3d6d260",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2023-03-01",
-      "endDate": "2023-03-31",
+      "startDate": "2025-03-01",
+      "endDate": "2025-03-31",
       "quantity": "4000"
     },
     {
       "id": "171f3b9a-5c82-4fed-983e-5e1b5c5891d8",
       "returnSubmissionId": "615251b9-eac9-40db-9212-ee4b7260a3a9",
-      "startDate": "2022-04-01",
-      "endDate": "2022-04-30",
+      "startDate": "2024-04-01",
+      "endDate": "2024-04-30",
       "quantity": "4000"
     },
     {
       "id": "309d8134-67a7-4ada-adec-73b8365e0979",
       "returnSubmissionId": "615251b9-eac9-40db-9212-ee4b7260a3a9",
-      "startDate": "2022-05-01",
-      "endDate": "2022-05-31",
+      "startDate": "2024-05-01",
+      "endDate": "2024-05-31",
       "quantity": "4000"
     },
     {
       "id": "ea7a351e-961b-4438-b2b8-b25fed91bc91",
       "returnSubmissionId": "615251b9-eac9-40db-9212-ee4b7260a3a9",
-      "startDate": "2022-06-01",
-      "endDate": "2022-06-30",
+      "startDate": "2024-06-01",
+      "endDate": "2024-06-30",
       "quantity": "4000"
     },
     {
       "id": "3936f4a8-a830-43a7-8d7c-a069fa4f1e33",
       "returnSubmissionId": "615251b9-eac9-40db-9212-ee4b7260a3a9",
-      "startDate": "2022-07-01",
-      "endDate": "2022-07-31",
+      "startDate": "2024-07-01",
+      "endDate": "2024-07-31",
       "quantity": "4000"
     },
     {
       "id": "14ffd710-cc22-486b-8cc0-e81dd13dda9f",
       "returnSubmissionId": "615251b9-eac9-40db-9212-ee4b7260a3a9",
-      "startDate": "2022-08-01",
-      "endDate": "2022-08-31",
+      "startDate": "2024-08-01",
+      "endDate": "2024-08-31",
       "quantity": "4000"
     },
     {
       "id": "64397807-92dd-45c4-8212-01e2f9f3d5db",
       "returnSubmissionId": "615251b9-eac9-40db-9212-ee4b7260a3a9",
-      "startDate": "2022-09-01",
-      "endDate": "2022-09-30",
+      "startDate": "2024-09-01",
+      "endDate": "2024-09-30",
       "quantity": "4000"
     },
     {
       "id": "b18a757d-95bf-4c4a-b71d-c2cb05d09383",
       "returnSubmissionId": "615251b9-eac9-40db-9212-ee4b7260a3a9",
-      "startDate": "2022-10-01",
-      "endDate": "2022-10-31",
+      "startDate": "2024-10-01",
+      "endDate": "2024-10-31",
       "quantity": "4000"
     },
     {
       "id": "f658175a-a0a1-4f01-8104-d63bb19c5f62",
       "returnSubmissionId": "615251b9-eac9-40db-9212-ee4b7260a3a9",
-      "startDate": "2022-11-01",
-      "endDate": "2022-11-30",
+      "startDate": "2024-11-01",
+      "endDate": "2024-11-30",
       "quantity": "4000"
     },
     {
       "id": "aa044a57-133d-4e32-8310-04049975bdfb",
       "returnSubmissionId": "615251b9-eac9-40db-9212-ee4b7260a3a9",
-      "startDate": "2023-03-01",
-      "endDate": "2023-03-31",
+      "startDate": "2025-03-01",
+      "endDate": "2025-03-31",
       "quantity": "4000"
     }
   ]

--- a/cypress/fixtures/review-scenario-12.json
+++ b/cypress/fixtures/review-scenario-12.json
@@ -144,7 +144,7 @@
   ],
   "returnLogs": [
     {
-      "id": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "id": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "returnReference": "10021668",
       "licenceRef": "AT/TEST/01",
       "metadata": {
@@ -173,10 +173,10 @@
           "periodEndMonth": "3"
         }
       },
-      "startDate": "2022-04-01",
-      "endDate": "2023-03-21",
-      "receivedDate": "2023-03-01",
-      "dueDate": "2023-04-28",
+      "startDate": "2024-04-01",
+      "endDate": "2025-03-21",
+      "receivedDate": "2025-03-01",
+      "dueDate": "2025-04-28",
       "status": "completed",
       "underQuery": false
     }
@@ -184,7 +184,7 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }
@@ -193,64 +193,64 @@
     {
       "id": "89966f6f-bc62-40bf-97a5-3c7bfeeb2a3b",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-04-01",
-      "endDate": "2022-04-30",
+      "startDate": "2024-04-01",
+      "endDate": "2024-04-30",
       "quantity": "4000"
     },
     {
       "id": "7e503eb2-323e-4b17-9d0c-2c8ad1ebe575",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-05-01",
-      "endDate": "2022-05-31",
+      "startDate": "2024-05-01",
+      "endDate": "2024-05-31",
       "quantity": "4000"
     },
     {
       "id": "0438b460-52d6-40b5-9dfd-963a63ada23d",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-06-01",
-      "endDate": "2022-06-30",
+      "startDate": "2024-06-01",
+      "endDate": "2024-06-30",
       "quantity": "4000"
     },
     {
       "id": "e6a493df-241a-47de-ae62-b976d2ff9941",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-07-01",
-      "endDate": "2022-07-31",
+      "startDate": "2024-07-01",
+      "endDate": "2024-07-31",
       "quantity": "4000"
     },
     {
       "id": "d2424aad-ba47-4a5e-bdc4-6570655f7807",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-08-01",
-      "endDate": "2022-08-31",
+      "startDate": "2024-08-01",
+      "endDate": "2024-08-31",
       "quantity": "2000"
     },
     {
       "id": "fb9d239e-0428-4ca4-a7fd-49ae9ac1d6c7",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-11-01",
-      "endDate": "2022-11-30",
+      "startDate": "2024-11-01",
+      "endDate": "2024-11-30",
       "quantity": "4000"
     },
     {
       "id": "85216196-0191-4fa3-9d3d-c1dba7d167ab",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-12-01",
-      "endDate": "2022-12-31",
+      "startDate": "2024-12-01",
+      "endDate": "2024-12-31",
       "quantity": "4000"
     },
     {
       "id": "802c7690-0006-4267-af3e-7dcf29dda03c",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2023-01-01",
-      "endDate": "2023-01-31",
+      "startDate": "2025-01-01",
+      "endDate": "2025-01-31",
       "quantity": "4000"
     },
     {
       "id": "30854030-2b23-4a3a-b4e4-1a30d3d6d260",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2023-03-01",
-      "endDate": "2023-03-31",
+      "startDate": "2025-03-01",
+      "endDate": "2025-03-31",
       "quantity": "2000"
     }
   ]

--- a/cypress/fixtures/review-scenario-13.json
+++ b/cypress/fixtures/review-scenario-13.json
@@ -85,7 +85,7 @@
   ],
   "returnLogs": [
     {
-      "id": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "id": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "returnReference": "10021668",
       "licenceRef": "AT/TEST/01",
       "metadata": {
@@ -114,10 +114,10 @@
           "periodEndMonth": "10"
         }
       },
-      "startDate": "2022-04-01",
-      "endDate": "2023-03-21",
-      "receivedDate": "2023-03-01",
-      "dueDate": "2023-04-28",
+      "startDate": "2024-04-01",
+      "endDate": "2025-03-21",
+      "receivedDate": "2025-03-01",
+      "dueDate": "2025-04-28",
       "status": "completed",
       "underQuery": false
     }
@@ -125,7 +125,7 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }
@@ -134,57 +134,57 @@
     {
       "id": "89966f6f-bc62-40bf-97a5-3c7bfeeb2a3b",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-04-01",
-      "endDate": "2022-04-30",
+      "startDate": "2024-04-01",
+      "endDate": "2024-04-30",
       "quantity": "4000"
     },
     {
       "id": "7e503eb2-323e-4b17-9d0c-2c8ad1ebe575",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-05-01",
-      "endDate": "2022-05-31",
+      "startDate": "2024-05-01",
+      "endDate": "2024-05-31",
       "quantity": "4000"
     },
     {
       "id": "0438b460-52d6-40b5-9dfd-963a63ada23d",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-06-01",
-      "endDate": "2022-06-30",
+      "startDate": "2024-06-01",
+      "endDate": "2024-06-30",
       "quantity": "4000"
     },
     {
       "id": "e6a493df-241a-47de-ae62-b976d2ff9941",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-07-01",
-      "endDate": "2022-07-31",
+      "startDate": "2024-07-01",
+      "endDate": "2024-07-31",
       "quantity": "4000"
     },
     {
       "id": "fb9d239e-0428-4ca4-a7fd-49ae9ac1d6c7",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-08-01",
-      "endDate": "2022-08-31",
+      "startDate": "2024-08-01",
+      "endDate": "2024-08-31",
       "quantity": "4000"
     },
     {
       "id": "85216196-0191-4fa3-9d3d-c1dba7d167ab",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-09-01",
-      "endDate": "2022-09-30",
+      "startDate": "2024-09-01",
+      "endDate": "2024-09-30",
       "quantity": "4000"
     },
     {
       "id": "802c7690-0006-4267-af3e-7dcf29dda03c",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-10-01",
-      "endDate": "2022-10-31",
+      "startDate": "2024-10-01",
+      "endDate": "2024-10-31",
       "quantity": "4000"
     },
     {
       "id": "30854030-2b23-4a3a-b4e4-1a30d3d6d260",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2023-03-01",
-      "endDate": "2023-03-31",
+      "startDate": "2025-03-01",
+      "endDate": "2025-03-31",
       "quantity": "4000"
     }
   ]

--- a/cypress/fixtures/review-scenario-14.json
+++ b/cypress/fixtures/review-scenario-14.json
@@ -117,7 +117,7 @@
   ],
   "returnLogs": [
     {
-      "id": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "id": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "returnReference": "10021668",
       "licenceRef": "AT/TEST/01",
       "metadata": {
@@ -146,10 +146,10 @@
           "periodEndMonth": "3"
         }
       },
-      "startDate": "2022-04-01",
-      "endDate": "2023-03-21",
-      "receivedDate": "2023-03-01",
-      "dueDate": "2023-04-28",
+      "startDate": "2024-04-01",
+      "endDate": "2025-03-21",
+      "receivedDate": "2025-03-01",
+      "dueDate": "2025-04-28",
       "status": "completed",
       "underQuery": false
     }
@@ -157,7 +157,7 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2022-04-01:2023-03-31",
+      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }
@@ -166,85 +166,85 @@
     {
       "id": "89966f6f-bc62-40bf-97a5-3c7bfeeb2a3b",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-04-01",
-      "endDate": "2022-04-30",
+      "startDate": "2024-04-01",
+      "endDate": "2024-04-30",
       "quantity": "4000"
     },
     {
       "id": "7e503eb2-323e-4b17-9d0c-2c8ad1ebe575",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-05-01",
-      "endDate": "2022-05-31",
+      "startDate": "2024-05-01",
+      "endDate": "2024-05-31",
       "quantity": "4000"
     },
     {
       "id": "0438b460-52d6-40b5-9dfd-963a63ada23d",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-06-01",
-      "endDate": "2022-06-30",
+      "startDate": "2024-06-01",
+      "endDate": "2024-06-30",
       "quantity": "4000"
     },
     {
       "id": "e6a493df-241a-47de-ae62-b976d2ff9941",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-07-01",
-      "endDate": "2022-07-31",
+      "startDate": "2024-07-01",
+      "endDate": "2024-07-31",
       "quantity": "4000"
     },
     {
       "id": "d2424aad-ba47-4a5e-bdc4-6570655f7807",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-08-01",
-      "endDate": "2022-08-31",
+      "startDate": "2024-08-01",
+      "endDate": "2024-08-31",
       "quantity": "4000"
     },
     {
       "id": "5a3629f5-d6ee-4234-bc30-0ecae82e9e1e",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-09-01",
-      "endDate": "2022-09-30",
+      "startDate": "2024-09-01",
+      "endDate": "2024-09-30",
       "quantity": "5000"
     },
     {
       "id": "6c4aca73-8c2d-4219-a264-06f0023ccadf",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-10-01",
-      "endDate": "2022-10-31",
+      "startDate": "2024-10-01",
+      "endDate": "2024-10-31",
       "quantity": "5000"
     },
     {
       "id": "fb9d239e-0428-4ca4-a7fd-49ae9ac1d6c7",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-11-01",
-      "endDate": "2022-11-30",
+      "startDate": "2024-11-01",
+      "endDate": "2024-11-30",
       "quantity": "4000"
     },
     {
       "id": "85216196-0191-4fa3-9d3d-c1dba7d167ab",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2022-12-01",
-      "endDate": "2022-12-31",
+      "startDate": "2024-12-01",
+      "endDate": "2024-12-31",
       "quantity": "4000"
     },
     {
       "id": "802c7690-0006-4267-af3e-7dcf29dda03c",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2023-01-01",
-      "endDate": "2023-01-31",
+      "startDate": "2025-01-01",
+      "endDate": "2025-01-31",
       "quantity": "4000"
     },
     {
       "id": "119df799-10e9-4964-bc8e-41415edf1c94",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2023-02-01",
-      "endDate": "2023-02-28",
+      "startDate": "2025-02-01",
+      "endDate": "2025-02-28",
       "quantity": "4000"
     },
     {
       "id": "30854030-2b23-4a3a-b4e4-1a30d3d6d260",
       "returnSubmissionId": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "startDate": "2023-03-01",
-      "endDate": "2023-03-31",
+      "startDate": "2025-03-01",
+      "endDate": "2025-03-31",
       "quantity": "4000"
     }
   ]


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5064

In [Update Two-part tariff annual years for 2024-25](https://github.com/DEFRA/water-abstraction-system/pull/2002), we updated the years shown in the bill run setup journey's "Select the financial year" page to reflect that the SROC 2PT bill runs have been run for 2022/23 and 2023/24. On the backlog are just 2020/21 and 2021/22. For future years, it will just be the previous financial year (currently 2024/25).

The same changes need to be made to the SROC-based two-part tariff bill run acceptance tests, as they now all fail.