### PR TITLE
Fix broken historic rtn ver test due to year change

### DIFF
--- a/cypress/e2e/internal/return-versions/quarterly-01.cy.js
+++ b/cypress/e2e/internal/return-versions/quarterly-01.cy.js
@@ -12,12 +12,9 @@ describe('Submit winter and all year quarterly historic correction using abstrac
 
     cy.fixture('users.json').its('billingAndData').as('userEmail')
 
-    let year = new Date().getFullYear()
-    if (new Date().getMonth() < 4) {
-      year = year - 1
-    }
-
-    cy.wrap(year).as('year')
+    cy.quarterlyPeriods().then((periods) => {
+      cy.wrap(periods).as('periods')
+    })
   })
 
   it('creates a return requirement using abstraction data and approves the requirement', () => {
@@ -31,7 +28,9 @@ describe('Submit winter and all year quarterly historic correction using abstrac
     // confirm we are on the licence returns tab and that there are previous return logs
     cy.get('h1').should('contain.text', 'Returns')
 
-    cy.get('@year').then((year) => {
+    cy.get('@periods').then((periods) => {
+      const year = periods.year
+
       cy.quarterlyReturnLogDueData(`${year + 1}-04-28`).then((data) => {
         cy.get('[data-test="return-due-date-0"]').contains(data.text)
         cy.get('[data-test="return-status-0"] > .govuk-tag').contains(data.label)
@@ -66,8 +65,8 @@ describe('Submit winter and all year quarterly historic correction using abstrac
     cy.get('#anotherStartDate').check()
     cy.get('#startDateDay').type('01')
     cy.get('#startDateMonth').type('04')
-    cy.get('@year').then((year) => {
-      cy.get('#startDateYear').type(year)
+    cy.get('@periods').then((periods) => {
+      cy.get('#startDateYear').type(periods.year)
     })
     cy.contains('Continue').click()
 
@@ -107,9 +106,11 @@ describe('Submit winter and all year quarterly historic correction using abstrac
     // confirm we are on the licence set up tab
     cy.get('h1').should('contain.text', 'Returns')
 
-    cy.get('@year').then((year) => {
+    cy.get('@periods').then((periods) => {
+      const year = periods.year
+
       cy.get('[data-test="return-due-date-0"]').should('have.value', '')
-      cy.get('[data-test="return-status-0"] > .govuk-tag').contains('not due yet')
+      cy.get('[data-test="return-status-0"] > .govuk-tag').contains(periods.q4.status)
 
       cy.quarterlyReturnLogDueData(`${year + 1}-04-28`).then((data) => {
         cy.get('[data-test="return-due-date-1"]').contains(data.text)
@@ -117,7 +118,7 @@ describe('Submit winter and all year quarterly historic correction using abstrac
       })
 
       cy.get('[data-test="return-due-date-2"]').should('have.value', '')
-      cy.get('[data-test="return-status-2"] > .govuk-tag').contains('not due yet')
+      cy.get('[data-test="return-status-2"] > .govuk-tag').contains(periods.q3.status)
 
       cy.quarterlyReturnLogDueData(`${year + 1}-01-28`).then((data) => {
         cy.get('[data-test="return-due-date-3"]').contains(data.text)
@@ -125,7 +126,7 @@ describe('Submit winter and all year quarterly historic correction using abstrac
       })
 
       cy.get('[data-test="return-due-date-4"]').should('have.value', '')
-      cy.get('[data-test="return-status-4"] > .govuk-tag').contains('open')
+      cy.get('[data-test="return-status-4"] > .govuk-tag').contains(periods.q2.status)
 
       cy.quarterlyReturnLogDueData(`${year}-10-28`).then((data) => {
         cy.get('[data-test="return-due-date-5"]').contains(data.text)
@@ -133,7 +134,7 @@ describe('Submit winter and all year quarterly historic correction using abstrac
       })
 
       cy.get('[data-test="return-due-date-6"]').should('have.value', '')
-      cy.get('[data-test="return-status-6"] > .govuk-tag').contains('open')
+      cy.get('[data-test="return-status-6"] > .govuk-tag').contains(periods.q1.status)
 
       cy.quarterlyReturnLogDueData(`${year}-07-28`).then((data) => {
         cy.get('[data-test="return-due-date-7"]').contains(data.text)

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -65,6 +65,44 @@ Cypress.Commands.add('calculatedDates', () => {
   })
 })
 
+// We do not control when the tests are run. This means for tests that depend on quarterly return periods we need to be
+// able to determine what the periods are and what their status is as of today.
+//
+// If no year is provided it will determine the current financial year.
+//
+// It then returns an object with the start and end dates for each quarterly period based on the year, along with their
+// status as of today. The status will be either 'not due yet' or 'open' (meaning the return period has ended and the
+// return can be submitted).
+Cypress.Commands.add('quarterlyPeriods', (year = null) => {
+  cy.log('Determine the quarterly period based on a given year and what status they will have as of today')
+
+  if (!year) {
+    year = new Date().getFullYear()
+    if (new Date().getMonth() < 4) {
+      year = year - 1
+    }
+  }
+
+  const periods = {
+    q1: { startDate: new Date(`${year}-04-01`), endDate: new Date(`${year}-06-30`) },
+    q2: { startDate: new Date(`${year}-07-01`), endDate: new Date(`${year}-09-30`) },
+    q3: { startDate: new Date(`${year}-10-01`), endDate: new Date(`${year}-12-31`) },
+    q4: { startDate: new Date(`${year + 1}-01-01`), endDate: new Date(`${year + 1}-03-31`) },
+    year
+  }
+
+  const today = new Date()
+
+  today.setHours(0, 0, 0, 0)
+
+  periods.q1.status = today > periods.q1.endDate ? 'open' : 'not due yet'
+  periods.q2.status = today > periods.q2.endDate ? 'open' : 'not due yet'
+  periods.q3.status = today > periods.q3.endDate ? 'open' : 'not due yet'
+  periods.q4.status = today > periods.q4.endDate ? 'open' : 'not due yet'
+
+  return cy.wrap(periods)
+})
+
 Cypress.Commands.add('previousPeriod', (period) => {
   cy.log('Push a return period back by one')
 


### PR DESCRIPTION
During our last run of the acceptance tests, a historic return version scenario began failing. It was expecting something to have a status of `NOT YET OPEN` that was actually `OPEN`.

We realised the issue was that we were running the tests later in the year. The test was asserting that the status of a new third-quarter return log should be `NOT DUE YET`. When the test was written, this was true. But now we're running the test after the third quarter has ended, its status is `OPEN`.

This change updates the test not just by changing the expected status, but by improving the logic so it will be more resilient to future-year changes.