### PR TITLE
Fix tests broken by adding `return_log_id`

### DIFF
--- a/cypress/fixtures/review-scenario-01.json
+++ b/cypress/fixtures/review-scenario-01.json
@@ -118,6 +118,7 @@
       "endDate": "2025-03-21",
       "receivedDate": "2025-03-01",
       "dueDate": "2025-04-28",
+      "returnId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
       "status": "completed",
       "underQuery": false
     }
@@ -125,7 +126,8 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
+      "returnLogId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
+      "returnId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }

--- a/cypress/fixtures/review-scenario-02.json
+++ b/cypress/fixtures/review-scenario-02.json
@@ -150,6 +150,7 @@
       "endDate": "2025-03-21",
       "receivedDate": "2025-03-01",
       "dueDate": "2025-04-28",
+      "returnId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
       "status": "completed",
       "underQuery": false
     },
@@ -187,6 +188,7 @@
       "endDate": "2022-10-30",
       "receivedDate": null,
       "dueDate": "2023-11-28",
+      "returnId": "3ea86894-692e-4c4c-baa6-6fce50bc34a5",
       "status": "completed",
       "underQuery": false
     }
@@ -194,13 +196,15 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
+      "returnLogId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
+      "returnId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     },
     {
       "id": "3138bd28-ace6-449a-8293-6213ac1a66df",
-      "returnLogId": "v2:1:01/38/38/9275:10055412:2021-11-01:2022-10-31",
+      "returnLogId": "3ea86894-692e-4c4c-baa6-6fce50bc34a5",
+      "returnId": "v2:1:01/38/38/9275:10055412:2021-11-01:2022-10-31",
       "nilReturn": false,
       "current": true
     }

--- a/cypress/fixtures/review-scenario-03.json
+++ b/cypress/fixtures/review-scenario-03.json
@@ -118,6 +118,7 @@
       "endDate": "2025-03-21",
       "receivedDate": "2025-05-01",
       "dueDate": "2025-04-28",
+      "returnId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
       "status": "completed",
       "underQuery": false
     }
@@ -125,7 +126,8 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
+      "returnLogId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
+      "returnId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }

--- a/cypress/fixtures/review-scenario-04.json
+++ b/cypress/fixtures/review-scenario-04.json
@@ -118,6 +118,7 @@
       "endDate": "2025-03-21",
       "receivedDate": "2025-03-01",
       "dueDate": "2025-04-28",
+      "returnId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
       "status": "completed",
       "underQuery": false
     }
@@ -125,7 +126,8 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
+      "returnLogId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
+      "returnId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }

--- a/cypress/fixtures/review-scenario-05.json
+++ b/cypress/fixtures/review-scenario-05.json
@@ -118,6 +118,7 @@
       "endDate": "2025-03-21",
       "receivedDate": "2025-03-01",
       "dueDate": "2025-04-28",
+      "returnId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
       "status": "completed",
       "underQuery": false
     }
@@ -125,7 +126,8 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
+      "returnLogId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
+      "returnId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }

--- a/cypress/fixtures/review-scenario-06.json
+++ b/cypress/fixtures/review-scenario-06.json
@@ -118,6 +118,7 @@
       "endDate": "2025-03-21",
       "receivedDate": "2025-03-01",
       "dueDate": "2025-04-28",
+      "returnId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
       "status": "completed",
       "underQuery": true
     }
@@ -125,7 +126,8 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
+      "returnLogId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
+      "returnId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }

--- a/cypress/fixtures/review-scenario-07.json
+++ b/cypress/fixtures/review-scenario-07.json
@@ -118,6 +118,7 @@
       "endDate": "2025-03-21",
       "receivedDate": "2025-03-01",
       "dueDate": "2025-04-28",
+      "returnId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
       "status": "received",
       "underQuery": false
     }
@@ -125,7 +126,8 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
+      "returnLogId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
+      "returnId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }

--- a/cypress/fixtures/review-scenario-08.json
+++ b/cypress/fixtures/review-scenario-08.json
@@ -118,6 +118,7 @@
       "endDate": "2025-03-21",
       "receivedDate": "2025-03-01",
       "dueDate": "2025-04-28",
+      "returnId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
       "status": "completed",
       "underQuery": false
     }
@@ -125,7 +126,8 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
+      "returnLogId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
+      "returnId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": true,
       "current": true
     }

--- a/cypress/fixtures/review-scenario-09.json
+++ b/cypress/fixtures/review-scenario-09.json
@@ -176,6 +176,7 @@
       "endDate": "2025-03-21",
       "receivedDate": "2025-03-01",
       "dueDate": "2025-04-28",
+      "returnId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
       "status": "due",
       "underQuery": false
     },
@@ -213,6 +214,7 @@
       "endDate": "2025-03-31",
       "receivedDate": "2025-03-01",
       "dueDate": "2025-04-28",
+      "returnId": "8211606e-302f-4547-9fd0-f3970443ba6d",
       "status": "due",
       "underQuery": false
     }

--- a/cypress/fixtures/review-scenario-10.json
+++ b/cypress/fixtures/review-scenario-10.json
@@ -118,6 +118,7 @@
       "endDate": "2025-03-21",
       "receivedDate": "2025-03-01",
       "dueDate": "2025-04-28",
+      "returnId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
       "status": "completed",
       "underQuery": false
     }
@@ -125,7 +126,8 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
+      "returnLogId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
+      "returnId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }

--- a/cypress/fixtures/review-scenario-11.json
+++ b/cypress/fixtures/review-scenario-11.json
@@ -150,6 +150,7 @@
       "endDate": "2025-03-21",
       "receivedDate": "2025-03-01",
       "dueDate": "2025-04-28",
+      "returnId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
       "status": "completed",
       "underQuery": false
     },
@@ -187,6 +188,7 @@
       "endDate": "2025-03-21",
       "receivedDate": "2025-03-01",
       "dueDate": "2025-04-28",
+      "returnId": "2b718a81-b45a-4c17-bf6a-b05086401cee",
       "status": "completed",
       "underQuery": false
     }
@@ -194,13 +196,15 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
+      "returnLogId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
+      "returnId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     },
     {
       "id": "615251b9-eac9-40db-9212-ee4b7260a3a9",
-      "returnLogId": "v1:1:AT/TEST/01:10021669:2024-05-01:2025-03-31",
+      "returnLogId": "2b718a81-b45a-4c17-bf6a-b05086401cee",
+      "returnId": "v1:1:AT/TEST/01:10021669:2024-05-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }

--- a/cypress/fixtures/review-scenario-12.json
+++ b/cypress/fixtures/review-scenario-12.json
@@ -177,6 +177,7 @@
       "endDate": "2025-03-21",
       "receivedDate": "2025-03-01",
       "dueDate": "2025-04-28",
+      "returnId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
       "status": "completed",
       "underQuery": false
     }
@@ -184,7 +185,8 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
+      "returnLogId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
+      "returnId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }

--- a/cypress/fixtures/review-scenario-13.json
+++ b/cypress/fixtures/review-scenario-13.json
@@ -118,6 +118,7 @@
       "endDate": "2025-03-21",
       "receivedDate": "2025-03-01",
       "dueDate": "2025-04-28",
+      "returnId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
       "status": "completed",
       "underQuery": false
     }
@@ -125,7 +126,8 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
+      "returnLogId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
+      "returnId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }

--- a/cypress/fixtures/review-scenario-14.json
+++ b/cypress/fixtures/review-scenario-14.json
@@ -150,6 +150,7 @@
       "endDate": "2025-03-21",
       "receivedDate": "2025-03-01",
       "dueDate": "2025-04-28",
+      "returnId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
       "status": "completed",
       "underQuery": false
     }
@@ -157,7 +158,8 @@
   "returnSubmissions": [
     {
       "id": "fb740b60-71f6-4fc8-8cce-02ae55a188cd",
-      "returnLogId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
+      "returnLogId": "6a1b2456-e9af-4845-b5a9-a54497dff769",
+      "returnId": "v1:1:AT/TEST/01:10021668:2024-04-01:2025-03-31",
       "nilReturn": false,
       "current": true
     }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5425

Following the addition of the `return_log_id`column to the `returns.versions` table (AKA `return_submissions` view) in PRs https://github.com/DEFRA/water-abstraction-returns/pull/462 & https://github.com/DEFRA/water-abstraction-system/pull/2791 some of the tests now fail due to the new ID not being in the fixtures.

This PR will fix the tests that the addition of the new column has broken.