### PR TITLE
Update GitHub workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,20 @@
+# See the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-  open-pull-requests-limit: 10
-  versioning-strategy: lockfile-only
+  - package-ecosystem: npm
+    cooldown:
+      default-days: 7
+    directory: '/'
+    schedule:
+      interval: daily
+    open-pull-requests-limit: 10
+    versioning-strategy: lockfile-only
+  - package-ecosystem: 'github-actions'
+    cooldown:
+      default-days: 7
+    # Workflow files stored in the default location of `.github/workflows`
+    directory: '/'
+    schedule:
+      interval: 'daily'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       # Downloads a copy of the code in your repository before running CI tests
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
 
       # Before we do anything, check we haven't accidentally left any `describe.only()` or `it.only(` statements in the
       # tests
@@ -21,14 +21,14 @@ jobs:
           ! grep -R 'describe.only(\|it.only(' cypress/e2e/
 
       - name: Install Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e #v6.4.0
         with:
           node-version-file: ".nvmrc"
 
       # Speeds up workflows by reading the node modules from cache. Obviously you need to run it at least once, and the
       # cache will be updated should the package-lock.json file change
       - name: Cache Node modules
-        uses: actions/cache@v3
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae #v5.0.5
         with:
           # npm cache files are stored in `~/.npm` on Linux/macOS
           path: ~/.npm

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,24 @@
+name: Dependency Review
+
+on: pull_request
+
+permissions:
+  contents: read
+  # Required when using the "comment-summary-in-pr" option
+  pull-requests: write
+
+jobs:
+  dependency-review:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
+
+      # Scans your pull requests for dependency changes, and will raise an error if any vulnerabilities or invalid
+      # licenses are being introduced.
+      - name: Dependency Review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 #v5.0.0
+        with:
+          fail-on-severity: moderate
+          comment-summary-in-pr: on-failure


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5675

We have been making some security updates to our GitHub Workflows but this repo has been missed.

This PR will make the following updates:

- Pin GitHub actions to commit SHAs instead of versions https://eaflood.atlassian.net/browse/WATER-5675
- Add GitHub action dependency-review-action to our CI https://eaflood.atlassian.net/browse/WATER-5679
- Add cooldown option to dependabot workflow https://eaflood.atlassian.net/browse/WATER-5681