### PR TITLE
Update send notice journeys

### DIFF
--- a/cypress/e2e/internal/monitoring-stations/abstraction-alerts/cancel-alert.cy.js
+++ b/cypress/e2e/internal/monitoring-stations/abstraction-alerts/cancel-alert.cy.js
@@ -73,7 +73,7 @@ describe('Set up but then cancel an abstraction alert (internal)', () => {
     cy.get('.govuk-table__caption').contains('Showing all 1 recipients')
     cy.get('.govuk-table__body').contains('external@example.com')
     cy.get('.govuk-table__body').contains('AT/TEST/01')
-    cy.get('.govuk-table__body').contains('Email - Primary user')
+    cy.get('.govuk-table__body').contains('Email - primary user')
     cy.get('.govuk-table__body').contains('Preview')
     cy.get('.govuk-button--secondary').contains('Cancel').click()
 

--- a/cypress/e2e/internal/monitoring-stations/abstraction-alerts/send-alert.cy.js
+++ b/cypress/e2e/internal/monitoring-stations/abstraction-alerts/send-alert.cy.js
@@ -72,7 +72,7 @@ describe('Send an abstraction alert (internal)', () => {
     cy.get('.govuk-table__caption').contains('Showing all 1 recipients')
     cy.get('.govuk-table__body').contains('external@example.com')
     cy.get('.govuk-table__body').contains('AT/TEST/01')
-    cy.get('.govuk-table__body').contains('Email - Primary user')
+    cy.get('.govuk-table__body').contains('Email - primary user')
     cy.get('.govuk-table__body').contains('Preview')
     cy.get('.govuk-button').contains('Send').click()
 

--- a/cypress/e2e/internal/notices/ad-hoc/paper-returns.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/paper-returns.cy.js
@@ -7,9 +7,13 @@ describe('Ad-hoc Paper returns journey (internal)', () => {
     cy.tearDown()
 
     cy.calculatedDates().then((body) => {
-      const scenario = scenarioData(body.firstReturnPeriod)
+      const period = body.firstReturnPeriod
 
-      cy.load(scenario)
+      cy.previousPeriod(period).then((previousPeriod) => {
+        const scenario = scenarioData(previousPeriod)
+
+        cy.load(scenario)
+      })
     })
 
     cy.fixture('users.json').its('billingAndData').as('userEmail')

--- a/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
@@ -108,7 +108,7 @@ describe('Ad-hoc returns invitation journey (internal)', () => {
     cy.get('[data-test="recipient-action-0"]').contains('Preview').click()
 
     // Preview contains the contact name and address
-    cy.contains('Returns invitation licence holder letter')
+    cy.contains('Returns invitation ad-hoc')
     cy.get('@noticeRecipients').then(({ singleUseLetter }) => {
       cy.contains(singleUseLetter.contactName)
     })

--- a/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
@@ -6,9 +6,13 @@ describe('Ad-hoc returns invitation journey (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
     cy.calculatedDates().then((body) => {
-      const scenario = scenarioData(body.firstReturnPeriod)
+      const period = body.firstReturnPeriod
 
-      cy.load(scenario)
+      cy.previousPeriod(period).then((previousPeriod) => {
+        const scenario = scenarioData(previousPeriod)
+
+        cy.load(scenario)
+      })
     })
 
     cy.fixture('users.json').its('billingAndData').as('userEmail')

--- a/cypress/e2e/internal/return-versions/copy-existing.cy.js
+++ b/cypress/e2e/internal/return-versions/copy-existing.cy.js
@@ -76,8 +76,8 @@ describe('Submit returns requirement using copy existing (internal)', () => {
     cy.get('[data-test="purposes-0"]').contains('Laundry Use (This is another purpose description)')
 
     // confirm we see the points for the requirement copied from existing
-    cy.get('[data-test="points-0"] > :nth-child(1)').contains('At National Grid Reference TQ 1234 5678 (Example point 1)')
-    cy.get('[data-test="points-0"] > :nth-child(2)').contains('At National Grid Reference TT 9876 5432 (Example point 2)')
+    cy.get('[data-test="points-0"]').contains('At National Grid Reference TQ 1234 5678 (Example point 1)')
+    cy.get('[data-test="points-0"]').contains('At National Grid Reference TT 9876 5432 (Example point 2)')
 
     // choose the change link for the points and confirm we are on the points page
     cy.get('[data-test="change-points-0"]').click()

--- a/cypress/fixtures/notice-recipients.json
+++ b/cypress/fixtures/notice-recipients.json
@@ -8,10 +8,10 @@
       "line3": "BRISTOL",
       "postcode": "BS1 5AH"
     },
-    "method": "Letter - Single use"
+    "method": "Letter - single use"
   },
   "primaryUserEmail": {
     "email": "external@example.com",
-    "method": "Email - Primary user"
+    "method": "Email - primary user"
   }
 }

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -65,6 +65,32 @@ Cypress.Commands.add('calculatedDates', () => {
   })
 })
 
+Cypress.Commands.add('previousPeriod', (period) => {
+  cy.log('Push a return period back by one')
+
+  const previousPeriod = {
+    dueDate: period.dueDate ? new Date(period.dueDate) : null,
+    endDate: new Date(period.endDate),
+    name: period.name,
+    quarterly: period.quarterly,
+    startDate: new Date(period.startDate)
+  }
+
+  let monthsBack = 12
+  if (period.quarterly) {
+    monthsBack = 3
+  }
+
+  previousPeriod.endDate.setMonth(previousPeriod.endDate.getMonth() - monthsBack)
+  previousPeriod.startDate.setMonth(previousPeriod.startDate.getMonth() - monthsBack)
+
+  if (period.dueDate) {
+    previousPeriod.dueDate.setMonth(previousPeriod.dueDate.getMonth() - monthsBack)
+  }
+
+  return cy.wrap(previousPeriod)
+})
+
 // We do not control when the tests are run so sometimes we need a date that is within the current financial year when
 // they are. For example, when testing billing scenarios we often only want to make charge information changes within
 // the current year to avoid additional calculations for previous years.


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-4991

Because of changes made to the service in support of dynamic due dates and how they now impact sending notices, we need to make some changes that require us to update the acceptance tests.

One of them was ensuring the ad-hoc journeys only consider 'due' return logs that can be submitted. So, those with an end date on or after the current date are not yet due.

It looks like the ad-hoc paper return and returns invitation tests were seeding return logs where this was not the case, because they were using the start and end dates for the current period.

So, we add a new command that takes the current period and pushes it back. This will always result in the return log that is seeded having an end date before the current date, i.e. it will be 'due', and the tests will pass again.