### PR TITLE
Update expected result order in adhoc rtn invite

### DIFF
--- a/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/returns-invitation.cy.js
@@ -74,27 +74,28 @@ describe('Ad-hoc returns invitation journey (internal)', () => {
 
     // Additional recipient is shown in the list
     cy.get('[data-test^="recipient-contact"]').should('have.length', 2)
-    cy.get('[data-test="recipient-contact-0"]').within(() => {
+
+    cy.get('[data-test="recipient-contact-0"]').should('contain.text', 'external@example.com')
+    cy.get('[data-test="recipient-licence-numbers-0"]').should('contain.text', 'AT/TE/ST/01/01')
+    cy.get('[data-test="recipient-method-0"]').should('contain.text', 'Email - primary user')
+    cy.get('[data-test="recipient-action-0"]').within(() => {
+      cy.contains('Preview')
+    })
+
+    cy.get('[data-test="recipient-contact-1"]').within(() => {
       cy.contains('Lookup recipient')
       cy.contains('ENVIRONMENT AGENCY')
       cy.contains('HORIZON HOUSE DEANERY ROAD')
       cy.contains('BRISTOL')
       cy.contains('BS1 5AH')
     })
-    cy.get('[data-test="recipient-licence-numbers-0"]').should('contain.text', 'AT/TE/ST/01/01')
-    cy.get('[data-test="recipient-method-0"]').should('contain.text', 'Letter - single use')
-    cy.get('[data-test="recipient-action-0"]').within(() => {
-      cy.contains('Preview')
-    })
-
-    cy.get('[data-test="recipient-contact-1"]').should('contain.text', 'external@example.com')
     cy.get('[data-test="recipient-licence-numbers-1"]').should('contain.text', 'AT/TE/ST/01/01')
-    cy.get('[data-test="recipient-method-1"]').should('contain.text', 'Email - primary user')
+    cy.get('[data-test="recipient-method-1"]').should('contain.text', 'Letter - single use')
     cy.get('[data-test="recipient-action-1"]').within(() => {
       cy.contains('Preview')
     })
 
-    cy.get('[data-test="recipient-action-0"]').contains('Preview').click()
+    cy.get('[data-test="recipient-action-1"]').contains('Preview').click()
 
     // Preview contains the contact name and address
     cy.contains('Returns invitation ad-hoc')


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5564

We recently did some housekeeping in [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system/pull/3302) and resolved an issue [SonarQube](https://sonarcloud.io/project/overview?id=DEFRA_water-abstraction-system) had been complaining about. When we just needed to sort an array by string, we just used the default [Array.sort()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort).

However, because the default sort is not locale-specific and works with all types, **SonarQube** flagged it as not deterministic, i.e., we couldn't guarantee the result each time.

So, we implemented our own helper 'string sort' method, and the one observed change is that the recipients in the `/check` notices page are now properly sorted. Previously, emails always came after letters.

This means we need to update the assertion in our ad-hoc returns invitation test to match.
