### PR TITLE
Fix broken tests

### DIFF
--- a/cypress/e2e/internal/returns/view-status.cy.js
+++ b/cypress/e2e/internal/returns/view-status.cy.js
@@ -44,11 +44,11 @@ describe('View returns and their status (internal)', () => {
       cy.get('.govuk-table__row:nth-child(2)').should('be.visible').and('contain.text', '9999992')
       cy.get('.govuk-table__row:nth-child(2)').should('be.visible').and('contain.text', 'overdue')
 
-      cy.get('.govuk-table__row:nth-child(3)').should('be.visible').and('contain.text', '9999991')
-      cy.get('.govuk-table__row:nth-child(3)').should('be.visible').and('contain.text', 'overdue')
+      cy.get('.govuk-table__row:nth-child(3)').should('be.visible').and('contain.text', '9999992')
+      cy.get('.govuk-table__row:nth-child(3)').should('be.visible').and('contain.text', 'complete')
 
-      cy.get('.govuk-table__row:nth-child(4)').should('be.visible').and('contain.text', '9999992')
-      cy.get('.govuk-table__row:nth-child(4)').should('be.visible').and('contain.text', 'complete')
+      cy.get('.govuk-table__row:nth-child(4)').should('be.visible').and('contain.text', '9999991')
+      cy.get('.govuk-table__row:nth-child(4)').should('be.visible').and('contain.text', 'overdue')
 
       cy.get('.govuk-table__row:nth-child(5)').should('be.visible').and('contain.text', '9999990')
       cy.get('.govuk-table__row:nth-child(5)').should('be.visible').and('contain.text', 'overdue')

--- a/cypress/e2e/internal/supplementary-billing-flags/editing-a-return.cy.js
+++ b/cypress/e2e/internal/supplementary-billing-flags/editing-a-return.cy.js
@@ -1,6 +1,6 @@
 'use strict'
 
-describe('Editing a return', () => {
+describe('Editing a return (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
     cy.fixture('barebones.json').then((fixture) => {
@@ -41,10 +41,10 @@ describe('Editing a return', () => {
 
     // confirm we see the return we are going to edit
     cy.get('#returns').within(() => {
-      cy.get('[data-test="return-reference-2"] > .govuk-link').should('be.visible').and('contain.text', '9999994')
-      cy.get('[data-test="return-status-2"] > .govuk-tag').should('be.visible').and('contain.text', 'complete')
+      cy.get('[data-test="return-reference-0"] > .govuk-link').should('be.visible').and('contain.text', '9999994')
+      cy.get('[data-test="return-status-0"] > .govuk-tag').should('be.visible').and('contain.text', 'complete')
 
-      cy.get('[data-test="return-reference-2"] > .govuk-link').contains('9999994').click()
+      cy.get('[data-test="return-reference-0"] > .govuk-link').contains('9999994').click()
     })
 
     // Edit return


### PR DESCRIPTION
The changes made in https://eaflood.atlassian.net/browse/WATER-5213 have changed the ordering on the Licence's return tab. As a result there are some tests which are now failing.

In this PR the "View returns and their status" and the "Editing a return" tests will be updated to work with the new ordering.