### PR TITLE
Update abstraction alerts show all recipients step

### DIFF
--- a/cypress/e2e/internal/monitoring-stations/abstraction-alerts/cancel-alert.cy.js
+++ b/cypress/e2e/internal/monitoring-stations/abstraction-alerts/cancel-alert.cy.js
@@ -79,7 +79,7 @@ describe('Set up but then cancel an abstraction alert (internal)', () => {
     // Confirm data on Check the recipients page is correct and cancel the alert
     cy.get('.govuk-caption-l').contains('Notice WAA-')
     cy.get('.govuk-heading-l').contains('Check the recipients')
-    cy.get('.govuk-body').contains('Showing all 1 recipients')
+    cy.get('p').contains('Showing all 1 recipients')
     cy.get('.govuk-table__body').contains('external@example.com')
     cy.get('.govuk-table__body').contains('AT/CURR/DAILY/01')
     cy.get('.govuk-table__body').contains('Email - Primary user')

--- a/cypress/e2e/internal/monitoring-stations/abstraction-alerts/cancel-alert.cy.js
+++ b/cypress/e2e/internal/monitoring-stations/abstraction-alerts/cancel-alert.cy.js
@@ -79,7 +79,7 @@ describe('Set up but then cancel an abstraction alert (internal)', () => {
     // Confirm data on Check the recipients page is correct and cancel the alert
     cy.get('.govuk-caption-l').contains('Notice WAA-')
     cy.get('.govuk-heading-l').contains('Check the recipients')
-    cy.get('p').contains('Showing all 1 recipients')
+    cy.get('[data-test="recipients-count"]').contains('Showing all 1 recipients')
     cy.get('.govuk-table__body').contains('external@example.com')
     cy.get('.govuk-table__body').contains('AT/CURR/DAILY/01')
     cy.get('.govuk-table__body').contains('Email - Primary user')

--- a/cypress/e2e/internal/monitoring-stations/abstraction-alerts/send-alert.cy.js
+++ b/cypress/e2e/internal/monitoring-stations/abstraction-alerts/send-alert.cy.js
@@ -78,7 +78,7 @@ describe('Send an abstraction alert (internal)', () => {
     // Confirm data on Check the recipients page is correct and send the alert
     cy.get('.govuk-caption-l').contains('Notice WAA-')
     cy.get('.govuk-heading-l').contains('Check the recipients')
-    cy.get('.govuk-body').contains('Showing all 1 recipients')
+    cy.get('p').contains('Showing all 1 recipients')
     cy.get('.govuk-table__body').contains('external@example.com')
     cy.get('.govuk-table__body').contains('AT/CURR/DAILY/01')
     cy.get('.govuk-table__body').contains('Email - Primary user')

--- a/cypress/e2e/internal/monitoring-stations/abstraction-alerts/send-alert.cy.js
+++ b/cypress/e2e/internal/monitoring-stations/abstraction-alerts/send-alert.cy.js
@@ -78,7 +78,7 @@ describe('Send an abstraction alert (internal)', () => {
     // Confirm data on Check the recipients page is correct and send the alert
     cy.get('.govuk-caption-l').contains('Notice WAA-')
     cy.get('.govuk-heading-l').contains('Check the recipients')
-    cy.get('p').contains('Showing all 1 recipients')
+    cy.get('[data-test="recipients-count"]').contains('Showing all 1 recipients')
     cy.get('.govuk-table__body').contains('external@example.com')
     cy.get('.govuk-table__body').contains('AT/CURR/DAILY/01')
     cy.get('.govuk-table__body').contains('Email - Primary user')


### PR DESCRIPTION
We recently updated our layout to provided another block 'pageContent'. When this was done we did a little clean up of stray (and unecessary) '.govuk-body' divs. 

This change updates the test selector to check there is a <p> on the page containing ''Showing all 1 recipients'. 

The tests are the ame as before just an updated selector

