### PR TITLE
Fix notice tests seed data not matching needs

### DIFF
--- a/cypress/e2e/internal/notices/ad-hoc/paper-returns.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/paper-returns.cy.js
@@ -10,7 +10,7 @@ describe('Ad-hoc Paper returns journey (internal)', () => {
       const period = body.firstReturnPeriod
 
       cy.previousPeriod(period).then((previousPeriod) => {
-        const scenario = scenarioData(previousPeriod)
+        const scenario = scenarioData(previousPeriod, false)
 
         cy.load(scenario)
       })

--- a/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
@@ -9,7 +9,7 @@ describe('Ad-hoc returns invitation journey (internal)', () => {
       const period = body.firstReturnPeriod
 
       cy.previousPeriod(period).then((previousPeriod) => {
-        const scenario = scenarioData(previousPeriod)
+        const scenario = scenarioData(previousPeriod, false)
 
         cy.load(scenario)
       })

--- a/cypress/e2e/internal/notices/standard/returns-invitation.cy.js
+++ b/cypress/e2e/internal/notices/standard/returns-invitation.cy.js
@@ -6,7 +6,7 @@ describe('Standard returns invitation journey (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
     cy.calculatedDates().then((body) => {
-      const scenario = scenarioData(body.firstReturnPeriod)
+      const scenario = scenarioData(body.firstReturnPeriod, false)
 
       cy.load(scenario)
     })

--- a/cypress/e2e/internal/notices/standard/returns-reminder.cy.js
+++ b/cypress/e2e/internal/notices/standard/returns-reminder.cy.js
@@ -7,7 +7,7 @@ describe('Standard returns reminder journey (internal)', () => {
     cy.tearDown()
 
     cy.calculatedDates().then((body) => {
-      const scenario = scenarioData(body.firstReturnPeriod)
+      const scenario = scenarioData(body.firstReturnPeriod, true)
 
       cy.load(scenario)
     })

--- a/cypress/support/scenarios/licence-with-due-return-log.js
+++ b/cypress/support/scenarios/licence-with-due-return-log.js
@@ -4,7 +4,7 @@ import returnLogs from '../fixture-builder/return-logs.js'
 import returnRequirements from '../fixture-builder/return-requirements.js'
 import returnVersion from '../fixture-builder/return-version.js'
 
-export default function (returnPeriod) {
+export default function (returnPeriod, applyDueDate = true) {
   const dueDate = new Date(returnPeriod.dueDate)
   const endDate = new Date(returnPeriod.endDate)
   const startDate = new Date(returnPeriod.startDate)
@@ -20,7 +20,11 @@ export default function (returnPeriod) {
     ...returnLogs(1)
   }
 
-  dataModel.returnLogs[0].dueDate = dueDateString
+  if (applyDueDate) {
+    dataModel.returnLogs[0].dueDate = dueDateString
+  } else {
+    dataModel.returnLogs[0].dueDate = null
+  }
   dataModel.returnLogs[0].endDate = endDateString
   dataModel.returnLogs[0].id = '7f6ff22b-f7f6-4f37-a29e-244fad5a22eb'
   dataModel.returnLogs[0].metadata.description = dataModel.returnRequirements[0].siteDescription
@@ -31,6 +35,7 @@ export default function (returnPeriod) {
   dataModel.returnLogs[0].returnRequirementId = dataModel.returnRequirements[0].id
   dataModel.returnLogs[0].startDate = startDateString
   dataModel.returnLogs[0].status = 'due'
+  dataModel.returnLogs[0].quarterly = returnPeriod.quarterly
 
   return dataModel
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5158

We've been making changes to the tests after several failed when we moved into the new financial year.

This was mainly due to issues with the test data we seeded, and we thought we had them bottomed out. But then we found discrepancies in the results across the team. Some reported all tests were green. Others reported that the 'notices' tests were failing.

When you create a returns invitation or reminder, the journey asks you to select from two periods. These are dynamically generated based on the current date. For example, today is 9 April 2026. So, in the journey, the periods we can select are

- Quarterly 1 January 2026 to 31 March 2026
- Winter and all year annual 1 April 2025 to 31 March 2026

Working this out is complex, so [we built the means to ask the service what those periods will be](https://github.com/DEFRA/water-abstraction-system/pull/2460).

The first period is passed into the scenario loader, so the return log is seeded with its dates.

But we hadn't taken into account the following when seeding the return log

- If the period is quarterly, the seeded return log also needs to be quarterly
- If creating a returns invitation, the due date must be null
- If creating a returns reminder, the due date must _not_ be null

Because of this, running the tests today would mean the seeded return log will be ignored. The test was still passing for those team members who already had quarterly return versions and, therefore, quarterly return logs in their database. For those who don't, the test fails.

We need to update how the DB is seeded for these tests to ensure that what we are seeding matches the first option in the journey and the journey itself.