### PR TITLE
Add customers tests

### DIFF
--- a/cypress/e2e/internal/customers/view-billing-accounts.cy.js
+++ b/cypress/e2e/internal/customers/view-billing-accounts.cy.js
@@ -1,0 +1,36 @@
+'use strict'
+
+import scenarioData from '../../../support/scenarios/one-licence-only.js'
+
+const scenario = scenarioData()
+
+describe("View a licence's contacts (internal)", () => {
+  beforeEach(() => {
+    cy.tearDown()
+
+    cy.load(scenario)
+
+    cy.fixture('users.json').its('super').as('userEmail')
+  })
+
+  it('search for a licence, select it and then view its contacts', () => {
+    cy.get('@userEmail').then((userEmail) => {
+      cy.programmaticLogin({
+        email: userEmail
+      })
+    })
+
+    cy.visit(`/system/customers/${scenario.companies[0].id}/billing-accounts`)
+
+    // Confirm expected tabs are present
+    cy.get('.x-govuk-sub-navigation').contains('Licences')
+    cy.get('.x-govuk-sub-navigation').contains('Billing accounts')
+    cy.get('.x-govuk-sub-navigation').contains('Contacts')
+
+    // Confirm the page title and caption
+    cy.get('.govuk-caption-l').should('contain.text', scenario.companies[0].name)
+    cy.get('h1').should('contain.text', 'Billing accounts')
+
+    cy.get('p').contains('No billing accounts for this customer.')
+  })
+})

--- a/cypress/e2e/internal/customers/view-contacts.cy.js
+++ b/cypress/e2e/internal/customers/view-contacts.cy.js
@@ -32,14 +32,15 @@ describe("View a licence's contacts (internal)", () => {
     cy.contains('Go to customer contacts').click()
 
     // Confirm expected tabs are present
-    cy.get('#main-content').contains('Licences')
-    cy.get('#main-content').contains('Billing accounts')
-    cy.get('#main-content').contains('Contacts')
+    cy.get('.x-govuk-sub-navigation').contains('Licences')
+    cy.get('.x-govuk-sub-navigation').contains('Billing accounts')
+    cy.get('.x-govuk-sub-navigation').contains('Contacts')
 
-    // Confirm contacts tab is selected
-    cy.get('#tab_contacts').invoke('attr', 'aria-selected').should('eq', 'true')
+    // Confirm the page title and caption
+    cy.get('.govuk-caption-l').should('contain.text', scenario.companies[0].name)
+    cy.get('h1').should('contain.text', 'Contacts')
 
     // Confirm contacts contains expected record
-    cy.get('.govuk-table__cell').contains('Mr John Testerson')
+    cy.get('.govuk-table__cell').contains('Mr J J Testerson')
   })
 })

--- a/cypress/e2e/internal/customers/view-licences.cy.js
+++ b/cypress/e2e/internal/customers/view-licences.cy.js
@@ -1,0 +1,38 @@
+'use strict'
+
+import scenarioData from '../../../support/scenarios/one-licence-only.js'
+
+const scenario = scenarioData()
+
+describe("View a licence's contacts (internal)", () => {
+  beforeEach(() => {
+    cy.tearDown()
+
+    cy.load(scenario)
+
+    cy.fixture('users.json').its('super').as('userEmail')
+  })
+
+  it('search for a licence, select it and then view its contacts', () => {
+    cy.get('@userEmail').then((userEmail) => {
+      cy.programmaticLogin({
+        email: userEmail
+      })
+    })
+
+    cy.visit(`/system/customers/${scenario.companies[0].id}/licences`)
+
+    // Confirm expected tabs are present
+    cy.get('.x-govuk-sub-navigation').contains('Licences')
+    cy.get('.x-govuk-sub-navigation').contains('Billing accounts')
+    cy.get('.x-govuk-sub-navigation').contains('Contacts')
+
+    // Confirm the page title and caption
+    cy.get('.govuk-caption-l').should('contain.text', scenario.companies[0].name)
+    cy.get('h1').should('contain.text', 'Licences')
+
+    // Confirm contacts contains expected record
+    cy.get('.govuk-table__cell').contains(scenario.licences[0].licenceRef)
+    cy.get('.govuk-table__cell').contains(scenario.licenceDocumentHeaders[0].licence_name)
+  })
+})


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5377

This change adds tests for the recentley implemented customers pages.

The previous 'view-contacts' test has been updated and moved into the customers folder.