### PR TITLE
Update user scope for renewal invitations

### DIFF
--- a/cypress/e2e/internal/notices/ad-hoc/renewal-invitation.cy.js
+++ b/cypress/e2e/internal/notices/ad-hoc/renewal-invitation.cy.js
@@ -11,7 +11,7 @@ describe('Ad-hoc renewal invitation journey (internal)', () => {
       cy.load(scenario)
     })
 
-    cy.fixture('users.json').its('admin').as('userEmail')
+    cy.fixture('users.json').its('psc').as('userEmail')
   })
 
   it('invites a customer to submit a renewal invitation', () => {


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5646

This change scopes the renewal invitations user to 'psc'.

The previous use of 'admin' was not showing a bug where the create an ad hoc licence button was not showing for non 'psc' users.