### PR TITLE
Update cli:seed to support continued usage

### DIFF
--- a/cli/seed.cli.js
+++ b/cli/seed.cli.js
@@ -30,7 +30,7 @@ async function run () {
 
   const scenarios = _scenarios()
 
-  let selectedScenario = undefined
+  let selectedScenario
 
   // Persistent loop until user aborts
   while (true) {

--- a/cli/seed.cli.js
+++ b/cli/seed.cli.js
@@ -30,17 +30,38 @@ async function run () {
 
   const scenarios = _scenarios()
 
-  const selectedScenario = await _prompt(scenarios)
+  let selectedScenario = undefined
 
-  await _tearDown()
+  // Persistent loop until user aborts
+  while (true) {
+    try {
+      selectedScenario = await _prompt(scenarios, selectedScenario)
 
-  const body = await _body(selectedScenario)
+      await _tearDown()
 
-  await _load(selectedScenario, body)
+      const body = await _body(selectedScenario)
 
-  logSuccess('Finished!')
+      await _load(selectedScenario, body)
+
+      logSuccess(`${styleBold('Finished!')} (press Escape to exit)\n`)
+    } catch (err) {
+      // Handle exit signals from Inquirer
+      if (['AbortPromptError', 'ExitPromptError'].includes(err.name)) {
+        logWarning('\nGoodbye!')
+        break
+      } else {
+        // Log the error but stay in the loop so the user can try again
+        logError(`\nError: ${err.message}`)
+        logInfo('Returning to menu... (press Escape to exit)\n')
+      }
+    }
+  }
 }
 
+/**
+ * Extract data from the scenario file
+ * @private
+ */
 async function _body (selectedScenario) {
   // 1. Get the absolute path
   const scenarioPath = path.resolve(SCENARIOS_DIR, `${selectedScenario}.js`)
@@ -60,6 +81,10 @@ async function _body (selectedScenario) {
   return await getBody()
 }
 
+/**
+ * Send scenario data to the water-abstraction-system for loading
+ * @private
+ */
 async function _load (selectedScenario, body) {
   logInfo(`Loading scenario ${styleBold(selectedScenario)}...`)
 
@@ -91,10 +116,11 @@ async function _load (selectedScenario, body) {
  *
  * @private
  */
-async function _prompt (scenarios) {
+async function _prompt (scenarios, defaultValue) {
   return search(
     {
       message: 'Type to search scenarios:',
+      default: defaultValue, // Highlights the last used scenario
       source: async (input) => {
         let filteredScenarios = scenarios
 
@@ -114,6 +140,10 @@ async function _prompt (scenarios) {
   )
 }
 
+/**
+ * Get list of available scenario files
+ * @private
+ */
 function _scenarios () {
   return fs.readdirSync(SCENARIOS_DIR)
     .filter((file) => {
@@ -124,25 +154,24 @@ function _scenarios () {
     })
 }
 
+/**
+ * Clear existing data
+ * @private
+ */
 async function _tearDown () {
   logInfo('Tearing down previous scenario data...')
 
   await post('/system/data/tear-down')
 }
 
+/**
+ * Global keypress listener for the Escape key signal
+ */
 process.stdin.on('keypress', (str, key) => {
   if (key.name === 'escape') {
     ESCAPE_KEY_ABORT_CONTROLLER.abort()
   }
 })
 
-try {
-  await run()
-} catch (err) {
-  if (['AbortPromptError', 'ExitPromptError'].includes(err.name)) {
-    logWarning('\nCancelled')
-  } else {
-    logError(err.message)
-    process.exit(1) // Standard practice to exit with failure code
-  }
-}
+// Entry point
+await run()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5602

When we added our new `cli:seed` feature, we made it a 'one-and-done' CLI. However, our workflow will often consist of seeding the test data, performing a manual test, and then repeating the seeding to reset the test data.

It's only a minor overhead to restart the CLI each time. But it would be much cleaner to keep the CLI open with your previous entry selected. 😁 