### PR TITLE
Update project to be fully ES6 compliant

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -1,13 +1,12 @@
-'use strict'
+import { defineConfig } from 'cypress'
+import { readFileSync } from 'fs'
+import cypressMochawesomeReporter from 'cypress-mochawesome-reporter/plugin.js'
 
-const { defineConfig } = require('cypress')
-const { readFileSync } = require('fs')
-
-module.exports = defineConfig({
+export default defineConfig({
   e2e: {
     setupNodeEvents (on, config) {
       // implement node event listeners here
-      require('cypress-mochawesome-reporter/plugin')(on)
+      cypressMochawesomeReporter(on)
 
       // Read in environment specific config
       const text = readFileSync(`./environments/${config.env.environment}.json`)

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -16,6 +16,3 @@
 // Import commands.js using ES2015 syntax:
 import './commands'
 import 'cypress-mochawesome-reporter/register'
-
-// Alternatively you can use CommonJS syntax:
-// require('./commands')

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Automated acceptance tests for the Water Abstraction Service",
   "homepage": "https://github.com/DEFRA/water-abstraction-team",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "cy:open:local": "cypress open --e2e --env environment=local",
     "cy:open:dev": "cypress open --e2e --env environment=dev",


### PR DESCRIPTION
It has always been our intention to make all Water Abstraction repos fully ES6 compliant.

> ECMAScript modules are the official standard format to package JavaScript code for reuse.
>
> [Node ECMAScript modules](https://nodejs.org/api/esm.html#introduction)

They are the standard for JavaScript and offer other benefits, such as enabling tree-shaking to improve performance and reduce bundle size.

Pretty much all the work we have done on acceptance tests has taken an 'ES6-first' approach, but we've never gone so far as to declare it in `package.json`.

We've been working on [adding the ability to seed scenarios from the command line](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/225), which is dependent on some ES6-only packages. If the project were fully ES6 compliant, we wouldn't have to use things like `--experimental-specifier-resolution=node` flag when running tests, or workarounds for importing them into CommonJS modules.

So, that has given us the nudge to set the 'type' in our `package.json` to 'module' and to make the necessary changes to our codebase to be fully ES6-compliant.

<img width="709" height="117" alt="Screenshot 2026-04-15 at 16 40 07" src="https://github.com/user-attachments/assets/4e61c334-c6f0-43da-bdc5-6200351b94ca" />
