### PR TITLE
Stop creating billing contacts

### DIFF
--- a/cypress/fixtures/pre-sroc-two-part-tariff-bill-run.json
+++ b/cypress/fixtures/pre-sroc-two-part-tariff-bill-run.json
@@ -56,14 +56,6 @@
       "companyEntityId": "e86c312b-222d-404f-ae08-eb90a80bec18"
     }
   ],
-  "companies": [
-    {
-      "id": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
-      "name": "Big Farm Co Ltd",
-      "type": "organisation",
-      "companyNumber": "12345"
-    }
-  ],
   "addresses": [
     {
       "id": "62549cdb-073f-4d5c-a2a1-c47b0b910010",
@@ -78,6 +70,16 @@
       "dataSource": "nald"
     }
   ],
+  "companies": [
+    {
+      "id": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
+      "name": "Big Farm Co Ltd",
+      "type": "organisation",
+      "companyNumber": "12345",
+      "externalId": "9:999991",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" }
+    }
+  ],
   "companyAddresses": [
     {
       "companyId": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
@@ -87,7 +89,7 @@
         "schema": "crm_v2",
         "table": "roles",
         "lookup": "name",
-        "value": "billing",
+        "value": "licenceHolder",
         "select": "roleId"
       }
     }

--- a/cypress/fixtures/sroc-billing.json
+++ b/cypress/fixtures/sroc-billing.json
@@ -30,25 +30,33 @@
       "id": "e8abdbb4-aeea-47d4-91b2-97bf82bc2778",
       "name": "Big Farm Co Ltd 01",
       "type": "organisation",
-      "companyNumber": "1234501"
+      "companyNumber": "1234501",
+      "externalId": "9:999991",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" }
     },
     {
       "id": "89dd5558-3af4-4878-8d09-1ba0b5fbaa00",
       "name": "Big Farm Co Ltd 02",
       "type": "organisation",
-      "companyNumber": "1234502"
+      "companyNumber": "1234502",
+      "externalId": "9:999992",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" }
     },
     {
       "id": "951f5383-d87c-41eb-bf54-8b6269045ff2",
       "name": "Big Farm Co Ltd 03",
       "type": "organisation",
-      "companyNumber": "1234503"
+      "companyNumber": "1234503",
+      "externalId": "9:999993",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" }
     },
     {
       "id": "cd6cefb2-260f-4292-8228-21ab23abb8f4",
       "name": "Big Farm Co Ltd 04",
       "type": "organisation",
-      "companyNumber": "1234504"
+      "companyNumber": "1234504",
+      "externalId": "9:999994",
+      "regionId": { "schema": "public", "table": "regions", "lookup": "naldRegionId", "value": 9, "select": "id" }
     }
   ],
   "companyAddresses": [
@@ -60,7 +68,7 @@
         "schema": "public",
         "table": "licenceRoles",
         "lookup": "name",
-        "value": "billing",
+        "value": "licenceHolder",
         "select": "id"
       }
     },
@@ -72,7 +80,7 @@
         "schema": "public",
         "table": "licenceRoles",
         "lookup": "name",
-        "value": "billing",
+        "value": "licenceHolder",
         "select": "id"
       }
     },
@@ -84,7 +92,7 @@
         "schema": "public",
         "table": "licenceRoles",
         "lookup": "name",
-        "value": "billing",
+        "value": "licenceHolder",
         "select": "id"
       }
     },
@@ -96,7 +104,7 @@
         "schema": "public",
         "table": "licenceRoles",
         "lookup": "name",
-        "value": "billing",
+        "value": "licenceHolder",
         "select": "id"
       }
     },
@@ -108,7 +116,7 @@
         "schema": "public",
         "table": "licenceRoles",
         "lookup": "name",
-        "value": "billing",
+        "value": "licenceHolder",
         "select": "id"
       }
     },
@@ -120,7 +128,7 @@
         "schema": "public",
         "table": "licenceRoles",
         "lookup": "name",
-        "value": "billing",
+        "value": "licenceHolder",
         "select": "id"
       }
     },
@@ -132,7 +140,7 @@
         "schema": "public",
         "table": "licenceRoles",
         "lookup": "name",
-        "value": "billing",
+        "value": "licenceHolder",
         "select": "id"
       }
     },
@@ -144,7 +152,7 @@
         "schema": "public",
         "table": "licenceRoles",
         "lookup": "name",
-        "value": "billing",
+        "value": "licenceHolder",
         "select": "id"
       }
     }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5691

When we migrated licence holder contacts management from the legacy service (see [WATER-5456](https://eaflood.atlassian.net/browse/WATER-5456)), as usual, we added our sparkles!

This included checking if a contact with the same name and email was already assigned to the licence holder. The legacy version made no such checks, leading to a number of duplicates in some licence holders.

A user has tried to add a contact to a licence holder but is seeing the "A contact with this name and email already exists" message, even though the contact isn't listed in the licence holder's contacts.

They think it is because the service doesn't allow duplicate contacts _at all_, so we've been asked to amend the logic to check only within the current licence holder.

But we already do.

What the user or anyone else cannot see is that there is an existing licence holder contact with the same name and email. This is because it is a redundant contact we no longer use.

Before the service handled charging, NALD maintained 'billing' contacts against licence holders. These were imported into WRLS as part of the nightly import. When WRLS took over charging and billing accounts were introduced, the import was amended to stop importing them.

But they still exist, and the query used in the duplicate check is not filtering by role, only licence holder (`company_id`).

We've added a change to [Delete redundant billing contacts](https://github.com/DEFRA/water-abstraction-tactical-crm/pull/1142). But this means we shouldn't be creating them in our acceptance tests anymore.

The old fixture data we inherited from the previous team was creating company contacts and addresses as 'billing' contacts, when they should have been 'licence holder' contacts.

This change updates those fixtures.

[WATER-5456]: https://eaflood.atlassian.net/browse/WATER-5456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ