### PR TITLE
Update failing return notice scenarios

### DIFF
--- a/cypress/e2e/internal/notices/standard/returns-invitation.cy.js
+++ b/cypress/e2e/internal/notices/standard/returns-invitation.cy.js
@@ -39,10 +39,26 @@ describe('Standard returns invitation journey (internal)', () => {
     cy.get('[data-test="returns-notice-type"]').should('contain.text', 'Returns invitation')
     cy.contains('Confirm').click()
 
+    // Capture the notice reference so we can verify it later
+    cy.contains('.govuk-caption-l', 'Notice').invoke('text').then((text) => {
+      cy.wrap(text.trim()).as('noticeReference')
+    })
+
     // Check the recipients
     cy.contains('Send').click()
 
     // Notice confirmation
     cy.get('.govuk-panel__title', { timeout: 15000 }).contains('Returns invitations sent')
+    cy.get('.govuk-link').contains('View notice').click()
+
+    // Notice page contains our seeded recipient
+    cy.get('@noticeReference').then((noticeReference) => {
+      cy.contains('.govuk-caption-l', noticeReference)
+    })
+
+    cy.get('#main-content > details > summary > span').click()
+    cy.get('[data-test="filter-licence"]').type('AT/TE/ST/01/01')
+    cy.contains('Apply filters').click()
+    cy.get('[data-test="notification-licences-0"]').should('contain.text', 'AT/TE/ST/01/01')
   })
 })

--- a/cypress/e2e/internal/notices/standard/returns-reminder.cy.js
+++ b/cypress/e2e/internal/notices/standard/returns-reminder.cy.js
@@ -40,10 +40,26 @@ describe('Standard returns reminder journey (internal)', () => {
     cy.get('[data-test="returns-notice-type"]').should('contain.text', 'Returns reminder')
     cy.contains('Confirm').click()
 
+    // Capture the notice reference so we can verify it later
+    cy.contains('.govuk-caption-l', 'Notice').invoke('text').then((text) => {
+      cy.wrap(text.trim()).as('noticeReference')
+    })
+
     // Check the recipients
     cy.contains('Send').click()
 
     // Notice confirmation
     cy.get('.govuk-panel__title', { timeout: 15000 }).contains('Returns reminders sent')
+    cy.get('.govuk-link').contains('View notice').click()
+
+    // Notice page contains our seeded recipient
+    cy.get('@noticeReference').then((noticeReference) => {
+      cy.contains('.govuk-caption-l', noticeReference)
+    })
+
+    cy.get('#main-content > details > summary > span').click()
+    cy.get('[data-test="filter-licence"]').type('AT/TE/ST/01/01')
+    cy.contains('Apply filters').click()
+    cy.get('[data-test="notification-licences-0"]').should('contain.text', 'AT/TE/ST/01/01')
   })
 })

--- a/cypress/e2e/internal/notices/standard/returns-reminder.cy.js
+++ b/cypress/e2e/internal/notices/standard/returns-reminder.cy.js
@@ -1,6 +1,6 @@
 'use strict'
 
-import scenarioData from '../../../../support/scenarios/licence-with-due-return-log.js'
+import scenarioData from '../../../../support/scenarios/licence-with-due-return-log-for-first-period.js'
 
 describe('Standard returns reminder journey (internal)', () => {
   beforeEach(() => {

--- a/cypress/support/scenarios/licence-with-due-return-log-for-first-period.js
+++ b/cypress/support/scenarios/licence-with-due-return-log-for-first-period.js
@@ -1,0 +1,39 @@
+import licenceData from '../fixture-builder/licence.js'
+import returnLogs from '../fixture-builder/return-logs.js'
+import returnRequirements from '../fixture-builder/return-requirements.js'
+import returnVersion from '../fixture-builder/return-version.js'
+import { formatDateToIso } from '../helpers/date.helpers.js'
+
+export default function (currentServiceData) {
+  const { firstReturnPeriod } = currentServiceData
+
+  const dueDate = new Date(firstReturnPeriod.dueDate)
+  const endDate = new Date(firstReturnPeriod.endDate)
+  const startDate = new Date(firstReturnPeriod.startDate)
+
+  const dueDateString = formatDateToIso(dueDate)
+  const endDateString = formatDateToIso(endDate)
+  const startDateString = formatDateToIso(startDate)
+
+  const dataModel = {
+    ...licenceData(),
+    ...returnVersion(),
+    ...returnRequirements(),
+    ...returnLogs(1)
+  }
+
+  dataModel.returnLogs[0].dueDate = dueDateString
+  dataModel.returnLogs[0].endDate = endDateString
+  dataModel.returnLogs[0].id = '7f6ff22b-f7f6-4f37-a29e-244fad5a22eb'
+  dataModel.returnLogs[0].metadata.description = dataModel.returnRequirements[0].siteDescription
+  dataModel.returnLogs[0].metadata.isSummer = dataModel.returnRequirements[0].summer
+  dataModel.returnLogs[0].returnCycleId.value = `${startDate.getFullYear()}-04-01`
+  dataModel.returnLogs[0].returnId = `v1:8:AT/TE/ST/01/01:9999990:${startDateString}:${endDateString}`
+  dataModel.returnLogs[0].returnReference = dataModel.returnRequirements[0].legacyId
+  dataModel.returnLogs[0].returnRequirementId = dataModel.returnRequirements[0].id
+  dataModel.returnLogs[0].startDate = startDateString
+  dataModel.returnLogs[0].status = 'due'
+  dataModel.returnLogs[0].quarterly = firstReturnPeriod.quarterly
+
+  return dataModel
+}


### PR DESCRIPTION
We recently encountered a problem when the date changed from April 28 to 29. The return periods we calculate and present to the user have switched to

- Quarterly 1 April 2026 to 30 June 2026
- Quarterly 1 July 2026 to 30 September 2026

The scenario used by the return log tests used the firstPeriod to set the start and end date of the return log it generates. But those tests are also expected to be able to submit the return log, which is not possible if the end date is set in the future.

This scenario is also used by some of the return notice tests.

We fixed it by shifting the period back to the previous one if its end date was in the future.

All tests passed, honest!

What then happened is some users reported the returns reminder test failing, whilst others said it passed fine. We realise now that it was passing for those who had other licences with returns for the selected period, but those who relied on seed data saw it fail

This change adds a scenario where we add a due return log for the first period. We also update the tests to assert that the seed data is in the recipients. This should ensure it fails for all if a similar data issue happens again.