### PR TITLE
Return log tests summer cycle

### DIFF
--- a/cypress/e2e/internal/return-logs/change-return-cycle-type.cy.js
+++ b/cypress/e2e/internal/return-logs/change-return-cycle-type.cy.js
@@ -165,35 +165,71 @@ describe('Submit changing return cycle type on new return version', () => {
     cy.get('#returns > .govuk-heading-l').contains('Returns')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const endYear = currentFinancialYearInfo.end.year
+      const today = new Date()
+      const novemberToMarch = (today.getMonth() > 9 || today.getMonth() < 4)
 
-      cy.returnLogDueData(endYear, true).then((data) => {
-        cy.get('[data-test="return-due-date-0"]').contains(data.text)
-        cy.get('[data-test="return-status-0"] > .govuk-tag').contains('void')
-      })
+      if (novemberToMarch) {
+        cy.get('[data-test="return-due-date-0"]').should('have.value', '')
+        cy.get('[data-test="return-status-0"] > .govuk-tag').contains('not due yet')
 
-      cy.get('[data-test="return-due-date-1"]').should('have.value', '')
-      cy.get('[data-test="return-status-1"] > .govuk-tag').contains('not due yet')
+        cy.returnLogDueData(endYear, true).then((data) => {
+          cy.get('[data-test="return-due-date-1"]').contains(data.text)
+          cy.get('[data-test="return-status-1"] > .govuk-tag').contains('void')
+        })
 
-      cy.returnLogDueData(endYear - 1, true).then((data) => {
-        cy.get('[data-test="return-due-date-2"]').contains(data.text)
-        cy.get('[data-test="return-status-2"] > .govuk-tag').contains('void')
-      })
+        cy.get('[data-test="return-due-date-2"]').should('have.value', '')
+        cy.get('[data-test="return-status-2"] > .govuk-tag').contains('open')
 
-      cy.get('[data-test="return-due-date-3"]').should('have.value', '')
-      cy.get('[data-test="return-status-3"] > .govuk-tag').contains('open')
+        cy.returnLogDueData(endYear - 1, true).then((data) => {
+          cy.get('[data-test="return-due-date-3"]').contains(data.text)
+          cy.get('[data-test="return-status-3"] > .govuk-tag').contains('void')
+        })
 
-      cy.get('[data-test="return-due-date-4"]').should('have.value', '')
-      cy.get('[data-test="return-status-4"] > .govuk-tag').contains('open')
+        cy.get('[data-test="return-due-date-4"]').should('have.value', '')
+        cy.get('[data-test="return-status-4"] > .govuk-tag').contains('open')
 
-      cy.returnLogDueData(endYear - 2, true).then((data) => {
-        cy.get('[data-test="return-due-date-5"]').contains(data.text)
-        cy.get('[data-test="return-status-5"] > .govuk-tag').contains('void')
-      })
+        cy.get('[data-test="return-due-date-5"]').should('have.value', '')
+        cy.get('[data-test="return-status-5"] > .govuk-tag').contains('open')
 
-      cy.returnLogDueData(endYear - 3, true).then((data) => {
-        cy.get('[data-test="return-due-date-6"]').contains(data.text)
-        cy.get('[data-test="return-status-6"] > .govuk-tag').contains('complete')
-      })
+        cy.returnLogDueData(endYear - 2, true).then((data) => {
+          cy.get('[data-test="return-due-date-6"]').contains(data.text)
+          cy.get('[data-test="return-status-6"] > .govuk-tag').contains('void')
+        })
+
+        cy.returnLogDueData(endYear - 3, true).then((data) => {
+          cy.get('[data-test="return-due-date-7"]').contains(data.text)
+          cy.get('[data-test="return-status-7"] > .govuk-tag').contains('complete')
+        })
+      } else {
+        cy.returnLogDueData(endYear, true).then((data) => {
+          cy.get('[data-test="return-due-date-0"]').contains(data.text)
+          cy.get('[data-test="return-status-0"] > .govuk-tag').contains('void')
+        })
+
+        cy.get('[data-test="return-due-date-1"]').should('have.value', '')
+        cy.get('[data-test="return-status-1"] > .govuk-tag').contains('not due yet')
+
+        cy.returnLogDueData(endYear - 1, true).then((data) => {
+          cy.get('[data-test="return-due-date-2"]').contains(data.text)
+          cy.get('[data-test="return-status-2"] > .govuk-tag').contains('void')
+        })
+
+        cy.get('[data-test="return-due-date-3"]').should('have.value', '')
+        cy.get('[data-test="return-status-3"] > .govuk-tag').contains('open')
+
+        cy.get('[data-test="return-due-date-4"]').should('have.value', '')
+        cy.get('[data-test="return-status-4"] > .govuk-tag').contains('open')
+
+        cy.returnLogDueData(endYear - 2, true).then((data) => {
+          cy.get('[data-test="return-due-date-5"]').contains(data.text)
+          cy.get('[data-test="return-status-5"] > .govuk-tag').contains('void')
+        })
+
+        cy.returnLogDueData(endYear - 3, true).then((data) => {
+          cy.get('[data-test="return-due-date-6"]').contains(data.text)
+          cy.get('[data-test="return-status-6"] > .govuk-tag').contains('complete')
+        })
+      }
     })
   })
 })

--- a/cypress/e2e/internal/return-logs/historic-corrections-02.cy.js
+++ b/cypress/e2e/internal/return-logs/historic-corrections-02.cy.js
@@ -111,37 +111,74 @@ describe('Submit summer and winter and all year historic correction using abstra
     cy.get('#returns > .govuk-heading-l').contains('Returns')
 
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
+      const today = new Date()
+      const novemberToMarch = (today.getMonth() > 9 || today.getMonth() < 4)
+
       const winter = { start: currentFinancialYearInfo.start.year, end: currentFinancialYearInfo.end.year }
       const summer = { start: currentFinancialYearInfo.start.year - 1, end: currentFinancialYearInfo.end.year - 1 }
 
-      cy.get('[data-test="return-due-date-0"]').should('have.value', '')
-      cy.get('[data-test="return-status-0"] > .govuk-tag').contains('not due yet')
+      if (novemberToMarch) {
+        cy.get('[data-test="return-due-date-0"]').should('have.value', '')
+        cy.get('[data-test="return-status-0"] > .govuk-tag').contains('not due yet')
 
-      cy.get('[data-test="return-due-date-1"]').should('have.value', '')
-      cy.get('[data-test="return-status-1"] > .govuk-tag').contains('not due yet')
+        cy.get('[data-test="return-due-date-1"]').should('have.value', '')
+        cy.get('[data-test="return-status-1"] > .govuk-tag').contains('open')
 
-      cy.returnLogDueData(winter.end, true).then((data) => {
-        cy.get('[data-test="return-due-date-2"]').contains(data.text)
-        cy.get('[data-test="return-status-2"] > .govuk-tag').contains('void')
-      })
+        cy.get('[data-test="return-due-date-2"]').should('have.value', '')
+        cy.get('[data-test="return-status-2"] > .govuk-tag').contains('not due yet')
 
-      cy.get('[data-test="return-due-date-3"]').should('have.value', '')
-      cy.get('[data-test="return-status-3"] > .govuk-tag').contains('open')
+        cy.returnLogDueData(winter.end, true).then((data) => {
+          cy.get('[data-test="return-due-date-3"]').contains(data.text)
+          cy.get('[data-test="return-status-3"] > .govuk-tag').contains('void')
+        })
 
-      cy.returnLogDueData(summer.end, false).then((data) => {
-        cy.get('[data-test="return-due-date-4"]').contains(data.text)
-        cy.get('[data-test="return-status-4"] > .govuk-tag').contains('void')
-      })
+        cy.get('[data-test="return-due-date-4"]').should('have.value', '')
+        cy.get('[data-test="return-status-4"] > .govuk-tag').contains('open')
 
-      cy.returnLogDueData(winter.end - 1, true).then((data) => {
-        cy.get('[data-test="return-due-date-5"]').contains(data.text)
-        cy.get('[data-test="return-status-5"] > .govuk-tag').contains('complete')
-      })
+        cy.returnLogDueData(summer.end, false).then((data) => {
+          cy.get('[data-test="return-due-date-5"]').contains(data.text)
+          cy.get('[data-test="return-status-5"] > .govuk-tag').contains('void')
+        })
 
-      cy.returnLogDueData(summer.end - 1, false).then((data) => {
-        cy.get('[data-test="return-due-date-6"]').contains(data.text)
-        cy.get('[data-test="return-status-6"] > .govuk-tag').contains('complete')
-      })
+        cy.returnLogDueData(winter.end - 1, true).then((data) => {
+          cy.get('[data-test="return-due-date-6"]').contains(data.text)
+          cy.get('[data-test="return-status-6"] > .govuk-tag').contains('complete')
+        })
+
+        cy.returnLogDueData(summer.end - 1, false).then((data) => {
+          cy.get('[data-test="return-due-date-7"]').contains(data.text)
+          cy.get('[data-test="return-status-7"] > .govuk-tag').contains('complete')
+        })
+      } else {
+        cy.get('[data-test="return-due-date-0"]').should('have.value', '')
+        cy.get('[data-test="return-status-0"] > .govuk-tag').contains('open')
+
+        cy.get('[data-test="return-due-date-1"]').should('have.value', '')
+        cy.get('[data-test="return-status-1"] > .govuk-tag').contains('not due yet')
+
+        cy.returnLogDueData(winter.end, true).then((data) => {
+          cy.get('[data-test="return-due-date-2"]').contains(data.text)
+          cy.get('[data-test="return-status-2"] > .govuk-tag').contains('void')
+        })
+
+        cy.get('[data-test="return-due-date-3"]').should('have.value', '')
+        cy.get('[data-test="return-status-3"] > .govuk-tag').contains('open')
+
+        cy.returnLogDueData(summer.end, false).then((data) => {
+          cy.get('[data-test="return-due-date-4"]').contains(data.text)
+          cy.get('[data-test="return-status-4"] > .govuk-tag').contains('void')
+        })
+
+        cy.returnLogDueData(winter.end - 1, true).then((data) => {
+          cy.get('[data-test="return-due-date-5"]').contains(data.text)
+          cy.get('[data-test="return-status-5"] > .govuk-tag').contains('complete')
+        })
+
+        cy.returnLogDueData(summer.end - 1, false).then((data) => {
+          cy.get('[data-test="return-due-date-6"]').contains(data.text)
+          cy.get('[data-test="return-status-6"] > .govuk-tag').contains('complete')
+        })
+      }
     })
   })
 })


### PR DESCRIPTION
We recently swapped into a new summer return cycle (1st of November) which has highlighted that some of our return log tests that use both summer and all year cycles don't account for this change. 

We need to expect different results on the return page during November and March. When the new all year cycle starts in April the tests will then change again. This PR adds in an if clause to handle this change over. 