### PR TITLE
Fix scenarios that fail to load via cli:seed 

### DIFF
--- a/cli/seed.cli.js
+++ b/cli/seed.cli.js
@@ -20,13 +20,15 @@ import path from 'path'
 import { search } from '@inquirer/prompts'
 
 import { logError, logInfo, logSuccess, logWarning, styleBold } from './log.lib.js'
-import { post } from './system.request.js'
+import { get, post } from './system.request.js'
 
 const ESCAPE_KEY_ABORT_CONTROLLER = new AbortController()
 const SCENARIOS_DIR = 'cypress/support/scenarios'
 
 async function run () {
   logInfo(styleBold('Use this tool to load test scenarios for manual exploratory testing\n'))
+
+  const currentServiceData = await _currentServiceData()
 
   const scenarios = _scenarios()
 
@@ -39,7 +41,7 @@ async function run () {
 
       await _tearDown()
 
-      const body = await _body(selectedScenario)
+      const body = await _body(selectedScenario, currentServiceData)
 
       await _load(selectedScenario, body)
 
@@ -59,10 +61,27 @@ async function run () {
 }
 
 /**
+ * Fetch 'current' data for the service
+ *
+ * This is information like the current financial year, summer and winter
+ * cycles, and billing periods.
+ *
+ * Some scenarios need this information to dynamically generate the data they
+ * will seed.
+ *
+ * @private
+ */
+async function _currentServiceData () {
+  const response = await get('/system/data/dates')
+
+  return response.json()
+}
+
+/**
  * Extract data from the scenario file
  * @private
  */
-async function _body (selectedScenario) {
+async function _body (selectedScenario, currentServiceData) {
   // 1. Get the absolute path
   const scenarioPath = path.resolve(SCENARIOS_DIR, `${selectedScenario}.js`)
 
@@ -78,7 +97,7 @@ async function _body (selectedScenario) {
   }
 
   // 4. Call the function here to get the actual data object
-  return await getBody()
+  return await getBody(currentServiceData)
 }
 
 /**

--- a/cli/system.request.js
+++ b/cli/system.request.js
@@ -17,11 +17,26 @@ import path from 'path'
 
 const ENVS_DIR = 'environments'
 
+export async function get (path) {
+  const env = await _environment()
+
+  const url = new URL(path, env.config.baseUrl)
+  const requestOptions = _requestOptions('GET')
+
+  const response = await fetch(url, requestOptions)
+
+  if (!response.ok) {
+    await _error(path, response)
+  }
+
+  return response
+}
+
 export async function post (path, body = null) {
   const env = await _environment()
 
   const url = new URL(path, env.config.baseUrl)
-  const requestOptions = _requestOptions(body)
+  const requestOptions = _requestOptions('POST', body)
 
   const response = await fetch(url, requestOptions)
 
@@ -61,9 +76,9 @@ async function _error (path, response) {
   throw new Error(message)
 }
 
-function _requestOptions (body) {
+function _requestOptions (method, body) {
   const requestOptions = {
-    method: 'POST'
+    method
   }
 
   if (body) {

--- a/cypress/e2e/internal/notices/ad-hoc/paper-returns.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/paper-returns.cy.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import scenarioData from '../../../../support/scenarios/licence-with-due-return-log.js'
+import scenarioData from '../../../../support/scenarios/licence-with-return-log.js'
 
 describe('Ad-hoc Paper returns journey (internal)', () => {
   beforeEach(() => {
@@ -10,7 +10,7 @@ describe('Ad-hoc Paper returns journey (internal)', () => {
       const period = body.firstReturnPeriod
 
       cy.previousPeriod(period).then((previousPeriod) => {
-        const scenario = scenarioData(previousPeriod, false)
+        const scenario = scenarioData(previousPeriod)
 
         cy.load(scenario)
       })

--- a/cypress/e2e/internal/notices/ad-hoc/paper-returns.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/paper-returns.cy.js
@@ -1,19 +1,15 @@
 'use strict'
 
-import scenarioData from '../../../../support/scenarios/licence-with-return-log.js'
+import scenarioData from '../../../../support/scenarios/licence-with-previous-return-log.js'
 
 describe('Ad-hoc Paper returns journey (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
 
     cy.calculatedDates().then((body) => {
-      const period = body.firstReturnPeriod
+      const scenario = scenarioData(body)
 
-      cy.previousPeriod(period).then((previousPeriod) => {
-        const scenario = scenarioData(previousPeriod)
-
-        cy.load(scenario)
-      })
+      cy.load(scenario)
     })
 
     cy.fixture('users.json').its('billingAndData').as('userEmail')

--- a/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import scenarioData from '../../../../support/scenarios/licence-with-due-return-log.js'
+import scenarioData from '../../../../support/scenarios/licence-with-return-log.js'
 
 describe('Ad-hoc returns invitation journey (internal)', () => {
   beforeEach(() => {
@@ -9,7 +9,7 @@ describe('Ad-hoc returns invitation journey (internal)', () => {
       const period = body.firstReturnPeriod
 
       cy.previousPeriod(period).then((previousPeriod) => {
-        const scenario = scenarioData(previousPeriod, false)
+        const scenario = scenarioData(previousPeriod)
 
         cy.load(scenario)
       })

--- a/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
@@ -1,18 +1,14 @@
 'use strict'
 
-import scenarioData from '../../../../support/scenarios/licence-with-return-log.js'
+import scenarioData from '../../../../support/scenarios/licence-with-previous-return-log.js'
 
 describe('Ad-hoc returns invitation journey (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
     cy.calculatedDates().then((body) => {
-      const period = body.firstReturnPeriod
-
-      cy.previousPeriod(period).then((previousPeriod) => {
-        const scenario = scenarioData(previousPeriod)
+      const scenario = scenarioData(body)
 
         cy.load(scenario)
-      })
     })
 
     cy.fixture('users.json').its('billingAndData').as('userEmail')

--- a/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
@@ -8,7 +8,7 @@ describe('Ad-hoc returns invitation journey (internal)', () => {
     cy.calculatedDates().then((body) => {
       const scenario = scenarioData(body)
 
-        cy.load(scenario)
+      cy.load(scenario)
     })
 
     cy.fixture('users.json').its('billingAndData').as('userEmail')

--- a/cypress/e2e/internal/notices/standard/returns-invitation.cy.js
+++ b/cypress/e2e/internal/notices/standard/returns-invitation.cy.js
@@ -1,12 +1,12 @@
 'use strict'
 
-import scenarioData from '../../../../support/scenarios/licence-with-due-return-log.js'
+import scenarioData from '../../../../support/scenarios/licence-with-return-log.js'
 
 describe('Standard returns invitation journey (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
     cy.calculatedDates().then((body) => {
-      const scenario = scenarioData(body.firstReturnPeriod, false)
+      const scenario = scenarioData(body.firstReturnPeriod)
 
       cy.load(scenario)
     })

--- a/cypress/e2e/internal/notices/standard/returns-invitation.cy.js
+++ b/cypress/e2e/internal/notices/standard/returns-invitation.cy.js
@@ -6,7 +6,7 @@ describe('Standard returns invitation journey (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
     cy.calculatedDates().then((body) => {
-      const scenario = scenarioData(body.firstReturnPeriod)
+      const scenario = scenarioData(body)
 
       cy.load(scenario)
     })

--- a/cypress/e2e/internal/notices/standard/returns-reminder.cy.js
+++ b/cypress/e2e/internal/notices/standard/returns-reminder.cy.js
@@ -7,7 +7,7 @@ describe('Standard returns reminder journey (internal)', () => {
     cy.tearDown()
 
     cy.calculatedDates().then((body) => {
-      const scenario = scenarioData(body.firstReturnPeriod)
+      const scenario = scenarioData(body)
 
       cy.load(scenario)
     })

--- a/cypress/e2e/internal/notices/standard/returns-reminder.cy.js
+++ b/cypress/e2e/internal/notices/standard/returns-reminder.cy.js
@@ -7,7 +7,7 @@ describe('Standard returns reminder journey (internal)', () => {
     cy.tearDown()
 
     cy.calculatedDates().then((body) => {
-      const scenario = scenarioData(body.firstReturnPeriod, true)
+      const scenario = scenarioData(body.firstReturnPeriod)
 
       cy.load(scenario)
     })

--- a/cypress/e2e/internal/return-logs/record-receipt.cy.js
+++ b/cypress/e2e/internal/return-logs/record-receipt.cy.js
@@ -6,7 +6,7 @@ describe('Record receipt for return (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
     cy.calculatedDates().then((body) => {
-      const scenario = scenarioData(body.firstReturnPeriod)
+      const scenario = scenarioData(body)
 
       cy.load(scenario)
 

--- a/cypress/e2e/internal/return-logs/submit-edit-zero-abstraction-volumes.cy.js
+++ b/cypress/e2e/internal/return-logs/submit-edit-zero-abstraction-volumes.cy.js
@@ -7,7 +7,7 @@ describe('Submit then edit an abstraction volumes return with zero quantities (i
     cy.tearDown()
 
     cy.calculatedDates().then((body) => {
-      const scenario = scenarioData(body.firstReturnPeriod)
+      const scenario = scenarioData(body)
 
       cy.load(scenario)
 

--- a/cypress/e2e/internal/return-logs/submit-edit-zero-meter-readings.cy.js
+++ b/cypress/e2e/internal/return-logs/submit-edit-zero-meter-readings.cy.js
@@ -7,7 +7,7 @@ describe('Submit then edit a meter readings return with zero reading (internal)'
     cy.tearDown()
 
     cy.calculatedDates().then((body) => {
-      const scenario = scenarioData(body.firstReturnPeriod)
+      const scenario = scenarioData(body)
 
       cy.load(scenario)
 

--- a/cypress/e2e/internal/return-logs/submit-meter-readings.cy.js
+++ b/cypress/e2e/internal/return-logs/submit-meter-readings.cy.js
@@ -7,7 +7,7 @@ describe('Submit a meter readings return (internal)', () => {
     cy.tearDown()
 
     cy.calculatedDates().then((body) => {
-      const scenario = scenarioData(body.firstReturnPeriod)
+      const scenario = scenarioData(body)
 
       cy.load(scenario)
 

--- a/cypress/e2e/internal/return-logs/submit-nil-return.cy.js
+++ b/cypress/e2e/internal/return-logs/submit-nil-return.cy.js
@@ -7,7 +7,7 @@ describe('Submit a nil return (internal)', () => {
     cy.tearDown()
 
     cy.calculatedDates().then((body) => {
-      const scenario = scenarioData(body.firstReturnPeriod)
+      const scenario = scenarioData(body)
 
       cy.load(scenario)
 

--- a/cypress/e2e/internal/return-logs/submit-no-quantities.cy.js
+++ b/cypress/e2e/internal/return-logs/submit-no-quantities.cy.js
@@ -7,7 +7,7 @@ describe('Submit a return with no quantities - validation errors (internal)', ()
     cy.tearDown()
 
     cy.calculatedDates().then((body) => {
-      const scenario = scenarioData(body.firstReturnPeriod)
+      const scenario = scenarioData(body)
 
       cy.load(scenario)
 

--- a/cypress/e2e/internal/return-logs/submit-no-readings.cy.js
+++ b/cypress/e2e/internal/return-logs/submit-no-readings.cy.js
@@ -7,7 +7,7 @@ describe('Submit a return with no meter readings - validation errors (internal)'
     cy.tearDown()
 
     cy.calculatedDates().then((body) => {
-      const scenario = scenarioData(body.firstReturnPeriod)
+      const scenario = scenarioData(body)
 
       cy.load(scenario)
 

--- a/cypress/e2e/internal/return-logs/submit-single-volume.cy.js
+++ b/cypress/e2e/internal/return-logs/submit-single-volume.cy.js
@@ -7,7 +7,7 @@ describe('Submit a single volume return (internal)', () => {
     cy.tearDown()
 
     cy.calculatedDates().then((body) => {
-      const scenario = scenarioData(body.firstReturnPeriod)
+      const scenario = scenarioData(body)
 
       cy.load(scenario)
 

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -103,32 +103,6 @@ Cypress.Commands.add('quarterlyPeriods', (year = null) => {
   return cy.wrap(periods)
 })
 
-Cypress.Commands.add('previousPeriod', (period) => {
-  cy.log('Push a return period back by one')
-
-  const previousPeriod = {
-    dueDate: period.dueDate ? new Date(period.dueDate) : null,
-    endDate: new Date(period.endDate),
-    name: period.name,
-    quarterly: period.quarterly,
-    startDate: new Date(period.startDate)
-  }
-
-  let monthsBack = 12
-  if (period.quarterly) {
-    monthsBack = 3
-  }
-
-  previousPeriod.endDate.setMonth(previousPeriod.endDate.getMonth() - monthsBack)
-  previousPeriod.startDate.setMonth(previousPeriod.startDate.getMonth() - monthsBack)
-
-  if (period.dueDate) {
-    previousPeriod.dueDate.setMonth(previousPeriod.dueDate.getMonth() - monthsBack)
-  }
-
-  return cy.wrap(previousPeriod)
-})
-
 // We do not control when the tests are run so sometimes we need a date that is within the current financial year when
 // they are. For example, when testing billing scenarios we often only want to make charge information changes within
 // the current year to avoid additional calculations for previous years.

--- a/cypress/support/helpers/previous-period.js
+++ b/cypress/support/helpers/previous-period.js
@@ -1,0 +1,33 @@
+/**
+ * Given a return period, returns a new period with the same properties but start and end dates moved back 1 period
+ *
+ * If the given period is quarterly, the dates will be moved back by 3 months. If it's not quarterly, the dates will be
+ * moved back by 12 months.
+ *
+ * @param {object} period - The return period to calculate the previous period for
+ *
+ * @return {object} The previous return period to the one provided
+ */
+export default function (period) {
+  const previousPeriod = {
+    dueDate: period.dueDate ? new Date(period.dueDate) : null,
+    endDate: new Date(period.endDate),
+    name: period.name,
+    quarterly: period.quarterly,
+    startDate: new Date(period.startDate)
+  }
+
+  let monthsBack = 12
+  if (period.quarterly) {
+    monthsBack = 3
+  }
+
+  previousPeriod.endDate.setMonth(previousPeriod.endDate.getMonth() - monthsBack)
+  previousPeriod.startDate.setMonth(previousPeriod.startDate.getMonth() - monthsBack)
+
+  if (period.dueDate) {
+    previousPeriod.dueDate.setMonth(previousPeriod.dueDate.getMonth() - monthsBack)
+  }
+
+  return previousPeriod
+}

--- a/cypress/support/scenarios/licence-with-due-return-log.js
+++ b/cypress/support/scenarios/licence-with-due-return-log.js
@@ -4,10 +4,12 @@ import returnLogs from '../fixture-builder/return-logs.js'
 import returnRequirements from '../fixture-builder/return-requirements.js'
 import returnVersion from '../fixture-builder/return-version.js'
 
-export default function (returnPeriod) {
-  const dueDate = new Date(returnPeriod.dueDate)
-  const endDate = new Date(returnPeriod.endDate)
-  const startDate = new Date(returnPeriod.startDate)
+export default function (currentServiceData) {
+  const { firstReturnPeriod } = currentServiceData
+
+  const dueDate = new Date(firstReturnPeriod.dueDate)
+  const endDate = new Date(firstReturnPeriod.endDate)
+  const startDate = new Date(firstReturnPeriod.startDate)
 
   const dueDateString = formatDateToIso(dueDate)
   const endDateString = formatDateToIso(endDate)
@@ -31,7 +33,7 @@ export default function (returnPeriod) {
   dataModel.returnLogs[0].returnRequirementId = dataModel.returnRequirements[0].id
   dataModel.returnLogs[0].startDate = startDateString
   dataModel.returnLogs[0].status = 'due'
-  dataModel.returnLogs[0].quarterly = returnPeriod.quarterly
+  dataModel.returnLogs[0].quarterly = firstReturnPeriod.quarterly
 
   return dataModel
 }

--- a/cypress/support/scenarios/licence-with-previous-return-log.js
+++ b/cypress/support/scenarios/licence-with-previous-return-log.js
@@ -1,0 +1,40 @@
+import formatDateToIso from '../helpers/formatDateToIso.js'
+import licenceData from '../fixture-builder/licence.js'
+import previousPeriod from '../helpers/previous-period.js'
+import returnLogs from '../fixture-builder/return-logs.js'
+import returnRequirements from '../fixture-builder/return-requirements.js'
+import returnVersion from '../fixture-builder/return-version.js'
+
+export default function (currentServiceData) {
+  const { firstReturnPeriod } = currentServiceData
+
+  const previousReturnPeriod = previousPeriod(firstReturnPeriod)
+
+  const endDate = new Date(previousReturnPeriod.endDate)
+  const startDate = new Date(previousReturnPeriod.startDate)
+
+  const endDateString = formatDateToIso(endDate)
+  const startDateString = formatDateToIso(startDate)
+
+  const dataModel = {
+    ...licenceData(),
+    ...returnVersion(),
+    ...returnRequirements(),
+    ...returnLogs(1)
+  }
+
+  dataModel.returnLogs[0].dueDate = null
+  dataModel.returnLogs[0].endDate = endDateString
+  dataModel.returnLogs[0].id = '7f6ff22b-f7f6-4f37-a29e-244fad5a22eb'
+  dataModel.returnLogs[0].metadata.description = dataModel.returnRequirements[0].siteDescription
+  dataModel.returnLogs[0].metadata.isSummer = dataModel.returnRequirements[0].summer
+  dataModel.returnLogs[0].returnCycleId.value = `${startDate.getFullYear()}-04-01`
+  dataModel.returnLogs[0].returnId = `v1:8:AT/TE/ST/01/01:9999990:${startDateString}:${endDateString}`
+  dataModel.returnLogs[0].returnReference = dataModel.returnRequirements[0].legacyId
+  dataModel.returnLogs[0].returnRequirementId = dataModel.returnRequirements[0].id
+  dataModel.returnLogs[0].startDate = startDateString
+  dataModel.returnLogs[0].status = 'due'
+  dataModel.returnLogs[0].quarterly = previousReturnPeriod.quarterly
+
+  return dataModel
+}

--- a/cypress/support/scenarios/licence-with-return-log.js
+++ b/cypress/support/scenarios/licence-with-return-log.js
@@ -4,12 +4,12 @@ import returnLogs from '../fixture-builder/return-logs.js'
 import returnRequirements from '../fixture-builder/return-requirements.js'
 import returnVersion from '../fixture-builder/return-version.js'
 
-export default function (returnPeriod) {
-  const dueDate = new Date(returnPeriod.dueDate)
-  const endDate = new Date(returnPeriod.endDate)
-  const startDate = new Date(returnPeriod.startDate)
+export default function (currentServiceData) {
+  const { firstReturnPeriod } = currentServiceData
 
-  const dueDateString = formatDateToIso(dueDate)
+  const endDate = new Date(firstReturnPeriod.endDate)
+  const startDate = new Date(firstReturnPeriod.startDate)
+
   const endDateString = formatDateToIso(endDate)
   const startDateString = formatDateToIso(startDate)
 
@@ -31,7 +31,7 @@ export default function (returnPeriod) {
   dataModel.returnLogs[0].returnRequirementId = dataModel.returnRequirements[0].id
   dataModel.returnLogs[0].startDate = startDateString
   dataModel.returnLogs[0].status = 'due'
-  dataModel.returnLogs[0].quarterly = returnPeriod.quarterly
+  dataModel.returnLogs[0].quarterly = firstReturnPeriod.quarterly
 
   return dataModel
 }

--- a/cypress/support/scenarios/licence-with-return-log.js
+++ b/cypress/support/scenarios/licence-with-return-log.js
@@ -20,7 +20,7 @@ export default function (returnPeriod) {
     ...returnLogs(1)
   }
 
-  dataModel.returnLogs[0].dueDate = dueDateString
+  dataModel.returnLogs[0].dueDate = null
   dataModel.returnLogs[0].endDate = endDateString
   dataModel.returnLogs[0].id = '7f6ff22b-f7f6-4f37-a29e-244fad5a22eb'
   dataModel.returnLogs[0].metadata.description = dataModel.returnRequirements[0].siteDescription

--- a/cypress/support/scenarios/one-return-requirement-four-return-logs.js
+++ b/cypress/support/scenarios/one-return-requirement-four-return-logs.js
@@ -7,7 +7,7 @@ import returnRequirements from '../fixture-builder/return-requirements.js'
 import returnRequirementPoints from '../fixture-builder/return-requirement-points.js'
 import returnVersion from '../fixture-builder/return-version.js'
 
-export default function basicLicenceOneReturnRequirementsWithFourReturnLogs () {
+export default function () {
   const dataModel = {
     ...licence(),
     ...points(),

--- a/cypress/support/scenarios/one-return-requirement-quarterly-returns.js
+++ b/cypress/support/scenarios/one-return-requirement-quarterly-returns.js
@@ -7,7 +7,7 @@ import returnRequirements from '../fixture-builder/return-requirements.js'
 import returnRequirementPoints from '../fixture-builder/return-requirement-points.js'
 import returnVersion from '../fixture-builder/return-version.js'
 
-export default function basicLicenceOneReturnRequirementQuarterlyReturns () {
+export default function () {
   const dataModel = {
     ...licence(),
     ...points(),

--- a/cypress/support/scenarios/one-return-requirement-two-points.js
+++ b/cypress/support/scenarios/one-return-requirement-two-points.js
@@ -5,7 +5,7 @@ import returnRequirements from '../fixture-builder/return-requirements.js'
 import returnRequirementPoints from '../fixture-builder/return-requirement-points.js'
 import returnVersion from '../fixture-builder/return-version.js'
 
-export default function basicLicenceOneReturnRequirementsWithTwoPoints () {
+export default function () {
   const dataModel = {
     ...licence(),
     ...points(2),

--- a/cypress/support/scenarios/one-return-requirement.js
+++ b/cypress/support/scenarios/one-return-requirement.js
@@ -2,7 +2,7 @@ import licence from '../fixture-builder/licence.js'
 import returnRequirements from '../fixture-builder/return-requirements.js'
 import returnVersion from '../fixture-builder/return-version.js'
 
-export default function basicLicenceOneReturnRequirement () {
+export default function () {
   return {
     ...licence(),
     ...returnVersion(),

--- a/cypress/support/scenarios/two-part-tariff-supplementary.js
+++ b/cypress/support/scenarios/two-part-tariff-supplementary.js
@@ -10,7 +10,7 @@ import licenceData from '../fixture-builder/licence.js'
 import licenceVersionPurposesData from '../fixture-builder/licence-version-purposes.js'
 import returnLogsData from '../fixture-builder/return-logs.js'
 
-export default function twoPartTariffSupplementary () {
+export default function () {
   const licenceRecords = _licenceRecords()
   const licenceRef = licenceRecords.licences[0].licenceRef
 

--- a/cypress/support/scenarios/two-return-requirements-three-return-logs.js
+++ b/cypress/support/scenarios/two-return-requirements-three-return-logs.js
@@ -7,7 +7,7 @@ import returnRequirements from '../fixture-builder/return-requirements.js'
 import returnRequirementPoints from '../fixture-builder/return-requirement-points.js'
 import returnVersion from '../fixture-builder/return-version.js'
 
-export default function basicLicenceTwoReturnRequirementsWithThreeReturnLogsEach () {
+export default function () {
   const dataModel = {
     ...licence(),
     ...points(2),

--- a/cypress/support/scenarios/two-return-requirements-two-return-logs.js
+++ b/cypress/support/scenarios/two-return-requirements-two-return-logs.js
@@ -7,7 +7,7 @@ import returnRequirements from '../fixture-builder/return-requirements.js'
 import returnRequirementPoints from '../fixture-builder/return-requirement-points.js'
 import returnVersion from '../fixture-builder/return-version.js'
 
-export default function basicLicenceTwoDifferentReturnRequirementsWithTwoReturnLogsEach () {
+export default function () {
   const dataModel = {
     ...licence(),
     ...points(2),

--- a/cypress/support/scenarios/two-return-requirements-with-points.js
+++ b/cypress/support/scenarios/two-return-requirements-with-points.js
@@ -5,7 +5,7 @@ import returnRequirements from '../fixture-builder/return-requirements.js'
 import returnRequirementPoints from '../fixture-builder/return-requirement-points.js'
 import returnVersion from '../fixture-builder/return-version.js'
 
-export default function basicLicenceTwoReturnRequirementsWithPoints () {
+export default function () {
   return {
     ...licence(),
     ...points(2),


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5602

We recently added a new `cli:seed` feature to the project, which allows us to load our scenarios via the command line. It means we can seed the service with a scenario we want to manually test or investigate.

However, in testing, we found that a number of scenarios threw an error when we attempted to load them.

In most cases, it was simply that the scenarios were exporting a named method. Removing the name resolved the issue with how `seed.cli.js` loaded them.

The last scenario was because it expected arguments to be passed in. Unfortunately, we can't do that with our new tool.

To get it loading, we had to make a number of changes.

- Where the arguments were being used to generate different scenarios, we instead created new scenario modules. This meant we could remove those arguments.
- Some tests were doing some work and then passing the result into the scenario. We moved that work into one of our new scenario modules, and those tests now load it.
- The primary issue was that the scenario needed calculated current data values from the service, which are retrieved via a Cypress command. The tests would then extract what was needed from the response and pass it in. We replicated the call to [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) in `cli:seed` and amended both the tests and scenarios to pass the whole response in. The scenarios now extract what they need

For that last change, we just pass in the current data to _all_ our scenarios in `cli:seed`. This keeps things simple there, and scenarios can use it or ignore it.

Now, all tests are passing and all scenarios can be loaded via `cli:seed`! 🏆 

<img width="692" height="71" alt="Screenshot 2026-04-23 at 22 29 24" src="https://github.com/user-attachments/assets/6e602b0d-0644-41a2-a78a-7d9c9a3b5070" />

---

<details>
<summary>All scenarios loading</summary>

<img width="362" height="1318" alt="water-5602_all-scenarios-loading" src="https://github.com/user-attachments/assets/d2403a6a-bd52-42f1-a8a1-e53fa0894c21" />

</details>


