### PR TITLE
Update broken tests after recent changes

### DIFF
--- a/cypress/e2e/internal/monitoring-stations/abstraction-alerts/send-alert.cy.js
+++ b/cypress/e2e/internal/monitoring-stations/abstraction-alerts/send-alert.cy.js
@@ -98,6 +98,6 @@ describe('Send an abstraction alert (internal)', () => {
     cy.get('tbody').contains('external@example.com')
     cy.get('tbody').contains('AT/CURR/DAILY/01')
     cy.get('tbody').contains('Email')
-    cy.get('tbody').contains('Pending')
+    cy.get('tbody').should('not.include.text', 'Error')
   })
 })

--- a/cypress/e2e/internal/return-logs/historic-corrections-02.cy.js
+++ b/cypress/e2e/internal/return-logs/historic-corrections-02.cy.js
@@ -115,33 +115,36 @@ describe('Submit summer and winter and all year historic correction using abstra
       const winter = { start: currentFinancialYearInfo.start.year, end: currentFinancialYearInfo.end.year }
       const summer = { start: currentFinancialYearInfo.start.year - 1, end: currentFinancialYearInfo.end.year - 1 }
 
-      cy.returnLogDueData(winter.end, true).then((data) => {
-        cy.get('[data-test="return-due-date-0"]').contains(data.text)
-        cy.get('[data-test="return-status-0"] > .govuk-tag').contains('void')
+      cy.get('[data-test="return-due-date-0"]').should('have.value', '')
+      cy.get('[data-test="return-status-0"] > .govuk-tag').contains('not due yet')
 
-        cy.get('[data-test="return-due-date-2"]').should('have.value', '')
-        cy.get('[data-test="return-status-2"] > .govuk-tag').contains('not due yet')
+      cy.returnLogDueData(winter.end, true).then((data) => {
+        cy.get('[data-test="return-due-date-1"]').contains(data.text)
+        cy.get('[data-test="return-status-1"] > .govuk-tag').contains('void')
       })
+
+      cy.get('[data-test="return-due-date-2"]').should('have.value', '')
+      cy.get('[data-test="return-status-2"] > .govuk-tag').contains('not due yet')
+
+      cy.get('[data-test="return-due-date-3"]').should('have.value', '')
+      cy.get('[data-test="return-status-3"] > .govuk-tag').contains('not due yet')
 
       cy.returnLogDueData(summer.end, false).then((data) => {
-        cy.get('[data-test="return-due-date-1"]').should('have.value', '')
-        cy.get('[data-test="return-status-1"] > .govuk-tag').contains('not due yet')
-
-        cy.get('[data-test="return-due-date-3"]').contains(data.text)
-        cy.get('[data-test="return-status-3"] > .govuk-tag').contains('void')
-
-        cy.get('[data-test="return-due-date-4"]').should('have.value', '')
-        cy.get('[data-test="return-status-4"] > .govuk-tag').contains('not due yet')
+        cy.get('[data-test="return-due-date-4"]').contains(data.text)
+        cy.get('[data-test="return-status-4"] > .govuk-tag').contains('void')
       })
 
+      cy.get('[data-test="return-due-date-5"]').should('have.value', '')
+      cy.get('[data-test="return-status-5"] > .govuk-tag').contains('not due yet')
+
       cy.returnLogDueData(winter.end - 1, true).then((data) => {
-        cy.get('[data-test="return-due-date-5"]').contains(data.text)
-        cy.get('[data-test="return-status-5"] > .govuk-tag').contains('complete')
+        cy.get('[data-test="return-due-date-6"]').contains(data.text)
+        cy.get('[data-test="return-status-6"] > .govuk-tag').contains('complete')
       })
 
       cy.returnLogDueData(summer.end - 1, false).then((data) => {
-        cy.get('[data-test="return-due-date-6"]').contains(data.text)
-        cy.get('[data-test="return-status-6"] > .govuk-tag').contains('complete')
+        cy.get('[data-test="return-due-date-7"]').contains(data.text)
+        cy.get('[data-test="return-status-7"] > .govuk-tag').contains('complete')
       })
     })
   })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5212
https://eaflood.atlassian.net/browse/WATER-5281

We've made two recent changes to the service that require the acceptance tests to be updated to account for them.

The first is that we will soon no longer apply a due date to newly created return logs. We have a test that is still asserting that a due date is being set.

We have also updated our send notice process to automatically check the status of email notifications once they have been sent to Notify. Again, this means an assertion is failing because it is expecting `PENDING` when it could be `SENT` (or even `ERROR` if Notify is down).

This change updates those broken tests.