### PR TITLE
Fix test broken by changes to return version setup

### DIFF
--- a/cypress/fixtures/return-logs-historic-01.json
+++ b/cypress/fixtures/return-logs-historic-01.json
@@ -222,7 +222,7 @@
     {
       "id": "bcd4e8c7-16ed-419c-915d-d8f184e45ed5",
       "version": 101,
-      "startDate": "2019-01-01",
+      "startDate": "2020-01-01",
       "endDate": null,
       "status": "current",
       "externalId": "6:9999990",

--- a/cypress/fixtures/return-logs-historic-02.json
+++ b/cypress/fixtures/return-logs-historic-02.json
@@ -270,7 +270,7 @@
     {
       "id": "bcd4e8c7-16ed-419c-915d-d8f184e45ed5",
       "version": 101,
-      "startDate": "2019-01-01",
+      "startDate": "2020-01-01",
       "endDate": null,
       "status": "current",
       "externalId": "6:9999990",

--- a/cypress/fixtures/return-logs-historic-03.json
+++ b/cypress/fixtures/return-logs-historic-03.json
@@ -270,7 +270,7 @@
     {
       "id": "bcd4e8c7-16ed-419c-915d-d8f184e45ed5",
       "version": 101,
-      "startDate": "2019-01-01",
+      "startDate": "2020-01-01",
       "endDate": null,
       "status": "current",
       "externalId": "6:9999990",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5096

We got the return version setup journey wrong by basing all the abstraction data we show in the journey on the 'current' licence version, even if the start date for the new return version is before it starts.

Now the journey selects the relevant licence version based on the start date entered. Another change is that, having determined the relevant licence version, it will only allow users to copy from return versions whose start date falls in the relevant licence version's period.

It's this last change which has broken our historic correction tests. They are assuming the `Copy from existing` option will be available, but because of the fixtures, that is not the case.

A minor tweak, and all is working again.