### PR TITLE
Add permissions to scanner workflow

### DIFF
--- a/.github/workflows/shai-hulud-detect.yml
+++ b/.github/workflows/shai-hulud-detect.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "5 4 * * *"
 
+permissions:
+  contents: read
+
 jobs:
   shai-hulud-detect:
     runs-on: ubuntu-latest

--- a/.github/workflows/shai-hulud-detect.yml
+++ b/.github/workflows/shai-hulud-detect.yml
@@ -1,6 +1,8 @@
 name: shai-hulud-detect
 
-on: push
+on:
+  schedule:
+    - cron: "5 4 * * *"
 
 permissions:
   contents: read

--- a/.github/workflows/shai-hulud-detect.yml
+++ b/.github/workflows/shai-hulud-detect.yml
@@ -1,8 +1,6 @@
 name: shai-hulud-detect
 
-on:
-  schedule:
-    - cron: "5 4 * * *"
+on: push
 
 permissions:
   contents: read


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5406

After adding a new workflow to scan for compromised npm packages with [shai-hulud-detect](https://github.com/Cobenian/shai-hulud-detect) to _all_ our repos, GitHub suddenly piped up in one of them that it "really should declare permissions".

As we are only cloning the code from the repo, we only need to declare `permissions: read`.

It would have been nice if it had told us before we merged them all!