### PR TITLE
Update selector for recalculate bills test

### DIFF
--- a/cypress/e2e/internal/supplementary-billing-flags/recalculate-bills-link.cy.js
+++ b/cypress/e2e/internal/supplementary-billing-flags/recalculate-bills-link.cy.js
@@ -31,7 +31,7 @@ describe('Recalculate Bills Link (internal)', () => {
     // You've marked this licence for the next supplementary bill run
     // confirm we see the success panel and then click the link to return to the licence
     cy.get('.govuk-panel').should('contain.text', "You've marked this licence for the next supplementary bill run")
-    cy.get(':nth-child(4) > .govuk-link').click()
+    cy.get('.govuk-body > .govuk-link').click()
 
     // Check the new licence agreement has flagged the licence for supplementary billing
     cy.get('.govuk-notification-banner__content')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5372

In [Update the licence mark and marked supplementary pages to the template standard](https://github.com/DEFRA/water-abstraction-system/pull/2637), we updated the pages used in the recalculate bills journey to "template standard".

However, this resulted in a change in the attributes of a link on the confirmation page that the test selects.

This updates the selector for it.