### PR TITLE
Pin GitHub actions to commit SHAs instead of versions

### DIFF
--- a/.github/workflows/shai-hulud-detect.yml
+++ b/.github/workflows/shai-hulud-detect.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       # Downloads a copy of the code in your repository by default
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
         with:
           ref: main
           path: project
@@ -22,7 +22,7 @@ jobs:
 
       # Checkout the security scanning repo we're using
       - name: Checkout scanner
-        uses: actions/checkout@v6
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 #v7.0.0
         with:
           repository: Cobenian/shai-hulud-detect
           ref: main


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5675

Following the updates to the GitHub workflows in PR https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/264 the `shai-hulud-detect` workflow was missed. This PR will pin the actions in this workflow.