### PR TITLE
Add snyk exception for tmp

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,10 @@
+# Snyk (https://snyk.io) policy file, patches or ignores known vulnerabilities.
+version: v1.25.1
+# ignores vulnerabilities until expiry date; change duration by modifying expiry date
+ignore:
+  SNYK-JS-TMP-11501554:
+    - '*':
+        reason: Waiting for cypress to resolve
+        expires: 2025-09-13T13:45:02.315Z
+        created: 2025-08-14T13:45:02.316Z
+patch: {}


### PR DESCRIPTION
https://github.com/DEFRA/water-abstraction-team/issues/144

**Snyk** has identified that [tmp](https://github.com/raszi/node-tmp) has a [Symlink Attack vulnerability](https://security.snyk.io/vuln/SNYK-JS-TMP-11501554).

It is introduced via [cypress](https://github.com/cypress-io/cypress). Looking at their releases, they are pretty hot on resolving vulnerabilities; they just haven't gotten to this one yet (it's very new).

We have faith they will, so we are happy to add an exception for now.