### PR TITLE
Update billing test due to changed charges

### DIFF
--- a/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
@@ -419,7 +419,7 @@ describe('Replace charge version in current financial year change the charge ref
 
     // Bill for Big Farm Co Ltd 02
     // check the debits, credits, adjustments and additional charges have been applied
-    cy.get('[data-test="additional-charges-0"]').should('contain.text', 'Supported source Earl Soham - Deben (£10696.00)')
+    cy.get('[data-test="additional-charges-0"]').should('contain.text', 'Supported source Earl Soham - Deben (£')
     cy.get('[data-test="adjustments-0"]').should('contain.text', 'Winter discount (0.5)')
 
     cy.get('[data-test="billable-days-0"]').should('contain.text', '212/365')


### PR DESCRIPTION
We know there are uplifts in charges planned for this year, and we have a test that asserts a value is equal to `x`.

Really, it should just be testing a value exists rather than the specific charge because these do change each year. So, this change updates the test to avoid it failing again in future years.