### PR TITLE
Short term fix for broken TPT annual billing tests

### DIFF
--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-01.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-01.cy.js
@@ -53,8 +53,8 @@ describe('Testing a two-part tariff bill run with a simple scenario, licence is 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // choose top option and continue
-    cy.get('#year').click()
+    // choose the 2024 to 2025 option (it is what the scenario seed data is setup for) and continue
+    cy.get('input[value="2025"]').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-02.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-02.cy.js
@@ -43,8 +43,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // choose top option and continue
-    cy.get('#year').click()
+    // choose the 2024 to 2025 option (it is what the scenario seed data is setup for) and continue
+    cy.get('input[value="2025"]').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-03.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-03.cy.js
@@ -44,8 +44,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // choose top option and continue
-    cy.get('#year').click()
+    // choose the 2024 to 2025 option (it is what the scenario seed data is setup for) and continue
+    cy.get('input[value="2025"]').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-04.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-04.cy.js
@@ -44,8 +44,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // choose top option and continue
-    cy.get('#year').click()
+    // choose the 2024 to 2025 option (it is what the scenario seed data is setup for) and continue
+    cy.get('input[value="2025"]').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-05.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-05.cy.js
@@ -44,8 +44,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // choose top option and continue
-    cy.get('#year').click()
+    // choose the 2024 to 2025 option (it is what the scenario seed data is setup for) and continue
+    cy.get('input[value="2025"]').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-06.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-06.cy.js
@@ -44,8 +44,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // choose top option and continue
-    cy.get('#year').click()
+    // choose the 2024 to 2025 option (it is what the scenario seed data is setup for) and continue
+    cy.get('input[value="2025"]').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-07.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-07.cy.js
@@ -44,8 +44,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // choose top option and continue
-    cy.get('#year').click()
+    // choose the 2024 to 2025 option (it is what the scenario seed data is setup for) and continue
+    cy.get('input[value="2025"]').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-08.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-08.cy.js
@@ -45,8 +45,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // choose top option and continue
-    cy.get('#year').click()
+    // choose the 2024 to 2025 option (it is what the scenario seed data is setup for) and continue
+    cy.get('input[value="2025"]').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-09.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-09.cy.js
@@ -48,8 +48,8 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // choose top option and continue
-    cy.get('#year').click()
+    // choose the 2024 to 2025 option (it is what the scenario seed data is setup for) and continue
+    cy.get('input[value="2025"]').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-10.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-10.cy.js
@@ -45,8 +45,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // choose top option and continue
-    cy.get('#year').click()
+    // choose the 2024 to 2025 option (it is what the scenario seed data is setup for) and continue
+    cy.get('input[value="2025"]').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-11.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-11.cy.js
@@ -45,8 +45,8 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // choose top option and continue
-    cy.get('#year').click()
+    // choose the 2024 to 2025 option (it is what the scenario seed data is setup for) and continue
+    cy.get('input[value="2025"]').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-12.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-12.cy.js
@@ -45,8 +45,8 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // choose top option and continue
-    cy.get('#year').click()
+    // choose the 2024 to 2025 option (it is what the scenario seed data is setup for) and continue
+    cy.get('input[value="2025"]').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-13.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-13.cy.js
@@ -44,8 +44,8 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // choose top option and continue
-    cy.get('#year').click()
+    // choose the 2024 to 2025 option (it is what the scenario seed data is setup for) and continue
+    cy.get('input[value="2025"]').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-14.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-14.cy.js
@@ -43,8 +43,8 @@ describe('Testing a two-part tariff bill run with a licence that is current and 
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Select the financial year
-    // choose top option and continue
-    cy.get('#year').click()
+    // choose the 2024 to 2025 option (it is what the scenario seed data is setup for) and continue
+    cy.get('input[value="2025"]').click()
     cy.get('form > .govuk-button').contains('Continue').click()
 
     // Check the bill run


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5578

Whilst we wait for the backlog of two-part tariff annual bill runs to be processed, the bill run setup journey allows the user to select a year. When the backlog is cleared, the page will become redundant because then we'll simply calculate it, i.e. it will always be for the previous financial year (because of the way the two-part tariff works).

Till then, we have the page with hard-coded values. When we moved into the new financial year, some of our acceptance tests started failing for various reasons. One of them was that we were not accepting 2025-26 as a valid year for the two-part tariff supplementary. The seed data for these tests is dynamic, which is why the problem arises.

It made us realise we need to [add 2025-26 to our temporary page](https://github.com/DEFRA/water-abstraction-system/pull/3214).

But after doing that _all_ the two-part tariff annual acceptance tests started failing.

The tests themselves are dynamically selecting the 'first' option on the temporary year page. Till we added 2025/26, that was always 2024 to 2025.

The issue is that the seed data is still using JSON fixtures. This means the data is fixed and set up assuming the billing year will always be 2024/25.

As a short-term fix, we've updated the tests to always select 2024/25. In the longer term, we need to migrate the JSON review fixtures to 'scenarios' that can generate their data for the current financial year.

<img width="410" height="65" alt="Screenshot 2026-04-07 at 18 05 08" src="https://github.com/user-attachments/assets/c9bcb402-919f-4cfb-8381-4c7b92198efc" />
