### PR TITLE
Update how user permissions are changed

### DIFF
--- a/cypress/e2e/internal/user/change-permissions.cy.js
+++ b/cypress/e2e/internal/user/change-permissions.cy.js
@@ -21,17 +21,18 @@ describe('Change user permissions (internal)', () => {
         email: userEmail
       })
     })
-    cy.visit('/')
+    cy.visit('/system/users')
 
     // search for the user by email
+    cy.get('.govuk-details__summary').click()
     cy.get('@userToBeUpdatedEmail').then((userToBeUpdatedEmail) => {
-      cy.get('#query').type(userToBeUpdatedEmail)
+      cy.get('#email').type(userToBeUpdatedEmail)
     })
-    cy.get('#search-button').click()
+    cy.get('.govuk-button-group > :nth-child(1)').click()
 
     // confirm we see the expected result then select it
     cy.get('@userToBeUpdatedEmail').then((userToBeUpdatedEmail) => {
-      cy.get('.searchresult-row').contains(userToBeUpdatedEmail).click()
+      cy.get('[data-test="user-email-0"]').contains(userToBeUpdatedEmail).click()
     })
 
     // Set permissions


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5480

We are migrating the internal search page (the root page of the internal service) from the legacy apps to our new water-abstraction-system app.

The existing page allows users to search for various values, including licence references, licence names, return references, and usernames.

We copied the same search as used by the legacy app for users in [Migrate user search](https://github.com/DEFRA/water-abstraction-system/pull/2646).

This allows any internal users to search for any other internal user. It was necessary because 'search' was the only means for those with the `manage_accounts` role to edit or disable existing users. But it appears to have been extended to all

Now, thanks to [a new view users page](https://github.com/DEFRA/water-abstraction-system/pull/2903), this is no longer the case.

After a review, the team agreed that all internal users need to search for external users. This helps them respond to customer queries about service access. However, there is no need for all internal users to be able to search for or view other internal users. This should be restricted to those with the `manage_accounts` role.

So, we [excluded internal users from the search results](https://github.com/DEFRA/water-abstraction-system/pull/2938) in our new search.

This breaks the existing user permission test as it is using search to find the user to change. This change fixes the test to use the new users page.