### PR TITLE
Switch to using Snyk CLI action in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,3 +52,8 @@ jobs:
       - name: Run unit tests
         run: |
           npm run cy:run:ci
+
+      - name: Run Snyk to check for vulnerabilities
+        uses: snyk/actions/node@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,20 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-BRACEEXPANSION-9789073:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-05T14:35:35.291Z
+        created: 2025-08-06T14:35:35.293Z
+  SNYK-JS-INFLIGHT-6095116:
+    - '*':
+        reason: Version jump is beyond scope for legacy
+        expires: 2025-09-05T14:36:04.129Z
+        created: 2025-08-06T14:36:04.136Z
+  SNYK-JS-CROSSSPAWN-8303230:
+    - '*':
+        reason: No direct upgrade or patch
+        expires: 2025-09-05T14:36:55.741Z
+        created: 2025-08-06T14:36:55.744Z
+patch: {}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5191

With the adoption of SSO in the Defra GitHub org, our current [Snyk](https://snyk.io) status checks have stopped working.

The [team issue](https://github.com/DEFRA/water-abstraction-team/issues/144) goes into more detail, but in essence, whilst the GitHub account that **Snyk** uses to connect has SSO enabled, it won't connect to GitHub to update the PR with the test result.

This change performs the same check without **Snyk** having to authenticate to GitHub. Instead, GitHub will authenticate with **Snyk** by using its CLI via a GitHub action.

It does mean **Snyk** will no longer be listed as a separate check; instead, it will just be a new step in our CI. So, the outcome (adding a package with a vulnerability will cause the PR to fail checks) will be the same.