### PR TITLE
Update acceptance tests after refactor of views

### DIFF
--- a/cypress/e2e/internal/return-versions/cancel-returns.cy.js
+++ b/cypress/e2e/internal/return-versions/cancel-returns.cy.js
@@ -47,35 +47,35 @@ describe('Cancel a return requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are on the reason page
-    cy.get('.govuk-fieldset__heading').contains('Select the reason for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the reason for the requirements for returns')
 
     // choose returns exception and click continue
     cy.get('#reason-2').check()
     cy.contains('Continue').click()
 
     // confirm we are on the set up page
-    cy.get('.govuk-fieldset__heading').contains('How do you want to set up the requirements for returns?')
+    cy.get('.govuk-heading-l').contains('How do you want to set up the requirements for returns?')
 
     // click set up manually and continue
     cy.get('#method-4').check()
     cy.contains('Continue').click()
 
     // confirm we are on the purpose page
-    cy.get('.govuk-heading-xl').contains('Select the purpose for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the purpose for the requirements for returns')
 
     // choose a purpose for the requirement and continue
     cy.get('[data-test="purpose-0"]').check()
     cy.contains('Continue').click()
 
     // confirm we are on the points page
-    cy.get('.govuk-heading-xl').contains('Select the points for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the points for the requirements for returns')
 
     // choose a points for the requirement and continue
     cy.get('#points').check()
     cy.contains('Continue').click()
 
     // confirm we are on the abstraction period page
-    cy.get('.govuk-heading-xl').contains('Enter the abstraction period for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Enter the abstraction period for the requirements for returns')
 
     // enter start and end dates for the abstraction period and click continue
     cy.get('#abstraction-period-start-day').type('01')
@@ -85,7 +85,7 @@ describe('Cancel a return requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are on the returns cycle page
-    cy.get('.govuk-heading-xl').contains('Select the returns cycle for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the returns cycle for the requirements for returns')
 
     // choose a returns cycle and continue
     cy.get('#returnsCycle').check()
@@ -99,14 +99,14 @@ describe('Cancel a return requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are on the readings collected page
-    cy.get('.govuk-heading-xl').contains('Select how often readings or volumes are collected')
+    cy.get('.govuk-heading-l').contains('Select how often readings or volumes are collected')
 
     // choose a collected time frame and continue
     cy.get('#frequencyCollected').check()
     cy.contains('Continue').click()
 
     // confirm we are on the readings reported page
-    cy.get('.govuk-heading-xl').contains('Select how often readings or volumes are reported')
+    cy.get('.govuk-heading-l').contains('Select how often readings or volumes are reported')
 
     // choose a reporting time frame and continue
     cy.get('#frequencyReported').check()
@@ -120,7 +120,7 @@ describe('Cancel a return requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are on the check page
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
 
     // confirm we see the start date information we expect
     cy.get('[data-test="start-date"]').contains('12 June 2023')

--- a/cypress/e2e/internal/return-versions/copy-existing.cy.js
+++ b/cypress/e2e/internal/return-versions/copy-existing.cy.js
@@ -47,28 +47,28 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are on the reason page
-    cy.get('.govuk-fieldset__heading').contains('Select the reason for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the reason for the requirements for returns')
 
     // choose a reason (minor change) for the return and click continue
     cy.get('#reason-8').check()
     cy.contains('Continue').click()
 
     // confirm we are on the set up page
-    cy.get('.govuk-fieldset__heading').contains('How do you want to set up the requirements for returns?')
+    cy.get('.govuk-heading-l').contains('How do you want to set up the requirements for returns?')
 
     // choose copy from existing requirements and continue
     cy.get('#method-2').check()
     cy.contains('Continue').click()
 
     // confirm we are on the existing requirements page
-    cy.get('.govuk-fieldset__heading').contains('Use previous requirements for returns')
+    cy.get('.govuk-heading-l').contains('Use previous requirements for returns')
 
     // choose a previous requirements for returns and continue
     cy.get('#existing').check()
     cy.contains('Continue').click()
 
     // confirm we are on the check page
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
 
     // confirm we see the start date and reason selected
     cy.get('[data-test="start-date"]').contains('12 June 2023')
@@ -79,7 +79,7 @@ describe('Submit returns requirement using copy existing (internal)', () => {
 
     // choose the change link for the purpose and confirm we are on the purpose page
     cy.get('[data-test="change-purposes-0"]').click()
-    cy.get('.govuk-heading-xl').contains('Select the purpose for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the purpose for the requirements for returns')
 
     // choose another purpose and add another purpose description and click continue
     cy.get('[data-test="purpose-0"]').uncheck()
@@ -88,7 +88,7 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we see the purpose changes on the check page
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
     cy.get('[data-test="purposes-0"]').contains('Laundry Use (This is another purpose description)')
 
     // confirm we see the points for the requirement copied from existing
@@ -97,35 +97,35 @@ describe('Submit returns requirement using copy existing (internal)', () => {
 
     // choose the change link for the points and confirm we are on the points page
     cy.get('[data-test="change-points-0"]').click()
-    cy.get('.govuk-heading-xl').contains('Select the points for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the points for the requirements for returns')
 
     // choose another points and continue
     cy.get('#points').uncheck()
     cy.contains('Continue').click()
 
     // confirm we see the points changes on the check page
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
     cy.get('[data-test="points-0"]').contains('At National Grid Reference TT 9876 5432 (Example point 2)')
 
     // choose add another requirement
     cy.contains('Add another requirement').click()
 
     // confirm we are on the purpose page
-    cy.get('.govuk-heading-xl').contains('Select the purpose for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the purpose for the requirements for returns')
 
     // choose a purpose and continue
     cy.get('[data-test="purpose-0"]').check()
     cy.contains('Continue').click()
 
     // confirm we are on the points page
-    cy.get('.govuk-heading-xl').contains('Select the points for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the points for the requirements for returns')
 
     // choose a points and continue
     cy.get('#points').check()
     cy.contains('Continue').click()
 
     // confirm we are on the abstraction period page
-    cy.get('.govuk-heading-xl').contains('Enter the abstraction period for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Enter the abstraction period for the requirements for returns')
 
     // choose a start and end date then continue
     cy.get('#abstraction-period-start-day').type('1')
@@ -135,7 +135,7 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are on the returns cycle page
-    cy.get('.govuk-heading-xl').contains('Select the returns cycle for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the returns cycle for the requirements for returns')
 
     // choose a returns cycle and continue
     cy.get('#returnsCycle').check()
@@ -149,14 +149,14 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are on the frequency collected page
-    cy.get('.govuk-heading-xl').contains('Select how often readings or volumes are collected')
+    cy.get('.govuk-heading-l').contains('Select how often readings or volumes are collected')
 
     // choose a frequency for collection and continue
     cy.get('#frequencyCollected-2').check()
     cy.contains('Continue').click()
 
     // confirm we are on the frequency reported page
-    cy.get('.govuk-heading-xl').contains('Select how often readings or volumes are reported')
+    cy.get('.govuk-heading-l').contains('Select how often readings or volumes are reported')
 
     // choose a frequency for reporting and continue
     cy.get('#frequencyReported-2').check()
@@ -171,7 +171,7 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are back on the check page
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
 
     // confirm we see the new requirement added message
     cy.get('.govuk-notification-banner__heading').contains('New requirement added')

--- a/cypress/e2e/internal/return-versions/no-returns-required.cy.js
+++ b/cypress/e2e/internal/return-versions/no-returns-required.cy.js
@@ -43,21 +43,21 @@ describe('Submit no returns requirement (internal)', () => {
     cy.contains("Mark licence as 'no returns needed'").click()
 
     // confirm we are on the start date page
-    cy.get('.govuk-fieldset__heading').contains('Select the start date for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the start date for the requirements for returns')
 
     // choose the licence version start date and click continue
     cy.get('#licence-start-date').check()
     cy.contains('Continue').click()
 
     // confirm we are on the why no returns required page
-    cy.get('.govuk-fieldset__heading').contains('Why are no returns required?')
+    cy.get('.govuk-heading-l').contains('Why are no returns required?')
 
     // choose returns exception and click continue
     cy.get('#reason-2').check()
     cy.contains('Continue').click()
 
     // confirm we are on the check page
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
 
     // confirm we see text about no returns required
     cy.contains('Returns are not required for this licence')
@@ -70,14 +70,14 @@ describe('Submit no returns requirement (internal)', () => {
     cy.get('[data-test="change-reason"]').click()
 
     // confirm we are on the why no returns required page
-    cy.get('.govuk-fieldset__heading').contains('Why are no returns required?')
+    cy.get('.govuk-heading-l').contains('Why are no returns required?')
 
     // choose returns exception and click continue
     cy.get('#reason-3').check()
     cy.contains('Continue').click()
 
     // confirm we are back on check page and see the reason changes
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
     cy.get('[data-test="reason"]').contains('Returns exception')
 
     // confirm we see the option to add note
@@ -97,7 +97,7 @@ describe('Submit no returns requirement (internal)', () => {
     cy.contains('Confirm').click()
 
     // confirm we are back on the check page
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
 
     // confirm we see pop up notification confirming changes have been made
     cy.get('.govuk-notification-banner').contains('Note added')
@@ -114,7 +114,7 @@ describe('Submit no returns requirement (internal)', () => {
     cy.contains('Confirm').click()
 
     // confirm we are back on the check page
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
 
     // confirm we see pop up notification confirming changes have been made
     cy.get('.govuk-notification-banner').contains('Note updated')

--- a/cypress/e2e/internal/return-versions/returns-required.cy.js
+++ b/cypress/e2e/internal/return-versions/returns-required.cy.js
@@ -47,21 +47,21 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are on the reason page
-    cy.get('.govuk-fieldset__heading').contains('Select the reason for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the reason for the requirements for returns')
 
     // choose returns exception and click continue
     cy.get('#reason-2').check()
     cy.contains('Continue').click()
 
     // confirm we are on the set up page
-    cy.get('.govuk-fieldset__heading').contains('How do you want to set up the requirements for returns?')
+    cy.get('.govuk-heading-l').contains('How do you want to set up the requirements for returns?')
 
     // click set up manually and continue
     cy.get('#method-4').check()
     cy.contains('Continue').click()
 
     // confirm we are on the purpose page
-    cy.get('.govuk-heading-xl').contains('Select the purpose for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the purpose for the requirements for returns')
 
     // choose a purpose and add a purpose description for the requirement and continue
     cy.get('[data-test="purpose-0"]').check()
@@ -69,14 +69,14 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are on the points page
-    cy.get('.govuk-heading-xl').contains('Select the points for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the points for the requirements for returns')
 
     // choose a points for the requirement and continue
     cy.get('#points').check()
     cy.contains('Continue').click()
 
     // confirm we are on the abstraction period page
-    cy.get('.govuk-heading-xl').contains('Enter the abstraction period for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Enter the abstraction period for the requirements for returns')
 
     // enter start and end dates for the abstraction period and click continue
     cy.get('#abstraction-period-start-day').type('01')
@@ -86,7 +86,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are on the returns cycle page
-    cy.get('.govuk-heading-xl').contains('Select the returns cycle for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the returns cycle for the requirements for returns')
 
     // choose a returns cycle and continue
     cy.get('#returnsCycle').check()
@@ -100,14 +100,14 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are on the readings collected page
-    cy.get('.govuk-heading-xl').contains('Select how often readings or volumes are collected')
+    cy.get('.govuk-heading-l').contains('Select how often readings or volumes are collected')
 
     // choose a collected time frame and continue
     cy.get('#frequencyCollected').check()
     cy.contains('Continue').click()
 
     // confirm we are on the readings reported page
-    cy.get('.govuk-heading-xl').contains('Select how often readings or volumes are reported')
+    cy.get('.govuk-heading-l').contains('Select how often readings or volumes are reported')
 
     // choose a reporting time frame and continue
     cy.get('#frequencyReported').check()
@@ -121,7 +121,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are on the check page
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
 
     // confirm we see the start date information we expect
     cy.get('[data-test="start-date"]').contains('12 June 2023')
@@ -137,7 +137,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are back on check page and see the start date changes
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
     cy.get('[data-test="start-date"]').contains('2 August 2023')
 
     // confirm we see the reason we selected
@@ -151,7 +151,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the reason changes
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
     cy.get('[data-test="reason"]').contains('Minor change')
 
     // confirm we see the purposes selected
@@ -167,7 +167,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the purpose changes
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
     cy.get('[data-test="purposes-0"]').contains('Laundry Use (This is another purpose description)')
 
     // confirm we see the points selected
@@ -182,7 +182,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the points changes
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
     cy.get('[data-test="points-0"]').contains('At National Grid Reference TT 9876 5432 (Example point 2)')
 
     // confirm we see the abstraction period selected
@@ -204,7 +204,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the abstraction period changes
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
     cy.get('[data-test="abstraction-period-0"]').contains('From 2 October to 5 December')
 
     // confirm we see the returns cycle selected
@@ -218,7 +218,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the returns cycle changes
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
     cy.get('[data-test="returns-cycle-0"]').contains('Winter')
 
     // confirm we see the site description we selected
@@ -233,7 +233,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the site description changes
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
     cy.get('[data-test="site-description-0"]').contains('This is another valid site description')
 
     // confirm we see the collection frequency we selected
@@ -247,7 +247,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the collection frequency changes
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
     cy.get('[data-test="frequency-collected-0"]').contains('Weekly')
 
     // confirm we see the reporting frequency we selected
@@ -261,7 +261,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the reporting frequency changes
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
     cy.get('[data-test="frequency-reported-0"]').contains('Monthly')
 
     // confirm we see the agreements and exceptions we selected
@@ -277,28 +277,28 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the agreements exceptions changes
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
     cy.get('[data-test="agreements-exceptions-0"]').contains('Transfer re-abstraction scheme and Two-part tariff')
 
     // click the add another requirement button
     cy.contains('Add another requirement').click()
 
     // confirm we are on the purpose page
-    cy.get('.govuk-heading-xl').contains('Select the purpose for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the purpose for the requirements for returns')
 
     // choose a purpose for the requirement and continue
     cy.get('[data-test="purpose-0"]').check()
     cy.contains('Continue').click()
 
     // confirm we are on the points page
-    cy.get('.govuk-heading-xl').contains('Select the points for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the points for the requirements for returns')
 
     // choose a points for the requirement and continue
     cy.get('#points').check()
     cy.contains('Continue').click()
 
     // confirm we are on the abstraction period page
-    cy.get('.govuk-heading-xl').contains('Enter the abstraction period for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Enter the abstraction period for the requirements for returns')
 
     // enter start and end dates for the abstraction period and click continue
     cy.get('#abstraction-period-start-day').type('07')
@@ -308,7 +308,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are on the returns cycle page
-    cy.get('.govuk-heading-xl').contains('Select the returns cycle for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the returns cycle for the requirements for returns')
 
     // choose a returns cycle and continue
     cy.get('#returnsCycle').check()
@@ -322,14 +322,14 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are on the readings collected page
-    cy.get('.govuk-heading-xl').contains('Select how often readings or volumes are collected')
+    cy.get('.govuk-heading-l').contains('Select how often readings or volumes are collected')
 
     // choose a collected time frame and continue
     cy.get('#frequencyCollected-3').check()
     cy.contains('Continue').click()
 
     // confirm we are on the readings reported page
-    cy.get('.govuk-heading-xl').contains('Select how often readings or volumes are reported')
+    cy.get('.govuk-heading-l').contains('Select how often readings or volumes are reported')
 
     // choose a reporting time frame and continue
     cy.get('#frequencyReported').check()
@@ -343,7 +343,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Continue').click()
 
     // confirm we are on the check page
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
 
     // confirm we see the new requirement
     cy.get('[data-test="requirement-1"]').contains('This is a valid site description for the second requirement')
@@ -352,16 +352,16 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('[data-test="remove-1"]').click()
 
     // confirm we are on the remove page
-    cy.get('.govuk-heading-xl').contains('You are about to remove these requirements for returns')
+    cy.get('.govuk-heading-l').contains('You are about to remove these requirements for returns')
 
     // confirm we see the correct requirement to be removed
-    cy.get('div.govuk-body > .govuk-body').contains('Summer daily requirements for returns, This is a valid site description for the second requirement.')
+    cy.get('p').contains('Summer daily requirements for returns, This is a valid site description for the second requirement.')
 
     // choose the remove button
     cy.contains('Remove').click()
 
     // confirm we are on the check page
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
 
     // confirm we receive a notification pop up confirming the removed requirement
     cy.get('.govuk-notification-banner').contains('Requirement removed')

--- a/cypress/e2e/internal/return-versions/start-by-using-abstraction-data.cy.js
+++ b/cypress/e2e/internal/return-versions/start-by-using-abstraction-data.cy.js
@@ -47,21 +47,21 @@ describe('Submit returns requirement (internal) using abstraction data', () => {
     cy.contains('Continue').click()
 
     // confirm we are on the reason page
-    cy.get('.govuk-fieldset__heading').contains('Select the reason for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the reason for the requirements for returns')
 
     // choose reason (new licence) and click continue
     cy.get('#reason-10').check()
     cy.contains('Continue').click()
 
     // confirm we are on the set up page
-    cy.get('.govuk-fieldset__heading').contains('How do you want to set up the requirements for returns?')
+    cy.get('.govuk-heading-l').contains('How do you want to set up the requirements for returns?')
 
     // choose the start by using abstraction data checkbox and continue
     cy.get('#method').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
 
     // confirm we see the start data and reason options selected previously
     cy.get('[data-test="start-date"]').contains('12 June 2023')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5139

Now that we have completed the return version set up journey it was time to revisit the views and standardise the code across them. As multiple people were working on the different pages it is always the case that there will be minor variations in how things are implemented.

This PR updates the acceptance tests based on the new updated views.