### PR TITLE
Add test for alternate Returns invite set due date

### DIFF
--- a/cypress/e2e/internal/notices/ad-hoc/returns-invitation-alternate.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/returns-invitation-alternate.cy.js
@@ -1,0 +1,123 @@
+'use strict'
+
+import scenarioData from '../../../../support/scenarios/licence-with-open-return-log-bad-primary-user.js'
+import { formatLongDate, relativeToToday } from '../../../../support/helpers/date.helpers.js'
+
+describe('Ad-hoc returns invitation alternate journey (internal)', () => {
+  beforeEach(() => {
+    cy.tearDown()
+    cy.calculatedDates().then((body) => {
+      const scenario = scenarioData(body)
+
+      cy.load(scenario)
+    })
+
+    const expectedDueDate = formatLongDate(relativeToToday(29))
+
+    cy.wrap(expectedDueDate).as('expectedDueDate')
+
+    cy.fixture('users.json').its('billingAndData').as('userEmail')
+  })
+
+  it('sends a return invite to a "bad" primary user, triggering the alternate notification to the licence, which when confirmed will set the "due date" on the OPEN return log', () => {
+    cy.get('@userEmail').then((userEmail) => {
+      cy.programmaticLogin({
+        email: userEmail
+      })
+    })
+
+    // Navigate to the Notices page
+    cy.visit('/system/notices')
+
+    // Start the standard notice journey
+    cy.get('.govuk-button').contains('Create an ad-hoc notice').click()
+
+    // Enter a licence number
+    cy.get('#licenceRef').type('AT/TE/ST/01/01')
+    cy.contains('Continue').click()
+
+    // Select the notice type
+    cy.get('#noticeType').check()
+    cy.contains('Continue').click()
+
+    // Check the notice type
+    cy.get('[data-test="licence-number"]').should('contain.text', 'AT/TE/ST/01/01')
+    cy.get('[data-test="returns-notice-type"]').should('contain.text', 'Returns invitation')
+    cy.contains('Confirm').click()
+
+    // Capture the notice reference so we can verify it later
+    cy.contains('.govuk-caption-l', 'Notice').invoke('text').then((text) => {
+      cy.wrap(text.trim()).as('noticeReference')
+    })
+
+    // Check the recipients
+    cy.contains('Showing all 1 recipients')
+
+    // Bad primary user is shown in the list
+    cy.get('[data-test^="recipient-contact"]').should('have.length', 1)
+
+    cy.get('[data-test="recipient-contact-0"]').should('contain.text', 'iwill-fail@e')
+    cy.get('[data-test="recipient-licence-numbers-0"]').should('contain.text', 'AT/TE/ST/01/01')
+    cy.get('[data-test="recipient-method-0"]').should('contain.text', 'Email - primary user')
+    cy.get('[data-test="recipient-action-0"]').within(() => {
+      cy.contains('Preview')
+    })
+
+    cy.contains('Send').click()
+
+    // Notice confirmation
+    cy.get('.govuk-panel__title', { timeout: 15000 }).contains('Returns invitations sent')
+    cy.get('.govuk-link').contains('View notice').click()
+
+    // Notice page contains the recipients
+    cy.get('@noticeReference').then((noticeReference) => {
+      cy.contains('.govuk-caption-l', noticeReference)
+    })
+
+    cy.contains('Showing all 1 notifications')
+
+    cy.get('[data-test^="notification-recipient"]').should('have.length', 1)
+    cy.get('[data-test="notification-recipient0"]').within(() => {
+      cy.contains('iwill-fail@e')
+    })
+
+    // Wait for notification to be flagged as errored. We know the service will pause for 5 seconds between between
+    // sending and then checking the email's status
+    cy.reloadUntilTextFound('#main-content > :nth-child(3) > .govuk-tag', 'error')
+
+    // Go back to the Notices page and wait for the alternate notice to appear as pending
+    cy.get('.govuk-back-link').click()
+    cy.reloadUntilTextFound('[data-test="notice-status-0"] > .govuk-tag', 'pending')
+
+    // Confirm it _is_ the alternate and not the notice we created!
+    cy.get('@noticeReference').then((noticeReference) => {
+      cy.get('[data-test="notice-reference-0"]').should('not.contain.text', noticeReference)
+    })
+
+    cy.get('[data-test="notice-date-created-0"] > .govuk-link').click()
+
+    cy.get('[data-test="notification-recipient0"]').within(() => {
+      cy.contains('Big Farm Co Ltd')
+      cy.contains('HORIZON HOUSE')
+      cy.contains('DEANERY ROAD')
+      cy.contains('BRISTOL')
+      cy.contains('BS1 5AH')
+    })
+
+    // Trigger the notification status job and then wait for Notify to confirm the letter was successful
+    cy.triggerJob('notification-status')
+    cy.reloadUntilTextFound('#main-content > :nth-child(3) > .govuk-tag', 'sent')
+
+    // Search for the licence so we can check the 'OPEN' return now has a due date assigned
+    cy.get('#nav-search').click()
+    cy.get('[name="query"]').type('AT/TE/ST/01/01')
+    cy.get('#search-button').click()
+    cy.get('.searchresult-link').contains('AT/TE/ST/01/01').click()
+    cy.get(':nth-child(4) > .x-govuk-sub-navigation__link').click()
+    cy.get('[data-test="return-reference-0"] > .govuk-link').should('contain.text', '9999990')
+
+    cy.get('@expectedDueDate').then((expectedDueDate) => {
+      cy.get('[data-test="return-due-date-0"]').should('contain.text', expectedDueDate)
+    })
+  })
+})

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -280,6 +280,19 @@ Cypress.Commands.add('tearDown', () => {
     .should('equal', 204)
 })
 
+Cypress.Commands.add('triggerJob', (job) => {
+  cy.log(`Triggering ${job} job`)
+
+  cy.request({
+    url: `/system/jobs/${job}`,
+    log: false,
+    method: 'POST',
+    timeout: 60000
+  })
+    .its('status', { log: false })
+    .should('equal', 204)
+})
+
 function _dueDateObject (dueDate) {
   const text = dueDate.toLocaleDateString('en-GB', { year: 'numeric', month: 'long', day: 'numeric' })
 

--- a/cypress/support/helpers/date.helpers.js
+++ b/cypress/support/helpers/date.helpers.js
@@ -91,6 +91,23 @@ export function formatDateToIso (date) {
 }
 
 /**
+ * Formats a date into a human readable day, month and year string, for example, '12 September 2021'
+ *
+ * @param {Date | string } date - The date to be formatted
+ *
+ * @returns {string | null} The date formatted as a 'DD MMMM YYYY' string
+ */
+export function formatLongDate(date) {
+  if (!date) {
+    return null
+  }
+
+  const localDate = new Date(date)
+
+  return localDate.toLocaleDateString('en-GB', { year: 'numeric', month: 'long', day: 'numeric' })
+}
+
+/**
  * Given a return period, returns a new period with the same properties but start and end dates moved back 1 period
  *
  * If the given period is quarterly, the dates will be moved back by 3 months. If it's not quarterly, the dates will be

--- a/cypress/support/helpers/date.helpers.js
+++ b/cypress/support/helpers/date.helpers.js
@@ -97,7 +97,7 @@ export function formatDateToIso (date) {
  *
  * @returns {string | null} The date formatted as a 'DD MMMM YYYY' string
  */
-export function formatLongDate(date) {
+export function formatLongDate (date) {
   if (!date) {
     return null
   }

--- a/cypress/support/scenarios/licence-with-open-return-log-bad-primary-user.js
+++ b/cypress/support/scenarios/licence-with-open-return-log-bad-primary-user.js
@@ -36,9 +36,8 @@ export default function (currentServiceData) {
   dataModel.addresses = [
     {
       id: '62549cdb-073f-4d5c-a2a1-c47b0b910010',
-      address1: 'Horizon House',
-      address2: 'Deanery Road',
-      address3: 'Bristol',
+      address1: 'HORIZON HOUSE',
+      address2: 'DEANERY ROAD',
       postcode: 'BS1 5AH',
       country: 'UK',
       dataSource: 'nald'


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5659

Our users identified an issue with our returns notice 'fallback' logic.

When we send a returns invitation, if the email to the primary user fails, we automatically generate another notice to the licence holder's address. That part is working fine.

When we then get confirmation from [GOV.UK Notify](https://www.notifications.service.gov.uk/) that the letter has been 'received' (meaning successfully sent to their mail provider), not only do we update the notification status, but we should be setting the 'due date' on the associated return logs.

It is this part that had the bug. We fixed it in [Fix not setting due date for alt. returns notices](https://github.com/DEFRA/water-abstraction-system/pull/3363).

To ensure we don't make the same mistake again, we're adding an acceptance test to cover this scenario.

In [Add licence with open return log bad primary user](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/246), we added a scenario that will set up the test data we need.

In this change, we add the actual test. We can create an ad-hoc returns notice for the licence with the bad primary user. It will fail, automatically triggering the alternate notice. As a letter, it will sit there in a `PENDING` state until the 'notification-status' job is run. Normally, this is done once a day in the evening, but we'll need to trigger it as part of our test.

Once the job runs, Notify should flag the notification as delivered, which will cause [water-abstraction-system](https://github.com/DEFRA/water-abstraction-system) to assign a due date to the licence's `OPEN` return log.