### PR TITLE
Fix billing tag selectors post 'template' std

### DIFF
--- a/cypress/e2e/internal/billing/annual/cancel-existing.cy.js
+++ b/cypress/e2e/internal/billing/annual/cancel-existing.cy.js
@@ -70,7 +70,7 @@ describe('Cancel an existing annual bill run (internal)', () => {
 
     // Test Region annual bill run
     // quick test that the display is as expected and then click Send bill run
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'ready')
     cy.get('[data-test="water-companies"]').should('exist')
     cy.get('[data-test="other-abstractors"]').should('not.exist')
     cy.get('.govuk-button').contains('Cancel bill run').click()

--- a/cypress/e2e/internal/billing/annual/journey.cy.js
+++ b/cypress/e2e/internal/billing/annual/journey.cy.js
@@ -72,7 +72,7 @@ describe('Create and send annual bill run (internal)', () => {
 
     // Test Region annual bill run
     // quick test that the display is as expected and then click Send bill run
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'ready')
     cy.get('[data-test="water-companies"]').should('exist')
     cy.get('[data-test="other-abstractors"]').should('not.exist')
     cy.get('.govuk-button').contains('Send bill run').click()
@@ -99,7 +99,7 @@ describe('Create and send annual bill run (internal)', () => {
 
     // Test Region annual bill run
     // confirm we see it is now SENT
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'sent')
 
     // click the back link to go to bill runs
     cy.get('.govuk-back-link').click()

--- a/cypress/e2e/internal/billing/annual/remove-licence.cy.js
+++ b/cypress/e2e/internal/billing/annual/remove-licence.cy.js
@@ -79,7 +79,7 @@ describe('Remove bill from annual bill run (internal)', () => {
 
     // Test Region annual bill run
     // quick test that the display is as expected and then click view bill link
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'ready')
     cy.get('[data-test="water-companies"]').should('exist')
     cy.get('[data-test="other-abstractors"]').should('not.exist')
     cy.get('[data-test="action-3"] > .govuk-link').click()
@@ -106,7 +106,7 @@ describe('Remove bill from annual bill run (internal)', () => {
     // Test Region annual bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can confirm we're down to 3 bills
-    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
+    cy.get('#main-content > p > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
     cy.get('[data-test="water-companies"]').should('exist')
     cy.get('[data-test="other-abstractors"]').should('not.exist')
     cy.get('[data-test="water-companies"] > tbody > tr').should('have.length', 3)

--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-current-year.cy.js
@@ -80,7 +80,7 @@ describe('Change billing account in current financial year (internal)', () => {
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'ready')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.sroc
       if (billingPeriodCount === 1) {
@@ -115,7 +115,7 @@ describe('Change billing account in current financial year (internal)', () => {
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'sent')
 
     // click the back link to go to bill runs
     cy.get('.govuk-back-link').click()
@@ -249,7 +249,7 @@ describe('Change billing account in current financial year (internal)', () => {
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'ready')
     cy.get('[data-test="bills-count"]').should('contain.text', '2 Supplementary bills')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('[data-test="meta-data-created"]').should('contain.text', formattedCurrentDate)
@@ -290,7 +290,7 @@ describe('Change billing account in current financial year (internal)', () => {
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'sent')
 
     // click the back link to go to bill runs
     cy.get('.govuk-back-link').click()

--- a/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/change-billing-account-previous-year.cy.js
@@ -80,7 +80,7 @@ describe('Change billing account in previous financial year (internal)', () => {
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'ready')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.sroc
       if (billingPeriodCount === 1) {
@@ -115,7 +115,7 @@ describe('Change billing account in previous financial year (internal)', () => {
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'sent')
 
     // click the back link to go to bill runs
     cy.get('.govuk-back-link').click()
@@ -247,7 +247,7 @@ describe('Change billing account in previous financial year (internal)', () => {
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('[data-test="meta-data-created"]').should('contain.text', formattedCurrentDate)
     })
@@ -295,7 +295,7 @@ describe('Change billing account in previous financial year (internal)', () => {
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'sent')
 
     // click the back link to go to bill runs
     cy.get('.govuk-back-link').click()

--- a/cypress/e2e/internal/billing/supplementary/journey.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/journey.cy.js
@@ -92,7 +92,7 @@ describe('Create and send supplementary bill runs (internal)', () => {
 
     // Test Region supplementary bill run
     // quick test that the display is as expected and then click Send bill run
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'ready')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.presroc
       if (billingPeriodCount === 1) {
@@ -127,7 +127,7 @@ describe('Create and send supplementary bill runs (internal)', () => {
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'sent')
 
     // click the back link to go to bill runs
     cy.get('.govuk-back-link').click()
@@ -153,7 +153,7 @@ describe('Create and send supplementary bill runs (internal)', () => {
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'ready')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.sroc
       if (billingPeriodCount === 1) {
@@ -188,7 +188,7 @@ describe('Create and send supplementary bill runs (internal)', () => {
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'sent')
 
     // click the back link to go to bill runs
     cy.get('.govuk-back-link').click()

--- a/cypress/e2e/internal/billing/supplementary/no-annual-in-current-year.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/no-annual-in-current-year.cy.js
@@ -85,7 +85,7 @@ describe('Create and send supplementary bill runs (internal)', () => {
 
     // Test Region supplementary bill run
     // check the the financial end year is not the current year
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'ready')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.sroc
       if (billingPeriodCount === 1) {

--- a/cypress/e2e/internal/billing/supplementary/non-charge-licence-credit.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/non-charge-licence-credit.cy.js
@@ -75,7 +75,7 @@ describe('Make licence non-chargeable then see credit in next bill run (internal
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('[data-test="meta-data-created"]').should('contain.text', formattedCurrentDate)
     })
@@ -201,7 +201,7 @@ describe('Make licence non-chargeable then see credit in next bill run (internal
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('[data-test="meta-data-created"]').should('contain.text', formattedCurrentDate)
     })

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-2023-fin-year-no-changes.cy.js
@@ -156,7 +156,7 @@ describe('Replace charge version in the 2023 financial year with no changes (int
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'ready')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.sroc
       if (billingPeriodCount === 1) {
@@ -191,7 +191,7 @@ describe('Replace charge version in the 2023 financial year with no changes (int
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'sent')
 
     // click the back link to go to bill runs
     cy.get('.govuk-back-link').click()
@@ -302,7 +302,7 @@ describe('Replace charge version in the 2023 financial year with no changes (int
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('[data-test="meta-data-created"]').should('contain.text', formattedCurrentDate)
     })
@@ -341,7 +341,7 @@ describe('Replace charge version in the 2023 financial year with no changes (int
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'sent')
 
     // click the back link to go to bill runs
     cy.get('.govuk-back-link').click()

--- a/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
+++ b/cypress/e2e/internal/billing/supplementary/replace-cv-current-year-with-changes.cy.js
@@ -156,7 +156,7 @@ describe('Replace charge version in current financial year change the charge ref
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'ready')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const billingPeriodCount = currentFinancialYearInfo.billingPeriodCounts.sroc
       if (billingPeriodCount === 1) {
@@ -191,7 +191,7 @@ describe('Replace charge version in current financial year change the charge ref
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'sent')
 
     // click the back link to go to bill runs
     cy.get('.govuk-back-link').click()
@@ -352,11 +352,11 @@ describe('Replace charge version in current financial year change the charge ref
     // Test Region supplementary bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can confirm the bill run is as expected
-    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
+    cy.get('#main-content > p > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
 
     // Test Region supplementary bill run
     // check the details before sending the bill run
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'ready')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'ready')
     cy.get('@formattedCurrentDate').then((formattedCurrentDate) => {
       cy.get('[data-test="meta-data-created"]').should('contain.text', formattedCurrentDate)
     })
@@ -395,7 +395,7 @@ describe('Replace charge version in current financial year change the charge ref
 
     // Test Region supplementary bill run
     // confirm we see it is now SENT
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'sent')
 
     // click the back link to go to bill runs
     cy.get('.govuk-back-link').click()

--- a/cypress/e2e/internal/billing/two-part-tariff/journey.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/journey.cy.js
@@ -127,7 +127,7 @@ describe('Create and send PRESROC two-part tariff bill run (internal)', () => {
     // Test Region two-part tariff bill run
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can check the rest of the details before confirming the bill run
-    cy.get('.govuk-body > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
+    cy.get('#main-content > p > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
     cy.get('[data-test="bill-total"]').should('contain.text', '£660.24')
     cy.get('[data-test="bills-count"]').should('contain.text', '1 Two-part tariff winter and all year bill')
     cy.get('.govuk-button').contains('Send bill run').click()
@@ -154,7 +154,7 @@ describe('Create and send PRESROC two-part tariff bill run (internal)', () => {
 
     // Test Region two-part tariff bill run
     // confirm we see it is now SENT
-    cy.get('.govuk-body > .govuk-tag').should('contain.text', 'sent')
+    cy.get('#main-content > p > .govuk-tag').should('contain.text', 'sent')
 
     // click the back link to go to bill runs
     cy.get('.govuk-back-link').click()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5202

We have recently been working through some of our views, updating them to a 'template' standard. This is to ensure consistency in the service as [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) takes over an increasing portion of the service.

One of the changes is dropping unnecessary applications of the `.govuk-body` class to elements. This is declared at the body level, and only in a few exceptional cases does it need to be applied to an element. However, this means several selectors in the billing pages for the status tag need updating.