### PR TITLE
Update tests for new OPEN return status

### DIFF
--- a/cypress/e2e/external/view-returns.cy.js
+++ b/cypress/e2e/external/view-returns.cy.js
@@ -38,7 +38,7 @@ describe('View returns (external)', () => {
     cy.contains('AT/CURR/MONTHLY/02').click()
     cy.get('#tab_returns').click()
     cy.get('#returns').should('be.visible')
-    cy.get('.govuk-tag').should('be.visible').and('contain.text', 'not due yet')
+    cy.get('.govuk-tag').should('be.visible').and('contain.text', 'open')
     cy.get('.govuk-tag').should('be.visible').and('contain.text', 'overdue')
     cy.get('.govuk-tag').should('be.visible').and('contain.text', 'complete')
     cy.get('.govuk-tag').should('be.visible').and('contain.text', 'overdue')

--- a/cypress/e2e/internal/return-logs/historic-corrections-01.cy.js
+++ b/cypress/e2e/internal/return-logs/historic-corrections-01.cy.js
@@ -120,18 +120,18 @@ describe('Submit winter and all year historic correction using abstraction data'
         cy.get('[data-test="return-status-2"] > .govuk-tag').contains('void')
 
         cy.get('[data-test="return-due-date-3"]').should('have.value', '')
-        cy.get('[data-test="return-status-3"] > .govuk-tag').contains('not due yet')
+        cy.get('[data-test="return-status-3"] > .govuk-tag').contains('open')
       })
 
       cy.returnLogDueData(startYear - 1, true).then((data) => {
         cy.get('[data-test="return-due-date-4"]').should('have.value', '')
-        cy.get('[data-test="return-status-4"] > .govuk-tag').contains('not due yet')
+        cy.get('[data-test="return-status-4"] > .govuk-tag').contains('open')
 
         cy.get('[data-test="return-due-date-5"]').contains(data.text)
         cy.get('[data-test="return-status-5"] > .govuk-tag').contains('void')
 
         cy.get('[data-test="return-due-date-6"]').should('have.value', '')
-        cy.get('[data-test="return-status-6"] > .govuk-tag').contains('not due yet')
+        cy.get('[data-test="return-status-6"] > .govuk-tag').contains('open')
       })
 
       cy.returnLogDueData(startYear - 2, true).then((data) => {

--- a/cypress/e2e/internal/return-logs/historic-corrections-02.cy.js
+++ b/cypress/e2e/internal/return-logs/historic-corrections-02.cy.js
@@ -135,7 +135,7 @@ describe('Submit summer and winter and all year historic correction using abstra
       })
 
       cy.get('[data-test="return-due-date-5"]').should('have.value', '')
-      cy.get('[data-test="return-status-5"] > .govuk-tag').contains('not due yet')
+      cy.get('[data-test="return-status-5"] > .govuk-tag').contains('open')
 
       cy.returnLogDueData(winter.end - 1, true).then((data) => {
         cy.get('[data-test="return-due-date-6"]').contains(data.text)

--- a/cypress/e2e/internal/return-logs/historic-corrections-03.cy.js
+++ b/cypress/e2e/internal/return-logs/historic-corrections-03.cy.js
@@ -132,18 +132,18 @@ describe('Submit historic correction using abstraction data for two abstraction 
         cy.get('[data-test="return-status-5"] > .govuk-tag').contains('void')
 
         cy.get('[data-test="return-due-date-6"]').should('have.value', '')
-        cy.get('[data-test="return-status-6"] > .govuk-tag').contains('not due yet')
+        cy.get('[data-test="return-status-6"] > .govuk-tag').contains('open')
 
         cy.get('[data-test="return-due-date-7"]').should('have.value', '')
-        cy.get('[data-test="return-status-7"] > .govuk-tag').contains('not due yet')
+        cy.get('[data-test="return-status-7"] > .govuk-tag').contains('open')
       })
 
       cy.returnLogDueData(startYear - 1, true).then((data) => {
         cy.get('[data-test="return-due-date-8"]').should('have.value', '')
-        cy.get('[data-test="return-status-8"] > .govuk-tag').contains('not due yet')
+        cy.get('[data-test="return-status-8"] > .govuk-tag').contains('open')
 
         cy.get('[data-test="return-due-date-9"]').should('have.value', '')
-        cy.get('[data-test="return-status-9"] > .govuk-tag').contains('not due yet')
+        cy.get('[data-test="return-status-9"] > .govuk-tag').contains('open')
 
         cy.get('[data-test="return-due-date-10"]').contains(data.text)
         cy.get('[data-test="return-status-10"] > .govuk-tag').contains('void')
@@ -152,7 +152,7 @@ describe('Submit historic correction using abstraction data for two abstraction 
         cy.get('[data-test="return-status-11"] > .govuk-tag').contains('void')
 
         cy.get('[data-test="return-due-date-12"]').should('have.value', '')
-        cy.get('[data-test="return-status-12"] > .govuk-tag').contains('not due yet')
+        cy.get('[data-test="return-status-12"] > .govuk-tag').contains('open')
       })
     })
   })

--- a/cypress/e2e/internal/return-logs/quarterly-01.cy.js
+++ b/cypress/e2e/internal/return-logs/quarterly-01.cy.js
@@ -131,7 +131,7 @@ describe('Submit winter and all year quarterly historic correction using abstrac
       cy.get('[data-test="return-status-6"] > .govuk-tag').contains('void')
 
       cy.get('[data-test="return-due-date-7"]').should('have.value', '')
-      cy.get('[data-test="return-status-7"] > .govuk-tag').contains('not due yet')
+      cy.get('[data-test="return-status-7"] > .govuk-tag').contains('open')
     })
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5288

We have added a new status of `OPEN` for return logs that have ended, and either have no due date, or the due date is more than 28 days in the future.

We need to update the tests affected by this new status.