### PR TITLE
Update licence based tests to secondary navigation

### DIFF
--- a/cypress/e2e/internal/charge-information/presroc/licence-transfer.cy.js
+++ b/cypress/e2e/internal/charge-information/presroc/licence-transfer.cy.js
@@ -148,6 +148,9 @@ describe('PRESROC licence transfer (internal)', () => {
     // bill run
     cy.contains('Review').should('not.exist')
 
+    // Navigate to the Licence summary page
+    cy.contains('nav a', 'Licence summary').click()
+
     cy.get('.govuk-notification-banner__content')
       .should('contain.text', 'This licence has been marked for the next supplementary bill run for the old charge scheme.')
   })

--- a/cypress/e2e/internal/charge-information/sroc/journey.cy.js
+++ b/cypress/e2e/internal/charge-information/sroc/journey.cy.js
@@ -202,6 +202,9 @@ describe('SROC charge information journey (internal)', () => {
     // bill run
     cy.contains('Review').should('not.exist')
 
+    // Navigate to the Licence summary page
+    cy.contains('nav a', 'Licence summary').click()
+
     cy.get('.govuk-notification-banner__content')
       .should('contain.text', 'This licence has been marked for the next supplementary bill run.')
   })

--- a/cypress/e2e/internal/licence-agreements/delete-licence-agreement.cy.js
+++ b/cypress/e2e/internal/licence-agreements/delete-licence-agreement.cy.js
@@ -50,8 +50,8 @@ describe('Delete licence agreement journey (internal)', () => {
     cy.contains('Delete agreement').click()
 
     // Charge information
-    // confirm we are back on the Charge Information tab and our licence agreement is no longer present
-    // cy.get('#set-up').should('be.visible')
+    // confirm we are back on the Charge Information page and our licence agreement is no longer present
+    cy.get('h1').should('contain.text', 'Licence set up')
     cy.contains('No agreements for this licence.')
 
     // Navigate to back to the Licence summary page

--- a/cypress/e2e/internal/licence-agreements/delete-licence-agreement.cy.js
+++ b/cypress/e2e/internal/licence-agreements/delete-licence-agreement.cy.js
@@ -19,11 +19,19 @@ describe('Delete licence agreement journey (internal)', () => {
         email: userEmail
       })
     })
-    cy.visit(`/system/licences/${scenario.licences[0].id}/set-up`)
+
+    cy.visit(`/system/licences/${scenario.licences[0].id}/summary`)
+
+    // Check there are no notification banners present initially
+    cy.get('.govuk-notification-banner__content').should('not.exist')
+
+
+    // Navigate to the Licence set up page
+    cy.contains('nav a', 'Licence set up').click();
+    cy.get('h1').should('contain.text', 'Licence set up')
 
     // Charge information
-    // On the Charge Information tab select to delete the licence
-    cy.get('#set-up').should('be.visible')
+    // On the Licence set up page select to delete the licence
     cy.contains('Delete').click()
 
     // You're about to delete this agreement
@@ -44,8 +52,11 @@ describe('Delete licence agreement journey (internal)', () => {
 
     // Charge information
     // confirm we are back on the Charge Information tab and our licence agreement is no longer present
-    cy.get('#set-up').should('be.visible')
-    cy.should('contain.text', 'No agreements for this licence.')
+    // cy.get('#set-up').should('be.visible')
+    cy.contains('No agreements for this licence.')
+
+    // Navigate to back to the Licence summary page
+    cy.contains('nav a', 'Licence summary').click();
 
     // Check the new licence agreement has flagged the licence for supplementary billing
     cy.get('.govuk-notification-banner__content')

--- a/cypress/e2e/internal/licence-agreements/delete-licence-agreement.cy.js
+++ b/cypress/e2e/internal/licence-agreements/delete-licence-agreement.cy.js
@@ -25,9 +25,8 @@ describe('Delete licence agreement journey (internal)', () => {
     // Check there are no notification banners present initially
     cy.get('.govuk-notification-banner__content').should('not.exist')
 
-
     // Navigate to the Licence set up page
-    cy.contains('nav a', 'Licence set up').click();
+    cy.contains('nav a', 'Licence set up').click()
     cy.get('h1').should('contain.text', 'Licence set up')
 
     // Charge information
@@ -56,7 +55,7 @@ describe('Delete licence agreement journey (internal)', () => {
     cy.contains('No agreements for this licence.')
 
     // Navigate to back to the Licence summary page
-    cy.contains('nav a', 'Licence summary').click();
+    cy.contains('nav a', 'Licence summary').click()
 
     // Check the new licence agreement has flagged the licence for supplementary billing
     cy.get('.govuk-notification-banner__content')

--- a/cypress/e2e/internal/licence-agreements/end-licence-agreement.cy.js
+++ b/cypress/e2e/internal/licence-agreements/end-licence-agreement.cy.js
@@ -26,12 +26,12 @@ describe('End licence agreement journey (internal)', () => {
     cy.get('.govuk-notification-banner__content').should('not.exist')
 
     // Navigate to the Licence set up page
-    cy.contains('nav a', 'Licence set up').click();
+    cy.contains('nav a', 'Licence set up').click()
     cy.get('h1').should('contain.text', 'Licence set up')
 
     // Charge information
     // On the Charge Information tab select to end the licence
-    cy.get('[data-test="end-agreement-0"]').click();
+    cy.get('[data-test="end-agreement-0"]').click()
 
     // Set agreement end date
     // first check the validation for invalid dates is working
@@ -78,7 +78,7 @@ describe('End licence agreement journey (internal)', () => {
     })
 
     // Navigate to back to the Licence summary page
-    cy.contains('nav a', 'Licence summary').click();
+    cy.contains('nav a', 'Licence summary').click()
 
     // Check the new licence agreement has flagged the licence for supplementary billing
     cy.get('.govuk-notification-banner__content')

--- a/cypress/e2e/internal/licence-agreements/end-licence-agreement.cy.js
+++ b/cypress/e2e/internal/licence-agreements/end-licence-agreement.cy.js
@@ -19,12 +19,19 @@ describe('End licence agreement journey (internal)', () => {
         email: userEmail
       })
     })
-    cy.visit(`/system/licences/${scenario.licences[0].id}/set-up`)
+
+    cy.visit(`/system/licences/${scenario.licences[0].id}/summary`)
+
+    // Check there are no notification banners present initially
+    cy.get('.govuk-notification-banner__content').should('not.exist')
+
+    // Navigate to the Licence set up page
+    cy.contains('nav a', 'Licence set up').click();
+    cy.get('h1').should('contain.text', 'Licence set up')
 
     // Charge information
     // On the Charge Information tab select to end the licence
-    cy.get('#set-up').should('be.visible')
-    cy.get(':nth-child(12) > .govuk-table__body > .govuk-table__row > :nth-child(5)').contains('End').click()
+    cy.get('[data-test="end-agreement-0"]').click();
 
     // Set agreement end date
     // first check the validation for invalid dates is working
@@ -57,21 +64,21 @@ describe('End licence agreement journey (internal)', () => {
     // Charge information
     // confirm we are back on the licence set up tab and our licence agreement is present with an end date and only
     // the delete action available
-    cy.get('#set-up').should('be.visible')
+    cy.get('h1').should('contain.text', 'Licence set up')
 
-    cy.get(':nth-child(12) > .govuk-table__body > .govuk-table__row').within(() => {
-      // start date
-      cy.get(':nth-child(1)').should('contain.text', '1 January 2018')
-      // end date
-      cy.get(':nth-child(2)').should('contain.text', '31 March 2022')
-      // agreement
-      cy.get(':nth-child(3)').should('contain.text', 'Two-part tariff')
-      // date signed
-      cy.get(':nth-child(4)').should('contain.text', '')
-      // actions
-      cy.get(':nth-child(5) > a:nth-child(1)').should('contain.text', 'Delete')
-      cy.get(':nth-child(5) > a:nth-child(2)').should('not.exist')
+    cy.contains('tbody tr', 'Two-part tariff').within(() => {
+      cy.get('td').eq(0).should('contain.text', '1 January 2018')
+      cy.get('td').eq(1).should('contain.text', '31 March 2022')
+      cy.get('td').eq(2).should('contain.text', 'Two-part tariff')
+      cy.get('td').eq(3).should('contain.text', '')
+      cy.get('td').eq(4).within(() => {
+        cy.contains('Delete').should('exist')
+        cy.contains('End').should('not.exist')
+      })
     })
+
+    // Navigate to back to the Licence summary page
+    cy.contains('nav a', 'Licence summary').click();
 
     // Check the new licence agreement has flagged the licence for supplementary billing
     cy.get('.govuk-notification-banner__content')

--- a/cypress/e2e/internal/licence-agreements/new-licence-agreement.cy.js
+++ b/cypress/e2e/internal/licence-agreements/new-licence-agreement.cy.js
@@ -59,7 +59,7 @@ describe('New licence agreement journey (internal)', () => {
     cy.get('form > .govuk-button').click()
 
     // Charge information
-    // confirm we are back on the Charge Information tab and our licence agreement is present
+    // confirm we are back on the Charge Information page and our licence agreement is present
     cy.get('h1').should('contain.text', 'Licence set up')
 
     cy.contains('tbody tr', '1 April 2018').within(() => {

--- a/cypress/e2e/internal/licence-agreements/new-licence-agreement.cy.js
+++ b/cypress/e2e/internal/licence-agreements/new-licence-agreement.cy.js
@@ -19,7 +19,15 @@ describe('New licence agreement journey (internal)', () => {
         email: userEmail
       })
     })
-    cy.visit(`/system/licences/${scenario.licences[0].id}/set-up`)
+
+    cy.visit(`/system/licences/${scenario.licences[0].id}/summary`)
+
+    // Check there are no notification banners present initially
+    cy.get('.govuk-notification-banner__content').should('not.exist')
+
+    // Navigate to the Licence set up page
+    cy.contains('nav a', 'Licence set up').click();
+    cy.get('h1').should('contain.text', 'Licence set up')
 
     // Confirm we are on the tab page and then click Set up a new agreement
     cy.contains('Charge information')
@@ -52,21 +60,22 @@ describe('New licence agreement journey (internal)', () => {
 
     // Charge information
     // confirm we are back on the Charge Information tab and our licence agreement is present
-    cy.get('#set-up').should('be.visible')
+    cy.get('h1').should('contain.text', 'Licence set up')
 
-    cy.get(':nth-child(12) > .govuk-table__body > .govuk-table__row').within(() => {
-      // start date
-      cy.get(':nth-child(1)').should('contain.text', '1 April 2018')
-      // end date
-      cy.get(':nth-child(2)').should('contain.text', '')
-      // agreement
-      cy.get(':nth-child(3)').should('contain.text', 'Two-part tariff')
-      // date signed
-      cy.get(':nth-child(4)').should('contain.text', '')
-      // actions
-      cy.get(':nth-child(5) > a:nth-child(1)').should('contain.text', 'Delete')
-      cy.get(':nth-child(5) > a:nth-child(2)').should('contain.text', 'End')
+    cy.contains('tbody tr', '1 April 2018').within(() => {
+      cy.get('td').eq(0).should('contain.text', '1 April 2018')   // start date
+      cy.get('td').eq(1).should('contain.text', '')               // end date
+      cy.get('td').eq(2).should('contain.text', 'Two-part tariff')// agreement
+      cy.get('td').eq(3).should('contain.text', '')               // date signed
+
+      cy.get('td').eq(4).within(() => {                           // actions
+        cy.contains('Delete').should('exist')
+        cy.contains('End').should('exist')
+      })
     })
+
+    // Navigate to back to the Licence summary page
+    cy.contains('nav a', 'Licence summary').click();
 
     // Check the new licence agreement has flagged the licence for supplementary billing
     cy.get('.govuk-notification-banner__content')

--- a/cypress/e2e/internal/licence-agreements/new-licence-agreement.cy.js
+++ b/cypress/e2e/internal/licence-agreements/new-licence-agreement.cy.js
@@ -26,7 +26,7 @@ describe('New licence agreement journey (internal)', () => {
     cy.get('.govuk-notification-banner__content').should('not.exist')
 
     // Navigate to the Licence set up page
-    cy.contains('nav a', 'Licence set up').click();
+    cy.contains('nav a', 'Licence set up').click()
     cy.get('h1').should('contain.text', 'Licence set up')
 
     // Confirm we are on the tab page and then click Set up a new agreement
@@ -63,19 +63,19 @@ describe('New licence agreement journey (internal)', () => {
     cy.get('h1').should('contain.text', 'Licence set up')
 
     cy.contains('tbody tr', '1 April 2018').within(() => {
-      cy.get('td').eq(0).should('contain.text', '1 April 2018')   // start date
-      cy.get('td').eq(1).should('contain.text', '')               // end date
+      cy.get('td').eq(0).should('contain.text', '1 April 2018') // start date
+      cy.get('td').eq(1).should('contain.text', '') // end date
       cy.get('td').eq(2).should('contain.text', 'Two-part tariff')// agreement
-      cy.get('td').eq(3).should('contain.text', '')               // date signed
+      cy.get('td').eq(3).should('contain.text', '') // date signed
 
-      cy.get('td').eq(4).within(() => {                           // actions
+      cy.get('td').eq(4).within(() => { // actions
         cy.contains('Delete').should('exist')
         cy.contains('End').should('exist')
       })
     })
 
     // Navigate to back to the Licence summary page
-    cy.contains('nav a', 'Licence summary').click();
+    cy.contains('nav a', 'Licence summary').click()
 
     // Check the new licence agreement has flagged the licence for supplementary billing
     cy.get('.govuk-notification-banner__content')

--- a/cypress/e2e/internal/licence/view-contacts.cy.js
+++ b/cypress/e2e/internal/licence/view-contacts.cy.js
@@ -22,7 +22,7 @@ describe("View a licence's contacts (internal)", () => {
     cy.visit(`/system/licences/${scenario.licences[0].id}/contact-details`)
 
     // Confirm we are on the licence contact details page and expected controls are present
-    cy.get('#contact-details > .govuk-heading-l').contains('Contact details')
+    cy.get('h1').should('contain.text', 'Contact details')
     cy.get('.govuk-body > .govuk-link').contains('Go to customer contacts')
 
     // Confirm we can see expected licence holder contact details

--- a/cypress/e2e/internal/monitoring-stations/licence-tagging/no-linked-condition.cy.js
+++ b/cypress/e2e/internal/monitoring-stations/licence-tagging/no-linked-condition.cy.js
@@ -78,7 +78,7 @@ describe('Tag a licence that is not linked to a condition (internal)', () => {
 
     // Confirm the licence is linked to the monitoring station in the licence summary
     cy.get('[data-test="licence-ref-0"]').contains('AT/TEST/01').click()
-    cy.get('.govuk-heading-l').contains('Licence number AT/TEST/01')
+    cy.get('h1').should('contain.text', 'Licence summary AT/TEST/01')
     cy.get('.govuk-list').contains('Test Station')
   })
 })

--- a/cypress/e2e/internal/return-logs/submit-nil-return.cy.js
+++ b/cypress/e2e/internal/return-logs/submit-nil-return.cy.js
@@ -45,6 +45,9 @@ describe('Submit a nil return (internal)', () => {
     cy.get('.govuk-panel').should('contain.text', 'Return 9999990 submitted')
     cy.get('.govuk-button').contains('Mark for supplementary bill run').click()
 
+    // Navigate to the Licence summary page
+    cy.contains('nav a', 'Licence summary').click()
+
     // Summary
     // confirm the licence has been flagged for the next supplementary bill run for the old charge scheme
     cy.get('.govuk-notification-banner__content').should(

--- a/cypress/e2e/internal/return-logs/submit-single-volume.cy.js
+++ b/cypress/e2e/internal/return-logs/submit-single-volume.cy.js
@@ -71,6 +71,9 @@ describe('Submit a single volume return (internal)', () => {
     cy.get('.govuk-panel').should('contain.text', 'Return 9999990 submitted')
     cy.get('.govuk-button').contains('Mark for supplementary bill run').click()
 
+    // Navigate to the Licence summary page
+    cy.contains('nav a', 'Licence summary').click()
+
     // Summary
     // confirm the licence has been flagged for the next supplementary bill run for the old charge scheme
     cy.get('.govuk-notification-banner__content').should(

--- a/cypress/e2e/internal/return-logs/view-status.cy.js
+++ b/cypress/e2e/internal/return-logs/view-status.cy.js
@@ -22,7 +22,7 @@ describe('View returns and their status (internal)', () => {
     cy.visit(`/system/licences/${scenario.licences[0].id}/returns`)
 
     // confirm we are on the returns tab page
-    cy.get('#returns > .govuk-heading-l').contains('Returns')
+     cy.get('h1').should('contain.text', 'Returns')
 
     // confirm we see the expected returns and their statuses
     cy.get('[data-test="return-reference-0"]').should('be.visible').and('contain.text', '9999990')

--- a/cypress/e2e/internal/return-logs/view-status.cy.js
+++ b/cypress/e2e/internal/return-logs/view-status.cy.js
@@ -22,7 +22,7 @@ describe('View returns and their status (internal)', () => {
     cy.visit(`/system/licences/${scenario.licences[0].id}/returns`)
 
     // confirm we are on the returns tab page
-     cy.get('h1').should('contain.text', 'Returns')
+    cy.get('h1').should('contain.text', 'Returns')
 
     // confirm we see the expected returns and their statuses
     cy.get('[data-test="return-reference-0"]').should('be.visible').and('contain.text', '9999990')

--- a/cypress/e2e/internal/return-versions/cancel-returns.cy.js
+++ b/cypress/e2e/internal/return-versions/cancel-returns.cy.js
@@ -23,7 +23,7 @@ describe('Cancel a return requirement (internal)', () => {
     cy.visit(`/system/licences/${scenario.licences[0].id}/set-up`)
 
     // confirm we are on the licence set up tab
-    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
+    cy.get('h1').should('contain.text', 'Licence set up')
 
     // click set up new requirements
     cy.contains('Set up new requirements').click()
@@ -151,6 +151,6 @@ describe('Cancel a return requirement (internal)', () => {
     cy.contains('Confirm cancel').click()
 
     // confirm we are on the licence set up tab
-    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
+    cy.get('h1').should('contain.text', 'Licence set up')
   })
 })

--- a/cypress/e2e/internal/return-versions/change-return-cycle-type.cy.js
+++ b/cypress/e2e/internal/return-versions/change-return-cycle-type.cy.js
@@ -30,7 +30,7 @@ describe('Submit changing return cycle type on new return version', () => {
     cy.visit(`/system/licences/${scenario.licences[0].id}/returns`)
 
     // confirm we are on the licence returns tab and that there are previous return logs
-    cy.get('#returns > .govuk-heading-l').contains('Returns')
+    cy.get('h1').should('contain.text', 'Returns')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const endYear = currentFinancialYearInfo.end.year
 
@@ -59,7 +59,7 @@ describe('Submit changing return cycle type on new return version', () => {
     cy.contains('Licence set up').click()
 
     // confirm we are on the licence set up tab
-    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
+    cy.get('h1').should('contain.text', 'Licence set up')
 
     // click set up new requirements
     cy.contains('Set up new requirements').click()
@@ -162,7 +162,7 @@ describe('Submit changing return cycle type on new return version', () => {
     cy.contains('Returns').click()
 
     // confirm we are on the licence set up tab
-    cy.get('#returns > .govuk-heading-l').contains('Returns')
+    cy.get('h1').should('contain.text', 'Returns')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const endYear = currentFinancialYearInfo.end.year
       const today = new Date()

--- a/cypress/e2e/internal/return-versions/copy-existing.cy.js
+++ b/cypress/e2e/internal/return-versions/copy-existing.cy.js
@@ -23,7 +23,7 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     cy.visit(`/system/licences/${scenario.licences[0].id}/set-up`)
 
     // confirm we are on the licence set up tab
-    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
+    cy.get('h1').should('contain.text', 'Licence set up')
 
     // click set up new requirements
     cy.contains('Set up new requirements').click()
@@ -180,6 +180,6 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     cy.contains('Return to licence set up').click()
 
     // confirm we are on the licence set up tab
-    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
+    cy.get('h1').should('contain.text', 'Licence set up')
   })
 })

--- a/cypress/e2e/internal/return-versions/historic-corrections-01.cy.js
+++ b/cypress/e2e/internal/return-versions/historic-corrections-01.cy.js
@@ -28,7 +28,7 @@ describe('Submit winter and all year historic correction using abstraction data'
     cy.visit(`/system/licences/${scenario.licences[0].id}/returns`)
 
     // confirm we are on the licence returns tab and that there are previous return logs
-    cy.get('#returns > .govuk-heading-l').contains('Returns')
+     cy.get('h1').should('contain.text', 'Returns')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const startYear = currentFinancialYearInfo.start.year
       const endYear = currentFinancialYearInfo.end.year
@@ -58,7 +58,7 @@ describe('Submit winter and all year historic correction using abstraction data'
     cy.contains('Licence set up').click()
 
     // confirm we are on the licence set up tab
-    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
+    cy.get('h1').should('contain.text', 'Licence set up')
 
     // click set up new requirements
     cy.contains('Set up new requirements').click()
@@ -101,7 +101,7 @@ describe('Submit winter and all year historic correction using abstraction data'
     cy.contains('Returns').click()
 
     // confirm we are on the licence set up tab
-    cy.get('#returns > .govuk-heading-l').contains('Returns')
+     cy.get('h1').should('contain.text', 'Returns')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const startYear = currentFinancialYearInfo.start.year
       const endYear = currentFinancialYearInfo.end.year

--- a/cypress/e2e/internal/return-versions/historic-corrections-01.cy.js
+++ b/cypress/e2e/internal/return-versions/historic-corrections-01.cy.js
@@ -28,7 +28,7 @@ describe('Submit winter and all year historic correction using abstraction data'
     cy.visit(`/system/licences/${scenario.licences[0].id}/returns`)
 
     // confirm we are on the licence returns tab and that there are previous return logs
-     cy.get('h1').should('contain.text', 'Returns')
+    cy.get('h1').should('contain.text', 'Returns')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const startYear = currentFinancialYearInfo.start.year
       const endYear = currentFinancialYearInfo.end.year
@@ -101,7 +101,7 @@ describe('Submit winter and all year historic correction using abstraction data'
     cy.contains('Returns').click()
 
     // confirm we are on the licence set up tab
-     cy.get('h1').should('contain.text', 'Returns')
+    cy.get('h1').should('contain.text', 'Returns')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const startYear = currentFinancialYearInfo.start.year
       const endYear = currentFinancialYearInfo.end.year

--- a/cypress/e2e/internal/return-versions/historic-corrections-02.cy.js
+++ b/cypress/e2e/internal/return-versions/historic-corrections-02.cy.js
@@ -28,7 +28,7 @@ describe('Submit summer and winter and all year historic correction using abstra
     cy.visit(`/system/licences/${scenario.licences[0].id}/returns`)
 
     // confirm we are on the licence returns tab and that there are previous return logs
-     cy.get('h1').should('contain.text', 'Returns')
+    cy.get('h1').should('contain.text', 'Returns')
 
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const winter = { start: currentFinancialYearInfo.start.year, end: currentFinancialYearInfo.end.year }
@@ -108,7 +108,7 @@ describe('Submit summer and winter and all year historic correction using abstra
     cy.contains('Returns').click()
 
     // confirm we are on the licence set up tab
-     cy.get('h1').should('contain.text', 'Returns')
+    cy.get('h1').should('contain.text', 'Returns')
 
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const today = new Date()

--- a/cypress/e2e/internal/return-versions/historic-corrections-02.cy.js
+++ b/cypress/e2e/internal/return-versions/historic-corrections-02.cy.js
@@ -28,7 +28,7 @@ describe('Submit summer and winter and all year historic correction using abstra
     cy.visit(`/system/licences/${scenario.licences[0].id}/returns`)
 
     // confirm we are on the licence returns tab and that there are previous return logs
-    cy.get('#returns > .govuk-heading-l').contains('Returns')
+     cy.get('h1').should('contain.text', 'Returns')
 
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const winter = { start: currentFinancialYearInfo.start.year, end: currentFinancialYearInfo.end.year }
@@ -59,7 +59,7 @@ describe('Submit summer and winter and all year historic correction using abstra
     cy.contains('Licence set up').click()
 
     // confirm we are on the licence set up tab
-    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
+    cy.get('h1').should('contain.text', 'Licence set up')
 
     // click set up new requirements
     cy.contains('Set up new requirements').click()
@@ -108,7 +108,7 @@ describe('Submit summer and winter and all year historic correction using abstra
     cy.contains('Returns').click()
 
     // confirm we are on the licence set up tab
-    cy.get('#returns > .govuk-heading-l').contains('Returns')
+     cy.get('h1').should('contain.text', 'Returns')
 
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const today = new Date()

--- a/cypress/e2e/internal/return-versions/historic-corrections-03.cy.js
+++ b/cypress/e2e/internal/return-versions/historic-corrections-03.cy.js
@@ -28,7 +28,7 @@ describe('Submit historic correction using abstraction data for two abstraction 
     cy.visit(`/system/licences/${scenario.licences[0].id}/returns`)
 
     // confirm we are on the licence returns tab and that there are previous return logs
-    cy.get('#returns > .govuk-heading-l').contains('Returns')
+     cy.get('h1').should('contain.text', 'Returns')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const startYear = currentFinancialYearInfo.start.year
       const endYear = currentFinancialYearInfo.end.year
@@ -60,7 +60,7 @@ describe('Submit historic correction using abstraction data for two abstraction 
     cy.contains('Licence set up').click()
 
     // confirm we are on the licence set up tab
-    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
+    cy.get('h1').should('contain.text', 'Licence set up')
 
     // click set up new requirements
     cy.contains('Set up new requirements').click()
@@ -104,7 +104,7 @@ describe('Submit historic correction using abstraction data for two abstraction 
     cy.contains('Returns').click()
 
     // confirm we are on the licence set up tab
-    cy.get('#returns > .govuk-heading-l').contains('Returns')
+     cy.get('h1').should('contain.text', 'Returns')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const startYear = currentFinancialYearInfo.start.year
       const endYear = currentFinancialYearInfo.end.year

--- a/cypress/e2e/internal/return-versions/historic-corrections-03.cy.js
+++ b/cypress/e2e/internal/return-versions/historic-corrections-03.cy.js
@@ -28,7 +28,7 @@ describe('Submit historic correction using abstraction data for two abstraction 
     cy.visit(`/system/licences/${scenario.licences[0].id}/returns`)
 
     // confirm we are on the licence returns tab and that there are previous return logs
-     cy.get('h1').should('contain.text', 'Returns')
+    cy.get('h1').should('contain.text', 'Returns')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const startYear = currentFinancialYearInfo.start.year
       const endYear = currentFinancialYearInfo.end.year
@@ -104,7 +104,7 @@ describe('Submit historic correction using abstraction data for two abstraction 
     cy.contains('Returns').click()
 
     // confirm we are on the licence set up tab
-     cy.get('h1').should('contain.text', 'Returns')
+    cy.get('h1').should('contain.text', 'Returns')
     cy.get('@currentFinancialYearInfo').then((currentFinancialYearInfo) => {
       const startYear = currentFinancialYearInfo.start.year
       const endYear = currentFinancialYearInfo.end.year

--- a/cypress/e2e/internal/return-versions/no-returns-required.cy.js
+++ b/cypress/e2e/internal/return-versions/no-returns-required.cy.js
@@ -23,7 +23,7 @@ describe('Submit no returns requirement (internal)', () => {
     cy.visit(`/system/licences/${scenario.licences[0].id}/set-up`)
 
     // confirm we are on the licence set up tab
-    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
+    cy.get('h1').should('contain.text', 'Licence set up')
 
     // click set up no returns requirement
     cy.contains("Mark licence as 'no returns needed'").click()
@@ -127,7 +127,7 @@ describe('Submit no returns requirement (internal)', () => {
     cy.contains('Return to licence set up').click()
 
     // confirm we are on the licence set up tab
-    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
+    cy.get('h1').should('contain.text', 'Licence set up')
 
     // Confirm we can display the return version details
     cy.get('[data-test="return-version-0').click()

--- a/cypress/e2e/internal/return-versions/quarterly-01.cy.js
+++ b/cypress/e2e/internal/return-versions/quarterly-01.cy.js
@@ -29,7 +29,7 @@ describe('Submit winter and all year quarterly historic correction using abstrac
     cy.visit(`/system/licences/${scenario.licences[0].id}/returns`)
 
     // confirm we are on the licence returns tab and that there are previous return logs
-    cy.get('#returns > .govuk-heading-l').contains('Returns')
+     cy.get('h1').should('contain.text', 'Returns')
 
     cy.get('@year').then((year) => {
       cy.quarterlyReturnLogDueData(`${year + 1}-04-28`).then((data) => {
@@ -57,7 +57,7 @@ describe('Submit winter and all year quarterly historic correction using abstrac
     cy.contains('Licence set up').click()
 
     // confirm we are on the licence set up tab
-    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
+    cy.get('h1').should('contain.text', 'Licence set up')
 
     // click set up new requirements
     cy.contains('Set up new requirements').click()
@@ -105,7 +105,7 @@ describe('Submit winter and all year quarterly historic correction using abstrac
     cy.contains('Returns').click()
 
     // confirm we are on the licence set up tab
-    cy.get('#returns > .govuk-heading-l').contains('Returns')
+     cy.get('h1').should('contain.text', 'Returns')
 
     cy.get('@year').then((year) => {
       cy.get('[data-test="return-due-date-0"]').should('have.value', '')

--- a/cypress/e2e/internal/return-versions/quarterly-01.cy.js
+++ b/cypress/e2e/internal/return-versions/quarterly-01.cy.js
@@ -29,7 +29,7 @@ describe('Submit winter and all year quarterly historic correction using abstrac
     cy.visit(`/system/licences/${scenario.licences[0].id}/returns`)
 
     // confirm we are on the licence returns tab and that there are previous return logs
-     cy.get('h1').should('contain.text', 'Returns')
+    cy.get('h1').should('contain.text', 'Returns')
 
     cy.get('@year').then((year) => {
       cy.quarterlyReturnLogDueData(`${year + 1}-04-28`).then((data) => {
@@ -105,7 +105,7 @@ describe('Submit winter and all year quarterly historic correction using abstrac
     cy.contains('Returns').click()
 
     // confirm we are on the licence set up tab
-     cy.get('h1').should('contain.text', 'Returns')
+    cy.get('h1').should('contain.text', 'Returns')
 
     cy.get('@year').then((year) => {
       cy.get('[data-test="return-due-date-0"]').should('have.value', '')

--- a/cypress/e2e/internal/return-versions/returns-required.cy.js
+++ b/cypress/e2e/internal/return-versions/returns-required.cy.js
@@ -23,7 +23,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.visit(`/system/licences/${scenario.licences[0].id}/set-up`)
 
     // confirm we are on the licence set up tab
-    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
+    cy.get('h1').should('contain.text', 'Licence set up')
 
     // click set up new requirements
     cy.contains('Set up new requirements').click()
@@ -365,7 +365,7 @@ describe('Submit returns requirement (internal)', () => {
     cy.contains('Return to licence set up').click()
 
     // confirm we are on the licence set up tab
-    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
+    cy.get('h1').should('contain.text', 'Licence set up')
 
     // Confirm we can display the return version details
     cy.get('[data-test="return-version-0').click()

--- a/cypress/e2e/internal/return-versions/start-by-using-abstraction-data.cy.js
+++ b/cypress/e2e/internal/return-versions/start-by-using-abstraction-data.cy.js
@@ -22,7 +22,7 @@ describe('Submit returns requirement (internal) using abstraction data', () => {
     cy.visit(`/system/licences/${scenario.licences[0].id}/set-up`)
 
     // confirm we are on the licence set up tab
-    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
+    cy.get('h1').should('contain.text', 'Licence set up')
 
     // click set up new requirements
     cy.contains('Set up new requirements').click()
@@ -85,7 +85,7 @@ describe('Submit returns requirement (internal) using abstraction data', () => {
     cy.contains('Return to licence set up').click()
 
     // confirm we are on the licence set up tab
-    cy.get('#set-up > .govuk-heading-l').contains('Licence set up')
+    cy.get('h1').should('contain.text', 'Licence set up')
 
     // Confirm we can display the return version details
     cy.get('[data-test="return-version-0').click()

--- a/cypress/e2e/internal/supplementary-billing-flags/approving-a-charge-version.cy.js
+++ b/cypress/e2e/internal/supplementary-billing-flags/approving-a-charge-version.cy.js
@@ -134,6 +134,9 @@ describe('Approving a charge version (internal)', () => {
     // bill run
     cy.contains('Review').should('not.exist')
 
+    // Navigate to back to the Licence summary page
+    cy.contains('nav a', 'Licence summary').click();
+
     cy.get('.govuk-notification-banner__content')
       .should('contain.text', 'This licence has been marked for the next two-part tariff supplementary bill run and the supplementary bill run.')
   })

--- a/cypress/e2e/internal/supplementary-billing-flags/approving-a-charge-version.cy.js
+++ b/cypress/e2e/internal/supplementary-billing-flags/approving-a-charge-version.cy.js
@@ -135,7 +135,7 @@ describe('Approving a charge version (internal)', () => {
     cy.contains('Review').should('not.exist')
 
     // Navigate to back to the Licence summary page
-    cy.contains('nav a', 'Licence summary').click();
+    cy.contains('nav a', 'Licence summary').click()
 
     cy.get('.govuk-notification-banner__content')
       .should('contain.text', 'This licence has been marked for the next two-part tariff supplementary bill run and the supplementary bill run.')

--- a/cypress/e2e/internal/supplementary-billing-flags/cancelling-a-charge-version.cy.js
+++ b/cypress/e2e/internal/supplementary-billing-flags/cancelling-a-charge-version.cy.js
@@ -26,7 +26,7 @@ describe('Cancelling a charge version in workflow (internal)', () => {
 
     // Click the workflow tab
     cy.get('#nav-manage').click()
-    cy.get(':nth-child(9) > li > .govuk-link').click()
+    cy.contains('a.govuk-link', 'Check licences in workflow').click()
     cy.get('#tab_review').click()
 
     // Check licences in workflow

--- a/cypress/e2e/internal/supplementary-billing-flags/cancelling-a-charge-version.cy.js
+++ b/cypress/e2e/internal/supplementary-billing-flags/cancelling-a-charge-version.cy.js
@@ -48,6 +48,9 @@ describe('Cancelling a charge version in workflow (internal)', () => {
     cy.get('.govuk-heading-l').contains("You're about to cancel this charge information")
     cy.get('form > .govuk-button').click()
 
+    // Navigate to back to the Licence summary page
+    cy.contains('nav a', 'Licence summary').click();
+
     // Check the new licence agreement has flagged the licence for supplementary billing
     cy.get('.govuk-notification-banner__content')
       .should('contain.text', 'This licence has been marked for the next two-part tariff supplementary bill run and the supplementary bill run.')

--- a/cypress/e2e/internal/supplementary-billing-flags/cancelling-a-charge-version.cy.js
+++ b/cypress/e2e/internal/supplementary-billing-flags/cancelling-a-charge-version.cy.js
@@ -49,7 +49,7 @@ describe('Cancelling a charge version in workflow (internal)', () => {
     cy.get('form > .govuk-button').click()
 
     // Navigate to back to the Licence summary page
-    cy.contains('nav a', 'Licence summary').click();
+    cy.contains('nav a', 'Licence summary').click()
 
     // Check the new licence agreement has flagged the licence for supplementary billing
     cy.get('.govuk-notification-banner__content')

--- a/cypress/e2e/internal/supplementary-billing-flags/deleting-licence-from-worfklow.cy.js
+++ b/cypress/e2e/internal/supplementary-billing-flags/deleting-licence-from-worfklow.cy.js
@@ -62,6 +62,9 @@ describe('Deleting a licence from workflow (internal)', () => {
     cy.get('.search__button').click()
     cy.get('.govuk-table__row').contains('AT/TEST/01').click()
 
+    // Navigate to back to the Licence summary page
+    cy.contains('nav a', 'Licence summary').click();
+
     // Check the new licence agreement has flagged the licence for supplementary billing
     cy.get('.govuk-notification-banner__content')
       .should('contain.text', 'This licence has been marked for the next two-part tariff supplementary bill run and the supplementary bill run.')

--- a/cypress/e2e/internal/supplementary-billing-flags/deleting-licence-from-worfklow.cy.js
+++ b/cypress/e2e/internal/supplementary-billing-flags/deleting-licence-from-worfklow.cy.js
@@ -63,7 +63,7 @@ describe('Deleting a licence from workflow (internal)', () => {
     cy.get('.govuk-table__row').contains('AT/TEST/01').click()
 
     // Navigate to back to the Licence summary page
-    cy.contains('nav a', 'Licence summary').click();
+    cy.contains('nav a', 'Licence summary').click()
 
     // Check the new licence agreement has flagged the licence for supplementary billing
     cy.get('.govuk-notification-banner__content')

--- a/cypress/e2e/internal/supplementary-billing-flags/editing-a-return.cy.js
+++ b/cypress/e2e/internal/supplementary-billing-flags/editing-a-return.cy.js
@@ -69,7 +69,7 @@ describe('Editing a return (internal)', () => {
     cy.get('.govuk-button').contains('Mark for supplementary bill run').click()
 
     // Navigate to back to the Licence summary page
-    cy.contains('nav a', 'Licence summary').click();
+    cy.contains('nav a', 'Licence summary').click()
 
     // confirm the licence has been flagged for the next supplementary bill run for the old charge scheme
     cy.get('.govuk-notification-banner__content').should(

--- a/cypress/e2e/internal/supplementary-billing-flags/editing-a-return.cy.js
+++ b/cypress/e2e/internal/supplementary-billing-flags/editing-a-return.cy.js
@@ -68,7 +68,9 @@ describe('Editing a return (internal)', () => {
     cy.get('.govuk-panel__title').should('contain.text', 'Return 9999990 submitted')
     cy.get('.govuk-button').contains('Mark for supplementary bill run').click()
 
-    // Summary
+    // Navigate to back to the Licence summary page
+    cy.contains('nav a', 'Licence summary').click();
+
     // confirm the licence has been flagged for the next supplementary bill run for the old charge scheme
     cy.get('.govuk-notification-banner__content').should(
       'contain.text',

--- a/cypress/e2e/internal/supplementary-billing-flags/recalculate-bills-link.cy.js
+++ b/cypress/e2e/internal/supplementary-billing-flags/recalculate-bills-link.cy.js
@@ -22,7 +22,7 @@ describe('Recalculate Bills Link (internal)', () => {
     cy.visit(`/system/licences/${scenario.licences[0].id}/set-up`)
 
     // Click the recalculate bills link
-    cy.contains('a.govuk-button', 'Recalculate bills').click();
+    cy.contains('a.govuk-button', 'Recalculate bills').click()
     cy.get('.govuk-caption-l').contains('AT/TEST/01').click()
     cy.get('[data-test="sroc-years-2024"]').click()
     cy.get('[data-test="pre-sroc-years"]').click()
@@ -34,7 +34,7 @@ describe('Recalculate Bills Link (internal)', () => {
     cy.get('.govuk-body > .govuk-link').click()
 
     // Navigate to back to the Licence summary page
-    cy.contains('nav a', 'Licence summary').click();
+    cy.contains('nav a', 'Licence summary').click()
 
     // Check the new licence agreement has flagged the licence for supplementary billing
     cy.get('.govuk-notification-banner__content')

--- a/cypress/e2e/internal/supplementary-billing-flags/recalculate-bills-link.cy.js
+++ b/cypress/e2e/internal/supplementary-billing-flags/recalculate-bills-link.cy.js
@@ -22,7 +22,7 @@ describe('Recalculate Bills Link (internal)', () => {
     cy.visit(`/system/licences/${scenario.licences[0].id}/set-up`)
 
     // Click the recalculate bills link
-    cy.get('#set-up > div > .govuk-button').click()
+    cy.contains('a.govuk-button', 'Recalculate bills').click();
     cy.get('.govuk-caption-l').contains('AT/TEST/01').click()
     cy.get('[data-test="sroc-years-2024"]').click()
     cy.get('[data-test="pre-sroc-years"]').click()
@@ -32,6 +32,9 @@ describe('Recalculate Bills Link (internal)', () => {
     // confirm we see the success panel and then click the link to return to the licence
     cy.get('.govuk-panel').should('contain.text', "You've marked this licence for the next supplementary bill run")
     cy.get('.govuk-body > .govuk-link').click()
+
+    // Navigate to back to the Licence summary page
+    cy.contains('nav a', 'Licence summary').click();
 
     // Check the new licence agreement has flagged the licence for supplementary billing
     cy.get('.govuk-notification-banner__content')

--- a/cypress/e2e/internal/user/permissions/billing-and-data.cy.js
+++ b/cypress/e2e/internal/user/permissions/billing-and-data.cy.js
@@ -24,7 +24,6 @@ describe('Billing & Data permissions (internal)', () => {
     // confirm we are on the licence page
     cy.contains('AT/TEST/01')
 
-
     // confirm we can see the summary, contact details, returns, communications, bill runs and licence set up links
     cy.get('nav.x-govuk-sub-navigation').within(() => {
       cy.contains('a', 'Licence summary').should('be.visible')
@@ -34,7 +33,6 @@ describe('Billing & Data permissions (internal)', () => {
       cy.contains('a', 'Bills').should('be.visible')
       cy.contains('a', 'Licence set up').should('be.visible')
     })
-
 
     // assert they can see the Bill runs page
     cy.get('#nav > ul').children().should('contain', 'Bill runs')

--- a/cypress/e2e/internal/user/permissions/billing-and-data.cy.js
+++ b/cypress/e2e/internal/user/permissions/billing-and-data.cy.js
@@ -24,13 +24,17 @@ describe('Billing & Data permissions (internal)', () => {
     // confirm we are on the licence page
     cy.contains('AT/TEST/01')
 
-    // confirm we can see the summary, contact details, returns, communications, bill runs and licence set up tabs
-    cy.get('.govuk-tabs__list-item--selected > .govuk-tabs__tab').should('contain.text', 'Summary')
-    cy.get(':nth-child(2) > .govuk-tabs__tab').should('contain.text', 'Contact details')
-    cy.get(':nth-child(3) > .govuk-tabs__tab').should('contain.text', 'Returns')
-    cy.get(':nth-child(4) > .govuk-tabs__tab').should('contain.text', 'Communications')
-    cy.get(':nth-child(5) > .govuk-tabs__tab').should('contain.text', 'Bills')
-    cy.get(':nth-child(6) > .govuk-tabs__tab').should('contain.text', 'Licence set up')
+
+    // confirm we can see the summary, contact details, returns, communications, bill runs and licence set up links
+    cy.get('nav.x-govuk-sub-navigation').within(() => {
+      cy.contains('a', 'Licence summary').should('be.visible')
+      cy.contains('a', 'Contact details').should('be.visible')
+      cy.contains('a', 'Returns').should('be.visible')
+      cy.contains('a', 'Communications').should('be.visible')
+      cy.contains('a', 'Bills').should('be.visible')
+      cy.contains('a', 'Licence set up').should('be.visible')
+    })
+
 
     // assert they can see the Bill runs page
     cy.get('#nav > ul').children().should('contain', 'Bill runs')

--- a/cypress/e2e/internal/user/permissions/psc.cy.js
+++ b/cypress/e2e/internal/user/permissions/psc.cy.js
@@ -25,16 +25,14 @@ describe('PSC permissions (internal)', () => {
     cy.contains('AT/TEST/01')
 
     // confirm we can see the summary, contact details, returns, communications and licence set up tabs
-    cy.get('.govuk-tabs__list-item--selected > .govuk-tabs__tab').should('contain.text', 'Summary')
-    cy.get(':nth-child(2) > .govuk-tabs__tab').should('contain.text', 'Contact details')
-    cy.get(':nth-child(3) > .govuk-tabs__tab').should('contain.text', 'Returns')
-    cy.get(':nth-child(4) > .govuk-tabs__tab').should('contain.text', 'Communications')
-    cy.get(':nth-child(5) > .govuk-tabs__tab').should('contain.text', 'Licence set up')
+    cy.get('nav.x-govuk-sub-navigation').within(() => {
+      cy.contains('a', 'Licence summary').should('be.visible')
+      cy.contains('a', 'Contact details').should('be.visible')
+      cy.contains('a', 'Returns').should('be.visible')
+      cy.contains('a', 'Communications').should('be.visible')
+    })
 
-    // confirm we cannot see the bills tab
-    cy.get('.govuk-tabs__list').should('not.contain', 'Bills')
-
-    // assert they cannot see the Bill runs page
-    cy.get('#nav > ul').children().should('not.contain', 'Bill runs')
+    // confirm we cannot see the bills link
+    cy.get('nav.x-govuk-sub-navigation').should('not.contain', 'Bills')
   })
 })


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5372

We recently removed tabs from the licence pages and implemented secondary navigation. 

This change updates the failing test to align with seconary navigation. 

Where the notificaiton was previouslt expected on the same page it is now only shown on the licence summary page. This means the test have been updated to navigate (using the secondary navigation) to the licence summary page. 
