### PR TITLE
Update tests post splitting the return log page

### DIFF
--- a/cypress/e2e/internal/return-logs/record-receipt.cy.js
+++ b/cypress/e2e/internal/return-logs/record-receipt.cy.js
@@ -23,7 +23,7 @@ describe('Record receipt for return (internal)', () => {
       })
     })
     cy.get('@returnId').then((returnId) => {
-      cy.visit(`/system/return-logs/${returnId}`)
+      cy.visit(`/system/return-logs/${returnId}/details`)
     })
 
     // Abstraction return

--- a/cypress/e2e/internal/return-logs/submit-edit-zero-abstraction-volumes.cy.js
+++ b/cypress/e2e/internal/return-logs/submit-edit-zero-abstraction-volumes.cy.js
@@ -24,7 +24,7 @@ describe('Submit then edit an abstraction volumes return with zero quantities (i
       })
     })
     cy.get('@returnId').then((returnId) => {
-      cy.visit(`/system/return-logs/${returnId}`)
+      cy.visit(`/system/return-logs/${returnId}/details`)
     })
 
     // Abstraction return

--- a/cypress/e2e/internal/return-logs/submit-edit-zero-meter-readings.cy.js
+++ b/cypress/e2e/internal/return-logs/submit-edit-zero-meter-readings.cy.js
@@ -24,7 +24,7 @@ describe('Submit then edit a meter readings return with zero reading (internal)'
       })
     })
     cy.get('@returnId').then((returnId) => {
-      cy.visit(`/system/return-logs/${returnId}`)
+      cy.visit(`/system/return-logs/${returnId}/details`)
     })
 
     // Abstraction return

--- a/cypress/e2e/internal/return-logs/submit-meter-readings.cy.js
+++ b/cypress/e2e/internal/return-logs/submit-meter-readings.cy.js
@@ -24,7 +24,7 @@ describe('Submit a meter readings return (internal)', () => {
       })
     })
     cy.get('@returnId').then((returnId) => {
-      cy.visit(`/system/return-logs/${returnId}`)
+      cy.visit(`/system/return-logs/${returnId}/details`)
     })
 
     // Abstraction return

--- a/cypress/e2e/internal/return-logs/submit-nil-return.cy.js
+++ b/cypress/e2e/internal/return-logs/submit-nil-return.cy.js
@@ -24,7 +24,7 @@ describe('Submit a nil return (internal)', () => {
       })
     })
     cy.get('@returnId').then((returnId) => {
-      cy.visit(`/system/return-logs/${returnId}`)
+      cy.visit(`/system/return-logs/${returnId}/details`)
     })
 
     // Abstraction return

--- a/cypress/e2e/internal/return-logs/submit-no-quantities.cy.js
+++ b/cypress/e2e/internal/return-logs/submit-no-quantities.cy.js
@@ -24,7 +24,7 @@ describe('Submit a return with no quantities - validation errors (internal)', ()
       })
     })
     cy.get('@returnId').then((returnId) => {
-      cy.visit(`/system/return-logs/${returnId}`)
+      cy.visit(`/system/return-logs/${returnId}/details`)
     })
 
     // Abstraction return

--- a/cypress/e2e/internal/return-logs/submit-no-readings.cy.js
+++ b/cypress/e2e/internal/return-logs/submit-no-readings.cy.js
@@ -24,7 +24,7 @@ describe('Submit a return with no meter readings - validation errors (internal)'
       })
     })
     cy.get('@returnId').then((returnId) => {
-      cy.visit(`/system/return-logs/${returnId}`)
+      cy.visit(`/system/return-logs/${returnId}/details`)
     })
 
     // Abstraction return

--- a/cypress/e2e/internal/return-logs/submit-single-volume.cy.js
+++ b/cypress/e2e/internal/return-logs/submit-single-volume.cy.js
@@ -24,7 +24,7 @@ describe('Submit a single volume return (internal)', () => {
       })
     })
     cy.get('@returnId').then((returnId) => {
-      cy.visit(`/system/return-logs/${returnId}`)
+      cy.visit(`/system/return-logs/${returnId}/details`)
     })
 
     // Abstraction return

--- a/cypress/e2e/internal/supplementary-billing-flags/editing-a-return.cy.js
+++ b/cypress/e2e/internal/supplementary-billing-flags/editing-a-return.cy.js
@@ -19,7 +19,7 @@ describe('Editing a return (internal)', () => {
         email: userEmail
       })
     })
-    cy.visit(`/system/return-logs/${scenario.returnLogs[0].id}`)
+    cy.visit(`/system/return-logs/${scenario.returnLogs[0].id}/details`)
 
     // Edit return
     cy.get('.govuk-button').first().click()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5581

Some time back, we updated the view return log page to [display all related communications](https://github.com/DEFRA/water-abstraction-system/pull/2744). For the first time, users could quickly access the notifications we've sent for the return log, confirming that the licensee had been sent their returns invitation and its status.

Unfortunately, notifications are stored in a single table that is not optimised for storing and searching the number of records it holds. We're working on fixing that, but in the meantime, queries against it can be slower than we'd like. From the user's point of view, it can add a noticeable delay to the page loading, which is not ideal.

We had the same issue when we [did the same for company contacts](https://github.com/DEFRA/water-abstraction-system/pull/3019), and found that [splitting the view page into details and communications](https://github.com/DEFRA/water-abstraction-system/pull/3147) alleviated the issue. It meant the details loaded instantly again, and for those who need it, communications could still be accessed.

Now that we have a solution, we've [applied it to return logs](https://github.com/DEFRA/water-abstraction-system/pull/3220).

This means those tests that start with `cy.visit(/system/return-logs/${returnId})` need to be updated to `cy.visit(/system/return-logs/${returnId}/details)`.

<img width="701" height="115" alt="Screenshot 2026-04-09 at 16 12 35" src="https://github.com/user-attachments/assets/92da6461-af6c-4b67-98d9-14afa3c3cae1" />
