### PR TITLE
Update to use new View notice page

### DIFF
--- a/cypress/e2e/internal/monitoring-stations/abstraction-alerts/send-alert.cy.js
+++ b/cypress/e2e/internal/monitoring-stations/abstraction-alerts/send-alert.cy.js
@@ -79,16 +79,9 @@ describe('Send an abstraction alert (internal)', () => {
     // Confirm we are on the Alert sent confirmation page
     cy.get('.govuk-panel__title').contains('Water abstraction alerts sent')
     cy.get('.govuk-panel__body').contains('Your reference number is WAA-')
+    cy.get('p > a').contains('View notice').should('be.visible').click()
 
-    // View the notifications report and check the data is correct
-    cy.wait(1000) // Pause for 1 second to ensure the DB is updated with the new notification
-    cy.get('div.govuk-body > :nth-child(2) > .govuk-link').click()
-    cy.get('.govuk-caption-xl').should('have.text', 'Notification report')
-    cy.get('.govuk-heading-xl').should('have.text', 'Water abstraction alert')
-    cy.get('.govuk-caption-m').contains('WAA-')
-    cy.get('tbody').contains('external@example.com')
-    cy.get('tbody').contains('AT/TEST/01')
-    cy.get('tbody').contains('Email')
-    cy.get('tbody').should('not.include.text', 'Error')
+    // Warning alert
+    cy.get('h1').contains('Warning alert')
   })
 })

--- a/cypress/e2e/internal/notices/send-invite.cy.js
+++ b/cypress/e2e/internal/notices/send-invite.cy.js
@@ -37,9 +37,9 @@ describe('Send returns invite to customer (internal)', () => {
 
     // Returns invitations sent
     cy.get('.govuk-panel__title').should('contain', 'Returns invitations sent')
-    cy.get('p > a').contains('View notifications report').should('be.visible').click()
+    cy.get('p > a').contains('View notice').should('be.visible').click()
 
     // Returns: invitation
-    cy.get('h1').contains('Notification report')
+    cy.get('h1').contains('Returns invitation')
   })
 })

--- a/cypress/e2e/internal/notices/send-reminder.cy.js
+++ b/cypress/e2e/internal/notices/send-reminder.cy.js
@@ -39,10 +39,9 @@ describe('Send returns reminder to customer (internal)', () => {
 
     // Return reminders sent
     cy.get('.govuk-panel__title').should('contain', 'Returns reminders sent')
-    cy.get('p > a').contains('View notifications report').should('be.visible').click()
+    cy.get('p > a').contains('View notice').should('be.visible').click()
 
     // Returns: reminder
-    // it can take some time to generate the report hence the extra timeout
-    cy.get('h1').contains('Notification report')
+    cy.get('h1').contains('Returns reminder')
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4992

As part of migrating the legacy pages to [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system), we have previously replaced the view notices page. Now it's the turn of the view notice page, which is linked to when a user clicks a notice to view.

This change updates any tests that are affected by it.