### PR TITLE
Add shai-hulud-detect as a daily workflow

### DIFF
--- a/.github/workflows/shai-hulud-detect.yml
+++ b/.github/workflows/shai-hulud-detect.yml
@@ -1,0 +1,32 @@
+name: shai-hulud-detect
+
+on:
+  schedule:
+    - cron: "5 4 * * *"
+
+jobs:
+  shai-hulud-detect:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Downloads a copy of the code in your repository by default
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          ref: main
+          path: project
+          fetch-depth: 1
+
+      # Checkout the security scanning repo we're using
+      - name: Checkout scanner
+        uses: actions/checkout@v6
+        with:
+          repository: Cobenian/shai-hulud-detect
+          ref: main
+          path: scanner
+          fetch-depth: 1
+
+      - name: Run scanner
+        run: |
+          chmod +x ./scanner/shai-hulud-detector.sh
+          ./scanner/shai-hulud-detector.sh ./project

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Water Abstraction acceptance tests
 
+[![shai-hulud-detect](https://github.com/DEFRA/hapi-pg-rest-api/actions/workflows/shai-hulud-detect.yml/badge.svg)](https://github.com/DEFRA/hapi-pg-rest-api/actions/workflows/shai-hulud-detect.yml)
+
 > This project originated with the migration of existing tests from the [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui). It used Cypress v8 and did not have test isolation so all had to be restructured. The quality of these tests is not great but it's our aim to review and improve all tests as soon as we can.
 
 These acceptance tests support the [Manage your water abstraction or impoundment licence service](https://manage-water-abstraction-impoundment-licence.service.gov.uk/) and it's internal counterpart.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Water Abstraction acceptance tests
 
-[![shai-hulud-detect](https://github.com/DEFRA/hapi-pg-rest-api/actions/workflows/shai-hulud-detect.yml/badge.svg)](https://github.com/DEFRA/hapi-pg-rest-api/actions/workflows/shai-hulud-detect.yml)
+![Build Status](https://github.com/DEFRA/water-abstraction-acceptance-tests/actions/workflows/ci.yml/badge.svg?branch=main)
+[![shai-hulud-detect](https://github.com/DEFRA/water-abstraction-acceptance-tests/actions/workflows/shai-hulud-detect.yml/badge.svg)](https://github.com/DEFRA/water-abstraction-acceptance-tests/actions/workflows/shai-hulud-detect.yml)
+[![Licence](https://img.shields.io/badge/Licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)
 
 > This project originated with the migration of existing tests from the [water-abstraction-ui](https://github.com/DEFRA/water-abstraction-ui). It used Cypress v8 and did not have test isolation so all had to be restructured. The quality of these tests is not great but it's our aim to review and improve all tests as soon as we can.
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5406

With the [announcement that the npm supply-chain Shai-Hulud attack is back](https://www.koi.ai/incident/live-updates-sha1-hulud-the-second-coming-hundred-npm-packages-compromised), we're being asked yet again to confirm if our services have been compromised.

The problem is, as a self-replicating worm, which npm packages are compromised is a moving target.

Some of our fantastic colleagues have pulled together bash scripts that can be run to test whether a project may have been compromised. Initially, they depended on self-maintained CSV files of compromised packages, but later iterations were pulling down [compromised-packages.txt](https://github.com/Cobenian/shai-hulud-detect/blob/main/compromised-packages.txt).

We'd already found [shai-hulud-detect](https://github.com/Cobenian/compromised-packages.txt) when looking for something 'off-the-shelf', so figured if we're using their list, why not also use their scanner?

We initially considered including the scan as a CI step. But we have seen that its scanning can change depending on whether `npm ci` is run before or after the scan.

Before, the scan was pretty quick. After, it can take more than an hour as a workflow action. The difference is the depth and types of scanning being performed.

So, we've opted to isolate this as a separate workflow, which we'll schedule daily, whilst we continue to monitor and develop how we check the service.

This first iteration uses the 'simple' version, i.e., we don't run 'npm ci' before the scan. There are issues with 'false' positives in the more thorough scan, which [we are continuing to monitor](https://github.com/DEFRA/water-abstraction-permit-repository/pull/398).