### PR TITLE
Add renewal invitations test

### DIFF
--- a/cypress/e2e/internal/notices/ad-hoc/paper-returns.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/paper-returns.cy.js
@@ -28,13 +28,13 @@ describe('Ad-hoc Paper returns journey (internal)', () => {
     // Start the ad-hoc notice journey
     cy.get('.govuk-button').contains('Create an ad-hoc notice').click()
 
+    // Select the notice type
+    cy.contains('label', 'Paper return').click()
+    cy.contains('Continue').click()
+
     // Enter a licence number
     cy.get('#licenceRef').type('AT/TE/ST/01/01')
     cy.get('button.govuk-button').click()
-
-    // Select the notice type
-    cy.get('#noticeType-3').check()
-    cy.contains('Continue').click()
 
     // Select the returns for the paper return
     cy.get('#returns').check()
@@ -42,7 +42,7 @@ describe('Ad-hoc Paper returns journey (internal)', () => {
 
     // Check the notice type
     cy.get('[data-test="licence-number"]').should('contain.text', 'AT/TE/ST/01/01')
-    cy.get('[data-test="returns-notice-type"]').should('contain.text', 'Paper return')
+    cy.get('[data-test="notice-type"]').should('contain.text', 'Paper return')
     cy.contains('Confirm').click()
 
     // Capture the notice reference so we can verify it later

--- a/cypress/e2e/internal/notices/ad-hoc/renewal-invitation.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/renewal-invitation.cy.js
@@ -1,8 +1,8 @@
 'use strict'
 
-import scenarioData from '../../../../support/scenarios/licence-with-previous-return-log.js'
+import scenarioData from '../../../../support/scenarios/licence-for-renewal-invitation.js'
 
-describe('Ad-hoc returns invitation journey (internal)', () => {
+describe('Ad-hoc renewal invitation journey (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
     cy.calculatedDates().then((body) => {
@@ -11,10 +11,10 @@ describe('Ad-hoc returns invitation journey (internal)', () => {
       cy.load(scenario)
     })
 
-    cy.fixture('users.json').its('billingAndData').as('userEmail')
+    cy.fixture('users.json').its('admin').as('userEmail')
   })
 
-  it('invites a customer to submit returns', () => {
+  it('invites a customer to submit a renewal invitation', () => {
     cy.get('@userEmail').then((userEmail) => {
       cy.programmaticLogin({
         email: userEmail
@@ -28,7 +28,7 @@ describe('Ad-hoc returns invitation journey (internal)', () => {
     cy.get('.govuk-button').contains('Create an ad-hoc notice').click()
 
     // Select the notice type
-    cy.contains('label', 'Returns invitation').click()
+    cy.contains('label', 'Renewals invitation').click()
     cy.contains('Continue').click()
 
     // Enter a licence number
@@ -37,7 +37,7 @@ describe('Ad-hoc returns invitation journey (internal)', () => {
 
     // Check the notice type
     cy.get('[data-test="licence-number"]').should('contain.text', 'AT/TE/ST/01/01')
-    cy.get('[data-test="notice-type"]').should('contain.text', 'Returns invitation')
+    cy.get('[data-test="notice-type"]').should('contain.text', 'Renewals invitation')
     cy.contains('Confirm').click()
 
     // Capture the notice reference so we can verify it later
@@ -98,7 +98,7 @@ describe('Ad-hoc returns invitation journey (internal)', () => {
     cy.get('[data-test="recipient-action-1"]').contains('Preview').click()
 
     // Preview contains the contact name and address
-    cy.contains('Returns invitation ad-hoc')
+    cy.contains('Renewal invitation ad-hoc')
     cy.contains('Lookup recipient')
     cy.get('.govuk-back-link').click()
 
@@ -106,7 +106,7 @@ describe('Ad-hoc returns invitation journey (internal)', () => {
     cy.contains('Send').click()
 
     // Notice confirmation
-    cy.get('.govuk-panel__title', { timeout: 15000 }).contains('Returns invitations sent')
+    cy.get('.govuk-panel__title', { timeout: 15000 }).contains('Renewal invitations sent')
     cy.get('.govuk-link').contains('View notice').click()
 
     // Notice page contains the recipients

--- a/cypress/e2e/internal/notices/ad-hoc/returns-invitation-alternate.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/returns-invitation-alternate.cy.js
@@ -32,17 +32,17 @@ describe('Ad-hoc returns invitation alternate journey (internal)', () => {
     // Start the standard notice journey
     cy.get('.govuk-button').contains('Create an ad-hoc notice').click()
 
+    // Select the notice type
+    cy.contains('label', 'Returns invitation').click()
+    cy.contains('Continue').click()
+
     // Enter a licence number
     cy.get('#licenceRef').type('AT/TE/ST/01/01')
     cy.contains('Continue').click()
 
-    // Select the notice type
-    cy.get('#noticeType').check()
-    cy.contains('Continue').click()
-
     // Check the notice type
     cy.get('[data-test="licence-number"]').should('contain.text', 'AT/TE/ST/01/01')
-    cy.get('[data-test="returns-notice-type"]').should('contain.text', 'Returns invitation')
+    cy.get('[data-test="notice-type"]').should('contain.text', 'Returns invitation')
     cy.contains('Confirm').click()
 
     // Capture the notice reference so we can verify it later

--- a/cypress/e2e/internal/notices/ad-hoc/returns-reminder.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/returns-reminder.cy.js
@@ -1,8 +1,8 @@
 'use strict'
 
-import scenarioData from '../../../../support/scenarios/licence-with-previous-return-log.js'
+import scenarioData from '../../../../support/scenarios/licence-with-due-return-log.js'
 
-describe('Ad-hoc returns invitation journey (internal)', () => {
+describe('Ad-hoc returns reminder journey (internal)', () => {
   beforeEach(() => {
     cy.tearDown()
     cy.calculatedDates().then((body) => {
@@ -28,7 +28,7 @@ describe('Ad-hoc returns invitation journey (internal)', () => {
     cy.get('.govuk-button').contains('Create an ad-hoc notice').click()
 
     // Select the notice type
-    cy.contains('label', 'Returns invitation').click()
+    cy.contains('label', 'Returns reminder').click()
     cy.contains('Continue').click()
 
     // Enter a licence number
@@ -37,7 +37,7 @@ describe('Ad-hoc returns invitation journey (internal)', () => {
 
     // Check the notice type
     cy.get('[data-test="licence-number"]').should('contain.text', 'AT/TE/ST/01/01')
-    cy.get('[data-test="notice-type"]').should('contain.text', 'Returns invitation')
+    cy.get('[data-test="notice-type"]').should('contain.text', 'Returns reminder')
     cy.contains('Confirm').click()
 
     // Capture the notice reference so we can verify it later
@@ -98,7 +98,7 @@ describe('Ad-hoc returns invitation journey (internal)', () => {
     cy.get('[data-test="recipient-action-1"]').contains('Preview').click()
 
     // Preview contains the contact name and address
-    cy.contains('Returns invitation ad-hoc')
+    cy.contains('Returns reminder ad-hoc')
     cy.contains('Lookup recipient')
     cy.get('.govuk-back-link').click()
 
@@ -106,7 +106,7 @@ describe('Ad-hoc returns invitation journey (internal)', () => {
     cy.contains('Send').click()
 
     // Notice confirmation
-    cy.get('.govuk-panel__title', { timeout: 15000 }).contains('Returns invitations sent')
+    cy.get('.govuk-panel__title', { timeout: 15000 }).contains('Returns reminders sent')
     cy.get('.govuk-link').contains('View notice').click()
 
     // Notice page contains the recipients

--- a/cypress/e2e/internal/notices/standard/returns-invitation.cy.js
+++ b/cypress/e2e/internal/notices/standard/returns-invitation.cy.js
@@ -36,7 +36,7 @@ describe('Standard returns invitation journey (internal)', () => {
     cy.contains('Continue').click()
 
     // Check the notice type
-    cy.get('[data-test="returns-notice-type"]').should('contain.text', 'Returns invitation')
+    cy.get('[data-test="notice-type"]').should('contain.text', 'Returns invitation')
     cy.contains('Confirm').click()
 
     // Capture the notice reference so we can verify it later

--- a/cypress/e2e/internal/notices/standard/returns-reminder.cy.js
+++ b/cypress/e2e/internal/notices/standard/returns-reminder.cy.js
@@ -37,7 +37,7 @@ describe('Standard returns reminder journey (internal)', () => {
     cy.contains('Continue').click()
 
     // Check the notice type
-    cy.get('[data-test="returns-notice-type"]').should('contain.text', 'Returns reminder')
+    cy.get('[data-test="notice-type"]').should('contain.text', 'Returns reminder')
     cy.contains('Confirm').click()
 
     // Capture the notice reference so we can verify it later

--- a/cypress/support/scenarios/licence-for-renewal-invitation.js
+++ b/cypress/support/scenarios/licence-for-renewal-invitation.js
@@ -2,7 +2,7 @@ import licenceData from '../fixture-builder/licence.js'
 
 export default function () {
   const dataModel = {
-    ...licenceData(),
+    ...licenceData()
   }
 
   // The expired date needs to be more than 90 days in the future for the licence to be eligible for a renewal invitation.

--- a/cypress/support/scenarios/licence-for-renewal-invitation.js
+++ b/cypress/support/scenarios/licence-for-renewal-invitation.js
@@ -1,0 +1,14 @@
+import licenceData from '../fixture-builder/licence.js'
+
+export default function () {
+  const dataModel = {
+    ...licenceData(),
+  }
+
+  // The expired date needs to be more than 90 days in the future for the licence to be eligible for a renewal invitation.
+  const expiredDate = new Date()
+  expiredDate.setDate(expiredDate.getDate() + 91)
+  dataModel.licences[0].expiredDate = expiredDate.toISOString().split('T')[0]
+
+  return dataModel
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5655

This change adds a test for the adhoc renewal invitations.

As part of this work we have reordered the journey, similar tests have been updated to represent this change.