### PR TITLE
Update return log historic changes tests

### DIFF
--- a/cypress/e2e/internal/return-logs/historic-corrections-01.cy.js
+++ b/cypress/e2e/internal/return-logs/historic-corrections-01.cy.js
@@ -105,21 +105,21 @@ describe('Submit winter and all year historic correction using abstraction data'
     cy.contains('Continue').click()
 
     // confirm we are on the reason page
-    cy.get('.govuk-fieldset__heading').contains('Select the reason for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the reason for the requirements for returns')
 
     // choose reason (new licence) and click continue
     cy.get('#reason-10').check()
     cy.contains('Continue').click()
 
     // confirm we are on the set up page
-    cy.get('.govuk-fieldset__heading').contains('How do you want to set up the requirements for returns?')
+    cy.get('.govuk-heading-l').contains('How do you want to set up the requirements for returns?')
 
     // choose the start by using abstraction data checkbox and continue
     cy.get('#method').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
 
     // choose the approve return requirement button
     cy.contains('Approve returns requirement').click()

--- a/cypress/e2e/internal/return-logs/historic-corrections-02.cy.js
+++ b/cypress/e2e/internal/return-logs/historic-corrections-02.cy.js
@@ -118,28 +118,28 @@ describe('Submit summer and winter and all year historic correction using abstra
     cy.contains('Continue').click()
 
     // confirm we are on the reason page
-    cy.get('.govuk-fieldset__heading').contains('Select the reason for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the reason for the requirements for returns')
 
     // choose reason (new licence) and click continue
     cy.get('#reason-10').check()
     cy.contains('Continue').click()
 
     // confirm we are on the set up page
-    cy.get('.govuk-fieldset__heading').contains('How do you want to set up the requirements for returns?')
+    cy.get('.govuk-heading-l').contains('How do you want to set up the requirements for returns?')
 
     // choose copy from existing requirements and continue
     cy.get('#method-2').check()
     cy.contains('Continue').click()
 
     // confirm we are on the existing requirements page
-    cy.get('.govuk-fieldset__heading').contains('Use previous requirements for returns')
+    cy.get('.govuk-heading-l').contains('Use previous requirements for returns')
 
     // choose a previous requirements for returns and continue
     cy.get('#existing').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
 
     // choose the approve return requirement button
     cy.contains('Approve returns requirement').click()

--- a/cypress/e2e/internal/return-logs/historic-corrections-03.cy.js
+++ b/cypress/e2e/internal/return-logs/historic-corrections-03.cy.js
@@ -139,21 +139,21 @@ describe('Submit historic correction using abstraction data for two abstraction 
     cy.contains('Continue').click()
 
     // confirm we are on the reason page
-    cy.get('.govuk-fieldset__heading').contains('Select the reason for the requirements for returns')
+    cy.get('.govuk-heading-l').contains('Select the reason for the requirements for returns')
 
     // choose reason (new licence) and click continue
     cy.get('#reason-10').check()
     cy.contains('Continue').click()
 
     // confirm we are on the set up page
-    cy.get('.govuk-fieldset__heading').contains('How do you want to set up the requirements for returns?')
+    cy.get('.govuk-heading-l').contains('How do you want to set up the requirements for returns?')
 
     // choose the start by using abstraction data checkbox and continue
     cy.get('#method').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page
-    cy.get('.govuk-heading-xl').contains('Check the requirements for returns for Mr J J Testerson')
+    cy.get('.govuk-heading-l').contains('Check the requirements for returns for Mr J J Testerson')
 
     // choose the approve return requirement button
     cy.contains('Approve returns requirement').click()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5139

Now that we have completed the return version set up journey it was time to revisit the views and standardise the code across them. As multiple people were working on the different pages it is always the case that there will be minor variations in how things are implemented.

This PR updates the acceptance tests based on the new updated views.