### PR TITLE
Stop using change reason SROC for new charge vers.

### DIFF
--- a/cypress/e2e/internal/charge-information/presroc/licence-transfer.cy.js
+++ b/cypress/e2e/internal/charge-information/presroc/licence-transfer.cy.js
@@ -27,7 +27,7 @@ describe('PRESROC licence transfer (internal)', () => {
 
     // Select reason for new charge information
     // choose Licence transferred and now chargeable and continue
-    cy.get('input#reason-5').click()
+    cy.get('input#reason-7').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Set charge start date

--- a/cypress/e2e/internal/charge-information/sroc/journey.cy.js
+++ b/cypress/e2e/internal/charge-information/sroc/journey.cy.js
@@ -26,8 +26,8 @@ describe('SROC charge information journey (internal)', () => {
     cy.contains('Set up a new charge').click()
 
     // Select reason for new charge information
-    // choose Strategic review of charges (SRoC) and continue
-    cy.get('input#reason-12').click()
+    // choose Change to charge scheme and continue
+    cy.get('input#reason-3').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Set charge start date

--- a/cypress/e2e/internal/charge-information/sroc/validation.cy.js
+++ b/cypress/e2e/internal/charge-information/sroc/validation.cy.js
@@ -30,8 +30,8 @@ describe('SROC charge information validation (internal)', () => {
     cy.get('form > .govuk-button').contains('Continue').click()
     cy.get('.govuk-error-summary__list').should('contain.text', 'Select a reason for new charge information')
     cy.get('.govuk-error-message').should('contain.text', 'Select a reason for new charge information')
-    // choose Strategic review of charges (SRoC) and continue
-    cy.get('input#reason-12').click()
+    // choose Change to charge scheme and continue
+    cy.get('input#reason-3').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Set charge start date
@@ -105,7 +105,7 @@ describe('SROC charge information validation (internal)', () => {
     // check the charge details and element details are as expected and then select option to add a note
     cy.get('section:nth-child(1) > dl').within(() => {
       // reason
-      cy.get('div:nth-child(1) > dd.govuk-summary-list__value').should('contain.text', 'Strategic review of charges (SRoC)')
+      cy.get('div:nth-child(1) > dd.govuk-summary-list__value').should('contain.text', 'Change to charge scheme')
       // start date
       cy.get('div:nth-child(2) > dd.govuk-summary-list__value').should('contain.text', '1 June 2022')
       // billing account

--- a/cypress/e2e/internal/supplementary-billing-flags/approving-a-charge-version.cy.js
+++ b/cypress/e2e/internal/supplementary-billing-flags/approving-a-charge-version.cy.js
@@ -26,8 +26,8 @@ describe('Approving a charge version (internal)', () => {
     cy.contains('Set up a new charge').click()
 
     // Select reason for new charge information
-    // choose Strategic review of charges (SRoC) and continue
-    cy.get('input#reason-12').click()
+    // choose Change to charge scheme and continue
+    cy.get('input#reason-3').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Set charge start date


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5242

Users responsible for setting up new charge versions have provided feedback that they would like to update the list of reasons available when amending a charge version.

"Strategic review of charges (SROC)" is no longer required (all licences have now been processed). Instead, they would prefer a more general "Change to charge scheme" to cover any future changes to our charge schemes.

They would also like to add "Error correction", as it has proved extremely useful when managing return versions.

We have some test scenarios that depend on using "Strategic review of charges (SROC)" as the reason for creating the new charge version. We need to update these to use a different reason ("Change to charge scheme").