### PR TITLE
Add Ad-Hoc returns invitations test

### DIFF
--- a/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
@@ -84,28 +84,28 @@ describe('Ad-hoc returns invitation journey (internal)', () => {
     // Additional recipient is shown in the list
     cy.get('@noticeRecipients').then(({ licenceNumber, singleUseLetter, primaryUserEmail }) => {
       cy.get('[data-test^="recipient-contact"]').should('have.length', 2)
-      cy.get('[data-test="recipient-contact0"]').within(() => {
+      cy.get('[data-test="recipient-contact-0"]').within(() => {
         cy.contains(singleUseLetter.contactName)
         cy.contains(singleUseLetter.address.line1)
         cy.contains(singleUseLetter.address.line2)
         cy.contains(singleUseLetter.address.line3)
         cy.contains(singleUseLetter.address.postcode)
       })
-      cy.get('[data-test="recipient-licence-numbers0"]').should('contain.text', licenceNumber)
-      cy.get('[data-test="recipient-method0"]').should('contain.text', singleUseLetter.method)
-      cy.get('[data-test="recipient-action0"]').within(() => {
+      cy.get('[data-test="recipient-licence-numbers-0"]').should('contain.text', licenceNumber)
+      cy.get('[data-test="recipient-method-0"]').should('contain.text', singleUseLetter.method)
+      cy.get('[data-test="recipient-action-0"]').within(() => {
         cy.contains('Preview')
       })
 
-      cy.get('[data-test="recipient-contact1"]').should('contain.text', primaryUserEmail.email)
-      cy.get('[data-test="recipient-licence-numbers1"]').should('contain.text', licenceNumber)
-      cy.get('[data-test="recipient-method1"]').should('contain.text', primaryUserEmail.method)
-      cy.get('[data-test="recipient-action1"]').within(() => {
+      cy.get('[data-test="recipient-contact-1"]').should('contain.text', primaryUserEmail.email)
+      cy.get('[data-test="recipient-licence-numbers-1"]').should('contain.text', licenceNumber)
+      cy.get('[data-test="recipient-method-1"]').should('contain.text', primaryUserEmail.method)
+      cy.get('[data-test="recipient-action-1"]').within(() => {
         cy.contains('Preview')
       })
     })
 
-    cy.get('[data-test="recipient-action0"]').contains('Preview').click()
+    cy.get('[data-test="recipient-action-0"]').contains('Preview').click()
 
     // Preview contains the contact name and address
     cy.contains('Returns invitation licence holder letter')

--- a/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
@@ -1,0 +1,108 @@
+'use strict'
+
+import scenarioData from '../../../../support/scenarios/return-notices.js'
+
+describe('Ad-hoc returns invitation journey (internal)', () => {
+  beforeEach(() => {
+    cy.tearDown()
+    cy.calculatedDates().then((body) => {
+      const scenario = scenarioData(body.firstReturnPeriod)
+
+      cy.load(scenario)
+    })
+
+    cy.fixture('users.json').its('billingAndData').as('userEmail')
+  })
+
+  it('invites a customer to submit returns', () => {
+    cy.get('@userEmail').then((userEmail) => {
+      cy.programmaticLogin({
+        email: userEmail
+      })
+    })
+
+    // Navigate to the Notices page
+    cy.visit('/system/notices')
+
+    // Start the standard notice journey
+    cy.get('.govuk-button').contains('Create an ad-hoc notice').click()
+
+    // Enter a licence number
+    cy.get('#licenceRef').type('AT/TEST/01')
+    cy.get('button.govuk-button').click()
+
+    // Select the notice type
+    cy.get('#noticeType').check()
+    cy.contains('Continue').click()
+
+    // Check the notice type
+    cy.get('[data-test="licence-number"]').should('contain.text', 'AT/TEST/01')
+    cy.get('[data-test="returns-notice-type"]').should('contain.text', 'Returns invitation')
+    cy.contains('Confirm').click()
+
+    // Capture the notice reference so we can verify it later
+    cy.contains('.govuk-caption-l', 'Notice').invoke('text').then((text) => {
+      cy.wrap(text.trim()).as('noticeReference')
+    })
+
+    // Recipients count
+    cy.contains('Showing all 1 recipients')
+
+    // Add an additional recipient
+    cy.contains('Manage recipients').click()
+    cy.contains('Set up a single use address or email address').click()
+
+    // Select 'post' and add the contacts name
+    cy.get('#contactType-2').check()
+    cy.get('#contactName').type('Pomona Sprout')
+    cy.get('button.govuk-button').click()
+
+    // Enter the postcode
+    cy.get('#postcode').type('BS1 5AH')
+    cy.get('button.govuk-button').click()
+
+    // Select the address returned from the lookup (rate limited so pause briefly)
+    cy.wait(1000)
+    cy.get('#addresses').select('340116')
+    cy.get('button.govuk-button').click()
+
+    // Recipients count
+    cy.contains('Showing all 2 recipients')
+
+    // Additional recipient is shown in the list
+    cy.contains('Pomona Sprout')
+    cy.contains('Letter - Single use')
+    cy.contains('tr', 'Letter - Single use')
+      .within(() => {
+        cy.contains('a', 'Preview').click()
+      })
+
+    // Preview contains the contact name and address
+    cy.contains('Returns invitation licence holder letter')
+    cy.contains('Pomona Sprout')
+    cy.get('.govuk-back-link').click()
+
+    // Check the recipients
+    cy.contains('Send').click()
+
+    // Notice confirmation
+    cy.get('.govuk-panel__title', { timeout: 15000 }).contains('Returns invitations sent')
+    cy.get('.govuk-link').contains('View notice').click()
+
+    // Notice page contains the recipients
+    cy.get('@noticeReference').then((noticeReference) => {
+      cy.contains('.govuk-caption-l', noticeReference)
+    })
+    cy.contains('Showing all 2 notifications')
+    cy.get('[data-test^="notification-recipient"]').should('have.length', 2)
+    cy.get('[data-test="notification-recipient0"]').within(() => {
+      cy.contains('external@example.com')
+    })
+    cy.get('[data-test="notification-recipient1"]').within(() => {
+      cy.contains('Pomona Sprout')
+      cy.contains('ENVIRONMENT AGENCY')
+      cy.contains('HORIZON HOUSE')
+      cy.contains('BS1 5AH')
+    })
+  })
+})

--- a/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
@@ -62,6 +62,9 @@ describe('Ad-hoc returns invitation journey (internal)', () => {
     cy.get('button.govuk-button').click()
 
     // Select the address returned from the lookup (rate limited so pause briefly)
+    // we have to wait a second. Both the lookup and selecting the address result in a call to the address facade which
+    // has rate monitoring protection. Because we're automating the calls, they happen to quickly so the facade rejects
+    // the second call. Hence we need to wait a second.
     cy.wait(1000)
     cy.get('#addresses').select('340116')
     cy.get('button.govuk-button').click()
@@ -72,6 +75,7 @@ describe('Ad-hoc returns invitation journey (internal)', () => {
     // Additional recipient is shown in the list
     cy.contains('Pomona Sprout')
     cy.contains('Letter - Single use')
+
     cy.contains('tr', 'Letter - Single use')
       .within(() => {
         cy.contains('a', 'Preview').click()
@@ -93,11 +97,14 @@ describe('Ad-hoc returns invitation journey (internal)', () => {
     cy.get('@noticeReference').then((noticeReference) => {
       cy.contains('.govuk-caption-l', noticeReference)
     })
+
     cy.contains('Showing all 2 notifications')
+
     cy.get('[data-test^="notification-recipient"]').should('have.length', 2)
     cy.get('[data-test="notification-recipient0"]').within(() => {
       cy.contains('external@example.com')
     })
+
     cy.get('[data-test="notification-recipient1"]').within(() => {
       cy.contains('Pomona Sprout')
       cy.contains('ENVIRONMENT AGENCY')

--- a/cypress/fixtures/notice-recipients.json
+++ b/cypress/fixtures/notice-recipients.json
@@ -1,0 +1,17 @@
+{
+  "licenceNumber": "AT/TEST/01",
+  "singleUseLetter": {
+    "contactName": "Pomona Sprout",
+    "address": {
+      "line1": "ENVIRONMENT AGENCY",
+      "line2": "HORIZON HOUSE DEANERY ROAD",
+      "line3": "BRISTOL",
+      "postcode": "BS1 5AH"
+    },
+    "method": "Letter - Single use"
+  },
+  "primaryUserEmail": {
+    "email": "external@example.com",
+    "method": "Email - Primary user"
+  }
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5389

Adds an ad-hoc returns invitation journey test which adds a postal recipient and then previews the notification

Adds a test to check the Notice page is displayed after the confirmation and all of the recipients are listed