### PR TITLE
Update bill run get() calls post template std work

### DIFF
--- a/cypress/e2e/internal/billing/annual/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/annual/cancel-existing.cy.js
@@ -87,6 +87,6 @@ describe('Cancel an existing annual bill run (internal)', () => {
 
     // Bill runs
     // confirm we are back on the bill runs page
-    cy.get('.govuk-heading-xl').should('contain.text', 'Bill runs')
+    cy.get('.govuk-heading-l').should('contain.text', 'Bill runs')
   })
 })

--- a/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/cancel-existing.cy.js
@@ -95,7 +95,7 @@ describe('Cancel existing supplementary bill runs (internal)', () => {
 
     // Bill runs
     // confirm we are back on the bill runs page
-    cy.get('.govuk-heading-xl').should('contain.text', 'Bill runs')
+    cy.get('.govuk-heading-l').should('contain.text', 'Bill runs')
 
     // -------------------------------------------------------------------------
     cy.log('Deleting the SROC supplementary bill run')
@@ -130,6 +130,6 @@ describe('Cancel existing supplementary bill runs (internal)', () => {
 
     // Bill runs
     // confirm we are back on the bill runs page
-    cy.get('.govuk-heading-xl').should('contain.text', 'Bill runs')
+    cy.get('.govuk-heading-l').should('contain.text', 'Bill runs')
   })
 })

--- a/cypress/e2e/internal/billing/two-part-tariff/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/cancel-existing.cy.js
@@ -91,6 +91,6 @@ describe('Cancel an existing two-part tariff bill run (internal)', () => {
 
     // Bill runs
     // confirm we are back on the bill runs page
-    cy.get('.govuk-heading-xl').should('contain.text', 'Bill runs')
+    cy.get('.govuk-heading-l').should('contain.text', 'Bill runs')
   })
 })

--- a/cypress/e2e/internal/billing/two-part-tariff/empty-bill-run.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/empty-bill-run.cy.js
@@ -66,7 +66,7 @@ describe('Create a empty SROC two-part tariff bill run (internal)', () => {
 
     // Test Region two-part tariff bill run
     // quick test that the display is as expected and then click Cancel bill run
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'empty')
+    cy.get('.govuk-tag').should('contain.text', 'empty')
     cy.get('[data-test="error-notification"]').should('exist')
     cy.get('[data-test="error-notification"]').should('contain.text', 'There are no licences ready for this bill run')
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5154

We have been working through the views in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) to ensure they are consistent. We refer to this as "template standard".

This means some of the current Cypress `cy.get()` calls need to be updated because of these changes, else the tests fail.