### PR TITLE
Fix return log tests broken by view updates

### DIFF
--- a/cypress/e2e/internal/returns/record-receipt.cy.js
+++ b/cypress/e2e/internal/returns/record-receipt.cy.js
@@ -42,7 +42,7 @@ describe('Record receipt for return (internal)', () => {
     cy.get('.govuk-panel').contains('Spray Irrigation - Storage').should('be.visible')
 
     // View returns for the licence (this is a different view)
-    cy.get('div > a').contains('View returns for AT/TEST/01').should('be.visible').click()
+    cy.get('#main-content > .govuk-link').contains('View returns for AT/TEST/01').should('be.visible').click()
 
     // confirm we see the received return
     cy.get('[data-test="return-status-0"] > .govuk-tag').should('be.visible').and('contain.text', 'received')

--- a/cypress/e2e/internal/returns/submit.cy.js
+++ b/cypress/e2e/internal/returns/submit.cy.js
@@ -42,7 +42,7 @@ describe('Submit a return (internal)', () => {
 
     // Which units were used?
     // choose Cubic metres and continue
-    cy.get('input#units').check()
+    cy.get('#cubicMetres').check()
     cy.get('form > .govuk-button').click()
 
     // Have meter details been provided?
@@ -53,7 +53,7 @@ describe('Submit a return (internal)', () => {
     // Is it a single volume?
     // choose Yes, enter 100 cubic metres and continue
     cy.get('label.govuk-radios__label').contains('Yes').click()
-    cy.get('input#single-volume-quantity').type('100')
+    cy.get('#singleVolumeQuantity').type('100')
     cy.get('form > .govuk-button').click()
 
     // What period was used for this volume?

--- a/cypress/e2e/internal/supplementary-billing-flags/editing-a-return.cy.js
+++ b/cypress/e2e/internal/supplementary-billing-flags/editing-a-return.cy.js
@@ -26,38 +26,38 @@ describe('Editing a return (internal)', () => {
 
     // When was the return received?
     // choose Today and continue
-    cy.get('input#received-date-options').check()
+    cy.get('#today').check()
     cy.get('form > .govuk-button').click()
 
     // What do you want to do with this return?
     // choose Enter and submit and continue
-    cy.get('input#journey').check()
+    cy.get('#enterReturn').check()
     cy.get('form > .govuk-button').click()
 
     // How was this return reported?
     // choose Abstraction volumes and continue
-    cy.get('input#reported-2').check()
+    cy.get('#abstractionVolumes').check()
     cy.get('form > .govuk-button').click()
 
     // Which units were used?
     // choose Cubic metres and continue
-    cy.get('input#units').check()
+    cy.get('#cubicMetres').check()
     cy.get('form > .govuk-button').click()
 
     // Have meter details been provided?
     // choose No and continue
-    cy.get('input#meterProvided-2').check()
+    cy.get('#no').check()
     cy.get('form > .govuk-button').click()
 
     // Is it a single volume?
     // choose Yes, enter 100 cubic metres and continue
-    cy.get('input#singleVolume').check()
-    cy.get('input#single-volume-quantity').type('100')
+    cy.get('#yes').check()
+    cy.get('#singleVolumeQuantity').type('100')
     cy.get('form > .govuk-button').click()
 
     // What period was used for this volume?
     // choose Default abstraction period and continue
-    cy.get('input#periodDateUsedOptions').check()
+    cy.get('#default').check()
     cy.get('form > .govuk-button').click()
 
     // Confirm this return


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5153

In PR https://github.com/DEFRA/water-abstraction-system/pull/2213 the views have been updated for the `return-logs/setup` journey to get them up to our "template" standard.

Part of this update involved changing some of the ids in the views. As the acceptance tests rely on these ids several of them now fail. These failing tests will be fixed in this PR.