### PR TITLE
Return version setup standardisation changes

### DIFF
--- a/cypress/e2e/internal/monitoring-stations/licence-tagging/change-type.cy.js
+++ b/cypress/e2e/internal/monitoring-stations/licence-tagging/change-type.cy.js
@@ -58,10 +58,10 @@ describe('Tag a licence but attempt to change the tag type during the journey (i
 
     // Enter the abstraction period for the licence
     cy.get('.govuk-heading-l').contains('Enter an abstraction period for licence AT/CURR/WEEKLY/01')
-    cy.get('#abstraction-period-start-day').type('10')
-    cy.get('#abstraction-period-start-month').type('10')
-    cy.get('#abstraction-period-end-day').type('11')
-    cy.get('#abstraction-period-end-month').type('11')
+    cy.get('#abstractionPeriodStartDay').type('10')
+    cy.get('#abstractionPeriodStartMonth').type('10')
+    cy.get('#abstractionPeriodEndDay').type('11')
+    cy.get('#abstractionPeriodEndMonth').type('11')
     cy.get('.govuk-button').contains('Continue').click()
 
     // Check the restriction details

--- a/cypress/e2e/internal/monitoring-stations/licence-tagging/linked-condition-manual-abs-period.cy.js
+++ b/cypress/e2e/internal/monitoring-stations/licence-tagging/linked-condition-manual-abs-period.cy.js
@@ -59,10 +59,10 @@ describe('Tag a licence linked to a condition but manually enter the abstraction
 
     // Enter the abstraction period for the licence
     cy.get('.govuk-heading-l').contains('Enter an abstraction period for licence AT/CURR/DAILY/01')
-    cy.get('#abstraction-period-start-day').type('10')
-    cy.get('#abstraction-period-start-month').type('10')
-    cy.get('#abstraction-period-end-day').type('11')
-    cy.get('#abstraction-period-end-month').type('11')
+    cy.get('#abstractionPeriodStartDay').type('10')
+    cy.get('#abstractionPeriodStartMonth').type('10')
+    cy.get('#abstractionPeriodEndDay').type('11')
+    cy.get('#abstractionPeriodEndMonth').type('11')
     cy.get('.govuk-button').contains('Continue').click()
 
     // Check the restriction details

--- a/cypress/e2e/internal/monitoring-stations/licence-tagging/no-linked-condition.cy.js
+++ b/cypress/e2e/internal/monitoring-stations/licence-tagging/no-linked-condition.cy.js
@@ -58,10 +58,10 @@ describe('Tag a licence that is not linked to a condition (internal)', () => {
 
     // Enter the abstraction period for the licence
     cy.get('.govuk-heading-l').contains('Enter an abstraction period for licence AT/CURR/WEEKLY/01')
-    cy.get('#abstraction-period-start-day').type('10')
-    cy.get('#abstraction-period-start-month').type('10')
-    cy.get('#abstraction-period-end-day').type('11')
-    cy.get('#abstraction-period-end-month').type('11')
+    cy.get('#abstractionPeriodStartDay').type('10')
+    cy.get('#abstractionPeriodStartMonth').type('10')
+    cy.get('#abstractionPeriodEndDay').type('11')
+    cy.get('#abstractionPeriodEndMonth').type('11')
     cy.get('.govuk-button').contains('Continue').click()
 
     // Check the restriction details

--- a/cypress/e2e/internal/return-logs/historic-corrections-01.cy.js
+++ b/cypress/e2e/internal/return-logs/historic-corrections-01.cy.js
@@ -65,11 +65,11 @@ describe('Submit winter and all year historic correction using abstraction data'
     cy.contains('Set up new requirements').click()
 
     // set the start date to be 2 years in the past
-    cy.get('#another-start-date').check()
-    cy.get('#other-start-date-day').type('01')
-    cy.get('#other-start-date-month').type('11')
+    cy.get('#anotherStartDate').check()
+    cy.get('#startDateDay').type('01')
+    cy.get('#startDateMonth').type('11')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
-      cy.get('#other-start-date-year').type(currentFinancialYearInfo.start.year - 2)
+      cy.get('#startDateYear').type(currentFinancialYearInfo.start.year - 2)
     })
     cy.contains('Continue').click()
 
@@ -77,14 +77,14 @@ describe('Submit winter and all year historic correction using abstraction data'
     cy.get('.govuk-heading-l').contains('Select the reason for the requirements for returns')
 
     // choose reason (new licence) and click continue
-    cy.get('#reason-10').check()
+    cy.get('#newLicence').check()
     cy.contains('Continue').click()
 
     // confirm we are on the set up page
     cy.get('.govuk-heading-l').contains('How do you want to set up the requirements for returns?')
 
     // choose the start by using abstraction data checkbox and continue
-    cy.get('#method').check()
+    cy.get('#useAbstractionData').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page

--- a/cypress/e2e/internal/return-logs/historic-corrections-02.cy.js
+++ b/cypress/e2e/internal/return-logs/historic-corrections-02.cy.js
@@ -66,11 +66,11 @@ describe('Submit summer and winter and all year historic correction using abstra
     cy.contains('Set up new requirements').click()
 
     // set the start date to be the beginning of the current winter and all year cycle
-    cy.get('#another-start-date').check()
-    cy.get('#other-start-date-day').type('01')
-    cy.get('#other-start-date-month').type('04')
+    cy.get('#anotherStartDate').check()
+    cy.get('#startDateDay').type('01')
+    cy.get('#startDateMonth').type('04')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
-      cy.get('#other-start-date-year').type(currentFinancialYearInfo.start.year)
+      cy.get('#startDateYear').type(currentFinancialYearInfo.start.year)
     })
     cy.contains('Continue').click()
 
@@ -78,14 +78,14 @@ describe('Submit summer and winter and all year historic correction using abstra
     cy.get('.govuk-heading-l').contains('Select the reason for the requirements for returns')
 
     // choose reason (new licence) and click continue
-    cy.get('#reason-10').check()
+    cy.get('#newLicence').check()
     cy.contains('Continue').click()
 
     // confirm we are on the set up page
     cy.get('.govuk-heading-l').contains('How do you want to set up the requirements for returns?')
 
     // choose copy from existing requirements and continue
-    cy.get('#method-2').check()
+    cy.get('#useExistingRequirements').check()
     cy.contains('Continue').click()
 
     // confirm we are on the existing requirements page

--- a/cypress/e2e/internal/return-logs/historic-corrections-02.cy.js
+++ b/cypress/e2e/internal/return-logs/historic-corrections-02.cy.js
@@ -115,36 +115,33 @@ describe('Submit summer and winter and all year historic correction using abstra
       const winter = { start: currentFinancialYearInfo.start.year, end: currentFinancialYearInfo.end.year }
       const summer = { start: currentFinancialYearInfo.start.year - 1, end: currentFinancialYearInfo.end.year - 1 }
 
-      cy.get('[data-test="return-due-date-0"]').should('have.value', '')
-      cy.get('[data-test="return-status-0"] > .govuk-tag').contains('not due yet')
-
       cy.returnLogDueData(winter.end, true).then((data) => {
-        cy.get('[data-test="return-due-date-1"]').contains(data.text)
-        cy.get('[data-test="return-status-1"] > .govuk-tag').contains('void')
+        cy.get('[data-test="return-due-date-0"]').contains(data.text)
+        cy.get('[data-test="return-status-0"] > .govuk-tag').contains('void')
       })
+
+      cy.get('[data-test="return-due-date-1"]').should('have.value', '')
+      cy.get('[data-test="return-status-1"] > .govuk-tag').contains('not due yet')
 
       cy.get('[data-test="return-due-date-2"]').should('have.value', '')
       cy.get('[data-test="return-status-2"] > .govuk-tag').contains('not due yet')
 
-      cy.get('[data-test="return-due-date-3"]').should('have.value', '')
-      cy.get('[data-test="return-status-3"] > .govuk-tag').contains('not due yet')
-
       cy.returnLogDueData(summer.end, false).then((data) => {
-        cy.get('[data-test="return-due-date-4"]').contains(data.text)
-        cy.get('[data-test="return-status-4"] > .govuk-tag').contains('void')
+        cy.get('[data-test="return-due-date-3"]').contains(data.text)
+        cy.get('[data-test="return-status-3"] > .govuk-tag').contains('void')
       })
 
-      cy.get('[data-test="return-due-date-5"]').should('have.value', '')
-      cy.get('[data-test="return-status-5"] > .govuk-tag').contains('open')
+      cy.get('[data-test="return-due-date-4"]').should('have.value', '')
+      cy.get('[data-test="return-status-4"] > .govuk-tag').contains('open')
 
       cy.returnLogDueData(winter.end - 1, true).then((data) => {
-        cy.get('[data-test="return-due-date-6"]').contains(data.text)
-        cy.get('[data-test="return-status-6"] > .govuk-tag').contains('complete')
+        cy.get('[data-test="return-due-date-5"]').contains(data.text)
+        cy.get('[data-test="return-status-5"] > .govuk-tag').contains('complete')
       })
 
       cy.returnLogDueData(summer.end - 1, false).then((data) => {
-        cy.get('[data-test="return-due-date-7"]').contains(data.text)
-        cy.get('[data-test="return-status-7"] > .govuk-tag').contains('complete')
+        cy.get('[data-test="return-due-date-6"]').contains(data.text)
+        cy.get('[data-test="return-status-6"] > .govuk-tag').contains('complete')
       })
     })
   })

--- a/cypress/e2e/internal/return-logs/historic-corrections-03.cy.js
+++ b/cypress/e2e/internal/return-logs/historic-corrections-03.cy.js
@@ -67,13 +67,13 @@ describe('Submit historic correction using abstraction data for two abstraction 
     cy.contains('Set up new requirements').click()
 
     // set the start date to be 2 years in the past
-    cy.get('#another-start-date').check()
-    cy.get('#other-start-date-day').type('01')
-    cy.get('#other-start-date-month').type('11')
+    cy.get('#anotherStartDate').check()
+    cy.get('#startDateDay').type('01')
+    cy.get('#startDateMonth').type('11')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const startYear = currentFinancialYearInfo.start.year
 
-      cy.get('#other-start-date-year').type(startYear - 2)
+      cy.get('#startDateYear').type(startYear - 2)
     })
     cy.contains('Continue').click()
 
@@ -81,14 +81,14 @@ describe('Submit historic correction using abstraction data for two abstraction 
     cy.get('.govuk-heading-l').contains('Select the reason for the requirements for returns')
 
     // choose reason (new licence) and click continue
-    cy.get('#reason-10').check()
+    cy.get('#newLicence').check()
     cy.contains('Continue').click()
 
     // confirm we are on the set up page
     cy.get('.govuk-heading-l').contains('How do you want to set up the requirements for returns?')
 
     // choose the start by using abstraction data checkbox and continue
-    cy.get('#method').check()
+    cy.get('#useAbstractionData').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page

--- a/cypress/e2e/internal/return-logs/quarterly-01.cy.js
+++ b/cypress/e2e/internal/return-logs/quarterly-01.cy.js
@@ -60,24 +60,24 @@ describe('Submit winter and all year quarterly historic correction using abstrac
     cy.contains('Set up new requirements').click()
 
     // set the start date to be at the start of the all year return cycle
-    cy.get('#another-start-date').check()
-    cy.get('#other-start-date-day').type('01')
-    cy.get('#other-start-date-month').type('04')
-    cy.get('#other-start-date-year').type(year)
+    cy.get('#anotherStartDate').check()
+    cy.get('#startDateDay').type('01')
+    cy.get('#startDateMonth').type('04')
+    cy.get('#startDateYear').type(year)
     cy.contains('Continue').click()
 
     // confirm we are on the reason page
     cy.get('.govuk-heading-l').contains('Select the reason for the requirements for returns')
 
     // choose reason (new licence) and click continue
-    cy.get('#reason-10').check()
+    cy.get('#newLicence').check()
     cy.contains('Continue').click()
 
     // confirm we are on the set up page
     cy.get('.govuk-heading-l').contains('How do you want to set up the requirements for returns?')
 
     // choose the start by using abstraction data checkbox and continue
-    cy.get('#method').check()
+    cy.get('#useAbstractionData').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page

--- a/cypress/e2e/internal/return-versions/cancel-returns.cy.js
+++ b/cypress/e2e/internal/return-versions/cancel-returns.cy.js
@@ -64,10 +64,10 @@ describe('Cancel a return requirement (internal)', () => {
     cy.get('.govuk-heading-l').contains('Enter the abstraction period for the requirements for returns')
 
     // enter start and end dates for the abstraction period and click continue
-    cy.get('#abstraction-period-start-day').type('01')
-    cy.get('#abstraction-period-start-month').type('12')
-    cy.get('#abstraction-period-end-day').type('03')
-    cy.get('#abstraction-period-end-month').type('09')
+    cy.get('#abstractionPeriodStartDay').type('01')
+    cy.get('#abstractionPeriodStartMonth').type('12')
+    cy.get('#abstractionPeriodEndDay').type('03')
+    cy.get('#abstractionPeriodEndMonth').type('09')
     cy.contains('Continue').click()
 
     // confirm we are on the returns cycle page

--- a/cypress/e2e/internal/return-versions/cancel-returns.cy.js
+++ b/cypress/e2e/internal/return-versions/cancel-returns.cy.js
@@ -29,21 +29,21 @@ describe('Cancel a return requirement (internal)', () => {
     cy.contains('Set up new requirements').click()
 
     // choose the licence version start date and click continue
-    cy.get('#licence-start-date').check()
+    cy.get('#licenceStartDate').check()
     cy.contains('Continue').click()
 
     // confirm we are on the reason page
     cy.get('.govuk-heading-l').contains('Select the reason for the requirements for returns')
 
     // choose returns exception and click continue
-    cy.get('#reason-2').check()
+    cy.get('#changeToSpecialAgreement').check()
     cy.contains('Continue').click()
 
     // confirm we are on the set up page
     cy.get('.govuk-heading-l').contains('How do you want to set up the requirements for returns?')
 
     // click set up manually and continue
-    cy.get('#method-4').check()
+    cy.get('#setUpManually').check()
     cy.contains('Continue').click()
 
     // confirm we are on the purpose page
@@ -74,35 +74,35 @@ describe('Cancel a return requirement (internal)', () => {
     cy.get('.govuk-heading-l').contains('Select the returns cycle for the requirements for returns')
 
     // choose a returns cycle and continue
-    cy.get('#returns-cycle').check()
+    cy.get('#summer').check()
     cy.contains('Continue').click()
 
     // confirm we are on the site description page
     cy.get('.govuk-label').contains('Enter a site description for the requirements for returns')
 
     // enter a site description and continue
-    cy.get('#site-description').type('This is a valid site description')
+    cy.get('#siteDescription').type('This is a valid site description')
     cy.contains('Continue').click()
 
     // confirm we are on the readings collected page
     cy.get('.govuk-heading-l').contains('Select how often readings or volumes are collected')
 
     // choose a collected time frame and continue
-    cy.get('#frequency-collected').check()
+    cy.get('#frequencyCollectedDay').check()
     cy.contains('Continue').click()
 
     // confirm we are on the readings reported page
     cy.get('.govuk-heading-l').contains('Select how often readings or volumes are reported')
 
     // choose a reporting time frame and continue
-    cy.get('#frequency-reported').check()
+    cy.get('#frequencyReportedDay').check()
     cy.contains('Continue').click()
 
     // confirm we are on the agreements and exceptions page
     cy.get('.govuk-heading-l').contains('Select agreements and exceptions for the requirements for returns')
 
     // choose an agreement and exception and continue
-    cy.get('#agreements-exceptions').check()
+    cy.get('#gravityFill').check()
     cy.contains('Continue').click()
 
     // confirm we are on the check page

--- a/cypress/e2e/internal/return-versions/cancel-returns.cy.js
+++ b/cypress/e2e/internal/return-versions/cancel-returns.cy.js
@@ -74,7 +74,7 @@ describe('Cancel a return requirement (internal)', () => {
     cy.get('.govuk-heading-l').contains('Select the returns cycle for the requirements for returns')
 
     // choose a returns cycle and continue
-    cy.get('#returnsCycle').check()
+    cy.get('#returns-cycle').check()
     cy.contains('Continue').click()
 
     // confirm we are on the site description page
@@ -88,21 +88,21 @@ describe('Cancel a return requirement (internal)', () => {
     cy.get('.govuk-heading-l').contains('Select how often readings or volumes are collected')
 
     // choose a collected time frame and continue
-    cy.get('#frequencyCollected').check()
+    cy.get('#frequency-collected').check()
     cy.contains('Continue').click()
 
     // confirm we are on the readings reported page
     cy.get('.govuk-heading-l').contains('Select how often readings or volumes are reported')
 
     // choose a reporting time frame and continue
-    cy.get('#frequencyReported').check()
+    cy.get('#frequency-reported').check()
     cy.contains('Continue').click()
 
     // confirm we are on the agreements and exceptions page
     cy.get('.govuk-heading-l').contains('Select agreements and exceptions for the requirements for returns')
 
     // choose an agreement and exception and continue
-    cy.get('#agreementsExceptions').check()
+    cy.get('#agreements-exceptions').check()
     cy.contains('Continue').click()
 
     // confirm we are on the check page

--- a/cypress/e2e/internal/return-versions/copy-existing.cy.js
+++ b/cypress/e2e/internal/return-versions/copy-existing.cy.js
@@ -112,10 +112,10 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     cy.get('.govuk-heading-l').contains('Enter the abstraction period for the requirements for returns')
 
     // choose a start and end date then continue
-    cy.get('#abstraction-period-start-day').type('1')
-    cy.get('#abstraction-period-start-month').type('12')
-    cy.get('#abstraction-period-end-day').type('3')
-    cy.get('#abstraction-period-end-month').type('11')
+    cy.get('#abstractionPeriodStartDay').type('1')
+    cy.get('#abstractionPeriodStartMonth').type('12')
+    cy.get('#abstractionPeriodEndDay').type('3')
+    cy.get('#abstractionPeriodEndMonth').type('11')
     cy.contains('Continue').click()
 
     // confirm we are on the returns cycle page

--- a/cypress/e2e/internal/return-versions/copy-existing.cy.js
+++ b/cypress/e2e/internal/return-versions/copy-existing.cy.js
@@ -29,21 +29,19 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     cy.contains('Set up new requirements').click()
 
     // choose the licence version start date and click continue
-    cy.get('#licence-start-date').check()
+    cy.get('#licenceStartDate').check()
     cy.contains('Continue').click()
 
     // confirm we are on the reason page
     cy.get('.govuk-heading-l').contains('Select the reason for the requirements for returns')
 
-    // choose a reason (minor change) for the return and click continue
-    cy.get('#reason-8').check()
+    cy.get('#minorChange').check()
     cy.contains('Continue').click()
 
     // confirm we are on the set up page
     cy.get('.govuk-heading-l').contains('How do you want to set up the requirements for returns?')
 
-    // choose copy from existing requirements and continue
-    cy.get('#method-2').check()
+    cy.get('#useExistingRequirements').check()
     cy.contains('Continue').click()
 
     // confirm we are on the existing requirements page
@@ -124,36 +122,36 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     cy.get('.govuk-heading-l').contains('Select the returns cycle for the requirements for returns')
 
     // choose a returns cycle and continue
-    cy.get('#returns-cycle').check()
+    cy.get('#summer').check()
     cy.contains('Continue').click()
 
     // confirm we are on the site description page
     cy.get('.govuk-label').contains('Enter a site description for the requirements for returns')
 
     // input a site description and continue
-    cy.get('#site-description').type('Site description for another return requirement')
+    cy.get('#siteDescription').type('Site description for another return requirement')
     cy.contains('Continue').click()
 
     // confirm we are on the frequency collected page
     cy.get('.govuk-heading-l').contains('Select how often readings or volumes are collected')
 
     // choose a frequency for collection and continue
-    cy.get('#frequency-collected-2').check()
+    cy.get('#frequencyCollectedWeek').check()
     cy.contains('Continue').click()
 
     // confirm we are on the frequency reported page
     cy.get('.govuk-heading-l').contains('Select how often readings or volumes are reported')
 
     // choose a frequency for reporting and continue
-    cy.get('#frequency-reported-2').check()
+    cy.get('#frequencyReportedWeek').check()
     cy.contains('Continue').click()
 
     // confirm we are on the agreements and exceptions page
     cy.get('.govuk-heading-l').contains('Select agreements and exceptions for the requirements for returns')
 
     // choose some agreements and exceptions and continue
-    cy.get('#agreements-exceptions-2').check()
-    cy.get('#agreements-exceptions-3').check()
+    cy.get('#transferReAbstractionScheme').check()
+    cy.get('#twoPartTariff').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page

--- a/cypress/e2e/internal/return-versions/copy-existing.cy.js
+++ b/cypress/e2e/internal/return-versions/copy-existing.cy.js
@@ -124,7 +124,7 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     cy.get('.govuk-heading-l').contains('Select the returns cycle for the requirements for returns')
 
     // choose a returns cycle and continue
-    cy.get('#returnsCycle').check()
+    cy.get('#returns-cycle').check()
     cy.contains('Continue').click()
 
     // confirm we are on the site description page
@@ -138,22 +138,22 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     cy.get('.govuk-heading-l').contains('Select how often readings or volumes are collected')
 
     // choose a frequency for collection and continue
-    cy.get('#frequencyCollected-2').check()
+    cy.get('#frequency-collected-2').check()
     cy.contains('Continue').click()
 
     // confirm we are on the frequency reported page
     cy.get('.govuk-heading-l').contains('Select how often readings or volumes are reported')
 
     // choose a frequency for reporting and continue
-    cy.get('#frequencyReported-2').check()
+    cy.get('#frequency-reported-2').check()
     cy.contains('Continue').click()
 
     // confirm we are on the agreements and exceptions page
     cy.get('.govuk-heading-l').contains('Select agreements and exceptions for the requirements for returns')
 
     // choose some agreements and exceptions and continue
-    cy.get('#agreementsExceptions-2').check()
-    cy.get('#agreementsExceptions-3').check()
+    cy.get('#agreements-exceptions-2').check()
+    cy.get('#agreements-exceptions-3').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page

--- a/cypress/e2e/internal/return-versions/no-returns-required.cy.js
+++ b/cypress/e2e/internal/return-versions/no-returns-required.cy.js
@@ -32,14 +32,14 @@ describe('Submit no returns requirement (internal)', () => {
     cy.get('.govuk-heading-l').contains('Select the start date for the requirements for returns')
 
     // choose the licence version start date and click continue
-    cy.get('#licence-start-date').check()
+    cy.get('#licenceStartDate').check()
     cy.contains('Continue').click()
 
     // confirm we are on the why no returns required page
     cy.get('.govuk-heading-l').contains('Why are no returns required?')
 
     // choose returns exception and click continue
-    cy.get('#reason-2').check()
+    cy.get('#licenceConditionsDoNotRequireReturns').check()
     cy.contains('Continue').click()
 
     // confirm we are on the check page
@@ -59,7 +59,7 @@ describe('Submit no returns requirement (internal)', () => {
     cy.get('.govuk-heading-l').contains('Why are no returns required?')
 
     // choose returns exception and click continue
-    cy.get('#reason-3').check()
+    cy.get('#returnsException').check()
     cy.contains('Continue').click()
 
     // confirm we are back on check page and see the reason changes

--- a/cypress/e2e/internal/return-versions/returns-required.cy.js
+++ b/cypress/e2e/internal/return-versions/returns-required.cy.js
@@ -29,21 +29,21 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Set up new requirements').click()
 
     // choose the licence version start date and click continue
-    cy.get('#licence-start-date').check()
+    cy.get('#licenceStartDate').check()
     cy.contains('Continue').click()
 
     // confirm we are on the reason page
     cy.get('.govuk-heading-l').contains('Select the reason for the requirements for returns')
 
     // choose returns exception and click continue
-    cy.get('#reason-2').check()
+    cy.get('#changeToSpecialAgreement').check()
     cy.contains('Continue').click()
 
     // confirm we are on the set up page
     cy.get('.govuk-heading-l').contains('How do you want to set up the requirements for returns?')
 
     // click set up manually and continue
-    cy.get('#method-4').check()
+    cy.get('#setUpManually').check()
     cy.contains('Continue').click()
 
     // confirm we are on the purpose page
@@ -75,35 +75,35 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-heading-l').contains('Select the returns cycle for the requirements for returns')
 
     // choose a returns cycle and continue
-    cy.get('#returns-cycle').check()
+    cy.get('#summer').check()
     cy.contains('Continue').click()
 
     // confirm we are on the site description page
     cy.get('.govuk-label').contains('Enter a site description for the requirements for returns')
 
     // enter a site description and continue
-    cy.get('#site-description').type('This is a valid site description')
+    cy.get('#siteDescription').type('This is a valid site description')
     cy.contains('Continue').click()
 
     // confirm we are on the readings collected page
     cy.get('.govuk-heading-l').contains('Select how often readings or volumes are collected')
 
     // choose a collected time frame and continue
-    cy.get('#frequency-collected').check()
+    cy.get('#frequencyCollectedDay').check()
     cy.contains('Continue').click()
 
     // confirm we are on the readings reported page
     cy.get('.govuk-heading-l').contains('Select how often readings or volumes are reported')
 
     // choose a reporting time frame and continue
-    cy.get('#frequency-reported').check()
+    cy.get('#frequencyReportedDay').check()
     cy.contains('Continue').click()
 
     // confirm we are on the agreements and exceptions page
     cy.get('.govuk-heading-l').contains('Select agreements and exceptions for the requirements for returns')
 
     // choose an agreement and exception and continue
-    cy.get('#agreements-exceptions').check()
+    cy.get('#gravityFill').check()
     cy.contains('Continue').click()
 
     // confirm we are on the check page
@@ -116,10 +116,10 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('[data-test="change-start-date"]').click()
 
     // change start date and continue
-    cy.get('#another-start-date').check()
-    cy.get('#other-start-date-day').type('02')
-    cy.get('#other-start-date-month').type('08')
-    cy.get('#other-start-date-year').type('2023')
+    cy.get('#anotherStartDate').check()
+    cy.get('#startDateDay').type('02')
+    cy.get('#startDateMonth').type('08')
+    cy.get('#startDateYear').type('2023')
     cy.contains('Continue').click()
 
     // confirm we are back on check page and see the start date changes
@@ -133,7 +133,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('[data-test="change-reason"]').click()
 
     // change the reason and continue
-    cy.get('#reason-8').check()
+    cy.get('#minorChange').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the reason changes
@@ -200,7 +200,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('[data-test="change-returns-cycle-0"]').click()
 
     // change the returns cycle and continue
-    cy.get('#returns-cycle-2').check()
+    cy.get('#winterAndAllYear').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the returns cycle changes
@@ -214,8 +214,8 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('[data-test="change-site-description-0"]').click()
 
     // change the site description and continue
-    cy.get('#site-description').clear()
-    cy.get('#site-description').type('This is another valid site description')
+    cy.get('#siteDescription').clear()
+    cy.get('#siteDescription').type('This is another valid site description')
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the site description changes
@@ -229,7 +229,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('[data-test="change-frequency-collected-0"]').click()
 
     // change the collection frequency and continue
-    cy.get('#frequency-collected-2').check()
+    cy.get('#frequencyCollectedWeek').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the collection frequency changes
@@ -243,7 +243,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('[data-test="change-frequency-reported-0"]').click()
 
     // change the reporting frequency and continue
-    cy.get('#frequency-reported-3').check()
+    cy.get('#frequencyReportedMonth').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the reporting frequency changes
@@ -257,9 +257,9 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('[data-test="change-agreements-exceptions-0"]').click()
 
     // change the agreements exceptions and continue
-    cy.get('#agreements-exceptions').uncheck()
-    cy.get('#agreements-exceptions-2').check()
-    cy.get('#agreements-exceptions-3').check()
+    cy.get('#gravityFill').uncheck()
+    cy.get('#transferReAbstractionScheme').check()
+    cy.get('#twoPartTariff').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the agreements exceptions changes
@@ -297,35 +297,35 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-heading-l').contains('Select the returns cycle for the requirements for returns')
 
     // choose a returns cycle and continue
-    cy.get('#returns-cycle').check()
+    cy.get('#summer').check()
     cy.contains('Continue').click()
 
     // confirm we are on the site description page
     cy.get('.govuk-label').contains('Enter a site description for the requirements for returns')
 
     // enter a site description and continue
-    cy.get('#site-description').type('This is a valid site description for the second requirement')
+    cy.get('#siteDescription').type('This is a valid site description for the second requirement')
     cy.contains('Continue').click()
 
     // confirm we are on the readings collected page
     cy.get('.govuk-heading-l').contains('Select how often readings or volumes are collected')
 
     // choose a collected time frame and continue
-    cy.get('#frequency-collected-3').check()
+    cy.get('#frequencyCollectedMonth').check()
     cy.contains('Continue').click()
 
     // confirm we are on the readings reported page
     cy.get('.govuk-heading-l').contains('Select how often readings or volumes are reported')
 
     // choose a reporting time frame and continue
-    cy.get('#frequency-reported').check()
+    cy.get('#frequencyReportedDay').check()
     cy.contains('Continue').click()
 
     // confirm we are on the agreements and exceptions page
     cy.get('.govuk-heading-l').contains('Select agreements and exceptions for the requirements for returns')
 
     // choose a agreement and exception and continue
-    cy.get('#agreements-exceptions').check()
+    cy.get('#gravityFill').check()
     cy.contains('Continue').click()
 
     // confirm we are on the check page

--- a/cypress/e2e/internal/return-versions/returns-required.cy.js
+++ b/cypress/e2e/internal/return-versions/returns-required.cy.js
@@ -65,10 +65,10 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-heading-l').contains('Enter the abstraction period for the requirements for returns')
 
     // enter start and end dates for the abstraction period and click continue
-    cy.get('#abstraction-period-start-day').type('01')
-    cy.get('#abstraction-period-start-month').type('12')
-    cy.get('#abstraction-period-end-day').type('03')
-    cy.get('#abstraction-period-end-month').type('09')
+    cy.get('#abstractionPeriodStartDay').type('01')
+    cy.get('#abstractionPeriodStartMonth').type('12')
+    cy.get('#abstractionPeriodEndDay').type('03')
+    cy.get('#abstractionPeriodEndMonth').type('09')
     cy.contains('Continue').click()
 
     // confirm we are on the returns cycle page
@@ -178,15 +178,15 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('[data-test="change-abstraction-period-0"]').click()
 
     // change the abstraction period and continue
-    cy.get('#abstraction-period-start-day').clear()
-    cy.get('#abstraction-period-start-month').clear()
-    cy.get('#abstraction-period-end-day').clear()
-    cy.get('#abstraction-period-end-month').clear()
+    cy.get('#abstractionPeriodStartDay').clear()
+    cy.get('#abstractionPeriodStartMonth').clear()
+    cy.get('#abstractionPeriodEndDay').clear()
+    cy.get('#abstractionPeriodEndMonth').clear()
 
-    cy.get('#abstraction-period-start-day').type('02')
-    cy.get('#abstraction-period-start-month').type('10')
-    cy.get('#abstraction-period-end-day').type('05')
-    cy.get('#abstraction-period-end-month').type('12')
+    cy.get('#abstractionPeriodStartDay').type('02')
+    cy.get('#abstractionPeriodStartMonth').type('10')
+    cy.get('#abstractionPeriodEndDay').type('05')
+    cy.get('#abstractionPeriodEndMonth').type('12')
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the abstraction period changes
@@ -287,10 +287,10 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-heading-l').contains('Enter the abstraction period for the requirements for returns')
 
     // enter start and end dates for the abstraction period and click continue
-    cy.get('#abstraction-period-start-day').type('07')
-    cy.get('#abstraction-period-start-month').type('07')
-    cy.get('#abstraction-period-end-day').type('08')
-    cy.get('#abstraction-period-end-month').type('12')
+    cy.get('#abstractionPeriodStartDay').type('07')
+    cy.get('#abstractionPeriodStartMonth').type('07')
+    cy.get('#abstractionPeriodEndDay').type('08')
+    cy.get('#abstractionPeriodEndMonth').type('12')
     cy.contains('Continue').click()
 
     // confirm we are on the returns cycle page

--- a/cypress/e2e/internal/return-versions/returns-required.cy.js
+++ b/cypress/e2e/internal/return-versions/returns-required.cy.js
@@ -75,7 +75,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-heading-l').contains('Select the returns cycle for the requirements for returns')
 
     // choose a returns cycle and continue
-    cy.get('#returnsCycle').check()
+    cy.get('#returns-cycle').check()
     cy.contains('Continue').click()
 
     // confirm we are on the site description page
@@ -89,21 +89,21 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-heading-l').contains('Select how often readings or volumes are collected')
 
     // choose a collected time frame and continue
-    cy.get('#frequencyCollected').check()
+    cy.get('#frequency-collected').check()
     cy.contains('Continue').click()
 
     // confirm we are on the readings reported page
     cy.get('.govuk-heading-l').contains('Select how often readings or volumes are reported')
 
     // choose a reporting time frame and continue
-    cy.get('#frequencyReported').check()
+    cy.get('#frequency-reported').check()
     cy.contains('Continue').click()
 
     // confirm we are on the agreements and exceptions page
     cy.get('.govuk-heading-l').contains('Select agreements and exceptions for the requirements for returns')
 
     // choose an agreement and exception and continue
-    cy.get('#agreementsExceptions').check()
+    cy.get('#agreements-exceptions').check()
     cy.contains('Continue').click()
 
     // confirm we are on the check page
@@ -200,7 +200,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('[data-test="change-returns-cycle-0"]').click()
 
     // change the returns cycle and continue
-    cy.get('#returnsCycle-2').check()
+    cy.get('#returns-cycle-2').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the returns cycle changes
@@ -229,7 +229,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('[data-test="change-frequency-collected-0"]').click()
 
     // change the collection frequency and continue
-    cy.get('#frequencyCollected-2').check()
+    cy.get('#frequency-collected-2').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the collection frequency changes
@@ -243,7 +243,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('[data-test="change-frequency-reported-0"]').click()
 
     // change the reporting frequency and continue
-    cy.get('#frequencyReported-3').check()
+    cy.get('#frequency-reported-3').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the reporting frequency changes
@@ -257,9 +257,9 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('[data-test="change-agreements-exceptions-0"]').click()
 
     // change the agreements exceptions and continue
-    cy.get('#agreementsExceptions').uncheck()
-    cy.get('#agreementsExceptions-2').check()
-    cy.get('#agreementsExceptions-3').check()
+    cy.get('#agreements-exceptions').uncheck()
+    cy.get('#agreements-exceptions-2').check()
+    cy.get('#agreements-exceptions-3').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page and see the agreements exceptions changes
@@ -297,7 +297,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-heading-l').contains('Select the returns cycle for the requirements for returns')
 
     // choose a returns cycle and continue
-    cy.get('#returnsCycle').check()
+    cy.get('#returns-cycle').check()
     cy.contains('Continue').click()
 
     // confirm we are on the site description page
@@ -311,21 +311,21 @@ describe('Submit returns requirement (internal)', () => {
     cy.get('.govuk-heading-l').contains('Select how often readings or volumes are collected')
 
     // choose a collected time frame and continue
-    cy.get('#frequencyCollected-3').check()
+    cy.get('#frequency-collected-3').check()
     cy.contains('Continue').click()
 
     // confirm we are on the readings reported page
     cy.get('.govuk-heading-l').contains('Select how often readings or volumes are reported')
 
     // choose a reporting time frame and continue
-    cy.get('#frequencyReported').check()
+    cy.get('#frequency-reported').check()
     cy.contains('Continue').click()
 
     // confirm we are on the agreements and exceptions page
     cy.get('.govuk-heading-l').contains('Select agreements and exceptions for the requirements for returns')
 
     // choose a agreement and exception and continue
-    cy.get('#agreementsExceptions').check()
+    cy.get('#agreements-exceptions').check()
     cy.contains('Continue').click()
 
     // confirm we are on the check page

--- a/cypress/e2e/internal/return-versions/start-by-using-abstraction-data.cy.js
+++ b/cypress/e2e/internal/return-versions/start-by-using-abstraction-data.cy.js
@@ -29,21 +29,21 @@ describe('Submit returns requirement (internal) using abstraction data', () => {
     cy.contains('Set up new requirements').click()
 
     // choose the licence version start date and click continue
-    cy.get('#licence-start-date').check()
+    cy.get('#licenceStartDate').check()
     cy.contains('Continue').click()
 
     // confirm we are on the reason page
     cy.get('.govuk-heading-l').contains('Select the reason for the requirements for returns')
 
     // choose reason (new licence) and click continue
-    cy.get('#reason-10').check()
+    cy.get('#newLicence').check()
     cy.contains('Continue').click()
 
     // confirm we are on the set up page
     cy.get('.govuk-heading-l').contains('How do you want to set up the requirements for returns?')
 
     // choose the start by using abstraction data checkbox and continue
-    cy.get('#method').check()
+    cy.get('#useAbstractionData').check()
     cy.contains('Continue').click()
 
     // confirm we are back on the check page


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5200

This PR continues our tech debt of standardising how we use the layouts and views. This PR updates the return version set up journey to use the new standard. This involves updating some of the id selectors.