### PR TITLE
Update `send-alert` test

### DIFF
--- a/cypress/e2e/internal/monitoring-stations/abstraction-alerts/send-alert.cy.js
+++ b/cypress/e2e/internal/monitoring-stations/abstraction-alerts/send-alert.cy.js
@@ -90,6 +90,7 @@ describe('Send an abstraction alert (internal)', () => {
     cy.get('.govuk-panel__body').contains('Your reference number is WAA-')
 
     // View the notifications report and check the data is correct
+    cy.wait(1000) // Pause for 1 second to ensure the DB is updated with the new notification
     cy.get('div.govuk-body > :nth-child(2) > .govuk-link').click()
     cy.get('.govuk-caption-xl').should('have.text', 'Notification report')
     cy.get('.govuk-heading-xl').should('have.text', 'Water abstraction alert')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5164

While running the tests I've spotted that the test to send an alert is failing intermittently. This is because it is trying to check the details of the sent alert before the DB is updated. Adding a 1 second delay between creating the alert and checking it resolves the issue.