### PR TITLE
Remove references to licence version holders

### DIFF
--- a/cypress/e2e/internal/customers/view-licences.cy.js
+++ b/cypress/e2e/internal/customers/view-licences.cy.js
@@ -33,6 +33,6 @@ describe("View a licence's contacts (internal)", () => {
 
     // Confirm contacts contains expected record
     cy.get('.govuk-table__cell').contains(scenario.licences[0].licenceRef)
-    cy.get('.govuk-table__cell').contains(scenario.licenceVersionHolders[0].derivedName)
+    cy.get('.govuk-table__cell').contains(scenario.companies[0].name)
   })
 })

--- a/cypress/fixtures/review-scenario-licence.json
+++ b/cypress/fixtures/review-scenario-licence.json
@@ -102,20 +102,5 @@
       "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
       "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010"
     }
-  ],
-  "licenceVersionHolders": [
-    {
-      "licenceVersionId": "6c42b2be-88a7-464f-8b43-2428f4e8eecd",
-      "holderType": "organisation",
-      "name": "Big Farm Co Ltd",
-      "addressLine1": "Big Farm",
-      "addressLine2": "Windy road",
-      "addressLine3": "Buttercup meadow",
-      "addressLine4": "Buttercup Village",
-      "town": "Testington",
-      "postcode": "TT1 1TT",
-      "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
-      "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010"
-    }
   ]
 }

--- a/cypress/fixtures/sroc-billing.json
+++ b/cypress/fixtures/sroc-billing.json
@@ -506,52 +506,6 @@
       "addressId": "62549cdb-073f-4d5c-a2a1-c47b0b910010"
     }
   ],
-  "licenceVersionHolders": [
-    {
-      "licenceVersionId": "6c42b2be-88a7-464f-8b43-2428f4e8eecd",
-      "holderType": "organisation",
-      "name": "Big Farm Co Ltd 01",
-      "addressLine1": "Big Farm",
-      "addressLine2": "Windy road",
-      "addressLine3": "Buttercup meadow",
-      "addressLine4": "Buttercup Village",
-      "town": "Testington",
-      "postcode": "TT1 1TT"
-    },
-    {
-      "licenceVersionId": "2c224090-92b5-46a8-9980-b5b8f602e773",
-      "holderType": "organisation",
-      "name": "Big Farm Co Ltd 02",
-      "addressLine1": "Big Farm",
-      "addressLine2": "Windy road",
-      "addressLine3": "Buttercup meadow",
-      "addressLine4": "Buttercup Village",
-      "town": "Testington",
-      "postcode": "TT1 1TT"
-    },
-    {
-      "licenceVersionId": "9ae4d4c7-26b7-49c8-858f-ae2c12381e12",
-      "holderType": "organisation",
-      "name": "Big Farm Co Ltd 03",
-      "addressLine1": "Big Farm",
-      "addressLine2": "Windy road",
-      "addressLine3": "Buttercup meadow",
-      "addressLine4": "Buttercup Village",
-      "town": "Testington",
-      "postcode": "TT1 1TT"
-    },
-    {
-      "licenceVersionId": "b6712354-9e5c-4fbf-ad6e-ac6c86be77e9",
-      "holderType": "organisation",
-      "name": "Big Farm Co Ltd 04",
-      "addressLine1": "Big Farm",
-      "addressLine2": "Windy road",
-      "addressLine3": "Buttercup meadow",
-      "addressLine4": "Buttercup Village",
-      "town": "Testington",
-      "postcode": "TT1 1TT"
-    }
-  ],
   "chargeVersions": [
     {
       "id": "8e5626ee-5e4c-48f6-a668-471d35997e2c",


### PR DESCRIPTION
In a recent change to **water-abstraction-system**, we [removed all references to 'LicenceVersionHolders'](https://github.com/DEFRA/water-abstraction-system/pull/3482).

We no longer use it as we found it was better to record the `company_id` and `address_id` directly against the licence version.

This means you can no longer seed the licence version holders. So they need to be removed; otherwise, tests fail.