### PR TITLE
Add title and description to scenario files for better CLI display

### DIFF
--- a/cli/seed.cli.js
+++ b/cli/seed.cli.js
@@ -30,7 +30,7 @@ async function run () {
 
   const currentServiceData = await _currentServiceData()
 
-  const scenarios = _scenarios()
+  const scenarios = await _scenarios()
 
   let selectedScenario
 
@@ -83,7 +83,7 @@ async function _currentServiceData () {
  */
 async function _body (selectedScenario, currentServiceData) {
   // 1. Get the absolute path
-  const scenarioPath = path.resolve(SCENARIOS_DIR, `${selectedScenario}.js`)
+  const scenarioPath = path.resolve(SCENARIOS_DIR, `${selectedScenario.filename}.js`)
 
   // 2. Use dynamic import() to load the ESM scenario file.
   // This allows the scenario to 'import' other ESM files (like licence.js)
@@ -93,7 +93,7 @@ async function _body (selectedScenario, currentServiceData) {
   const getBody = scenarioModule.default || scenarioModule
 
   if (typeof getBody !== 'function') {
-    throw new Error(`The file "${selectedScenario}.js" must have an "export default" function.`)
+    throw new Error(`The file "${selectedScenario.filename}.js" must have an "export default" function.`)
   }
 
   // 4. Call the function here to get the actual data object
@@ -105,7 +105,7 @@ async function _body (selectedScenario, currentServiceData) {
  * @private
  */
 async function _load (selectedScenario, body) {
-  logInfo(`Loading scenario ${styleBold(selectedScenario)}...`)
+  logInfo(`Loading scenario ${styleBold(selectedScenario.title)}...`)
 
   await post('/system/data/load', body)
 }
@@ -144,15 +144,19 @@ async function _prompt (scenarios, defaultValue) {
         let filteredScenarios = scenarios
 
         if (input) {
+          const query = input.toLowerCase()
+
           filteredScenarios = scenarios.filter((scenario) => {
-            return scenario.toLowerCase().includes(input.toLowerCase())
+            return scenario.title.toLowerCase().includes(query) ||
+              scenario.filename.toLowerCase().includes(query)
           })
         }
 
-        return filteredScenarios
-          .map((scenario) => {
-            return { name: scenario, value: scenario }
-          })
+        return filteredScenarios.map((scenario) => ({
+          name: scenario.title,
+          value: scenario,
+          description: scenario.description
+        }))
       }
     },
     { signal: ESCAPE_KEY_ABORT_CONTROLLER.signal }
@@ -160,17 +164,28 @@ async function _prompt (scenarios, defaultValue) {
 }
 
 /**
- * Get list of available scenario files
+ * Get list of available scenario files with their title and description
  * @private
  */
-function _scenarios () {
-  return fs.readdirSync(SCENARIOS_DIR)
-    .filter((file) => {
-      return file.endsWith('.js')
+async function _scenarios () {
+  const filenames = fs.readdirSync(SCENARIOS_DIR)
+    .filter((file) => file.endsWith('.js'))
+    .map((file) => file.replace('.js', ''))
+
+  const scenarios = []
+
+  for (const filename of filenames) {
+    const scenarioPath = path.resolve(SCENARIOS_DIR, `${filename}.js`)
+    const mod = await import(`file://${scenarioPath}`)
+
+    scenarios.push({
+      filename,
+      title: mod.title ?? filename,
+      description: mod.description ?? ''
     })
-    .map((file) => {
-      return file.replace('.js', '')
-    })
+  }
+
+  return scenarios
 }
 
 /**

--- a/cypress/support/scenarios/cancelling-charge-version.js
+++ b/cypress/support/scenarios/cancelling-charge-version.js
@@ -1,5 +1,8 @@
 import licenceData from '../fixture-builder/licence.js'
 
+export const title = 'Cancelling a charge version'
+export const description = "Licence in workflow 'review' with a draft charge version, plus sent annual and two-part tariff bill runs"
+
 export default function () {
   return {
     ...licenceData(),

--- a/cypress/support/scenarios/company-contact.js
+++ b/cypress/support/scenarios/company-contact.js
@@ -2,6 +2,9 @@ import licenceData from '../fixture-builder/licence.js'
 import notificationData from '../fixture-builder/notification.js'
 import companyContactData from '../fixture-builder/company-contact.js'
 
+export const title = 'Company contact'
+export const description = 'Licence with a company contact and notification data'
+
 export default function () {
   return {
     ...licenceData(),

--- a/cypress/support/scenarios/delete-licence-from-workflow.js
+++ b/cypress/support/scenarios/delete-licence-from-workflow.js
@@ -1,5 +1,8 @@
 import licenceData from '../fixture-builder/licence.js'
 
+export const title = 'Deleting a licence from workflow'
+export const description = "Licence with two workflow entries ('to_setup' and 'review') and sent bill runs for workflow deletion testing"
+
 export default function () {
   return {
     ...licenceData(),

--- a/cypress/support/scenarios/editing-return.js
+++ b/cypress/support/scenarios/editing-return.js
@@ -1,5 +1,8 @@
 import licenceData from '../fixture-builder/licence.js'
 
+export const title = 'Editing a return'
+export const description = 'Licence with a completed two-part tariff return log ready for editing'
+
 export default function () {
   return {
     ...licenceData(),

--- a/cypress/support/scenarios/external-return-statuses.js
+++ b/cypress/support/scenarios/external-return-statuses.js
@@ -1,6 +1,9 @@
 import returnStatusesData from './return-statuses.js'
 import usersData from '../fixture-builder/users.js'
 
+export const title = 'External user viewing return statuses'
+export const description = 'All return statuses (due, overdue, void, open, not yet due, completed) visible to a registered external user'
+
 export default function () {
   return {
     users: [

--- a/cypress/support/scenarios/external-return-submission.js
+++ b/cypress/support/scenarios/external-return-submission.js
@@ -1,6 +1,9 @@
 import licenceData from '../fixture-builder/licence.js'
 import usersData from '../fixture-builder/users.js'
 
+export const title = 'External return submission'
+export const description = 'Licence with a due return log and registered external user for testing return submission'
+
 export default function () {
   return {
     users: [

--- a/cypress/support/scenarios/external-user-only.js
+++ b/cypress/support/scenarios/external-user-only.js
@@ -1,5 +1,8 @@
 import usersData from '../fixture-builder/users.js'
 
+export const title = 'External user only'
+export const description = 'A single external user with no associated licence or return data'
+
 export default function () {
   return {
     users: [

--- a/cypress/support/scenarios/internal-user-only.js
+++ b/cypress/support/scenarios/internal-user-only.js
@@ -1,5 +1,8 @@
 import usersData from '../fixture-builder/users.js'
 
+export const title = 'Internal user only'
+export const description = 'A single internal basic user with no associated licence or return data'
+
 export default function () {
   return {
     users: [

--- a/cypress/support/scenarios/licence-for-renewal-invitation.js
+++ b/cypress/support/scenarios/licence-for-renewal-invitation.js
@@ -1,5 +1,8 @@
 import licenceData from '../fixture-builder/licence.js'
 
+export const title = 'Licence for renewal invitation'
+export const description = 'Licence expiring more than 90 days ahead, making it eligible for a renewal invitation'
+
 export default function () {
   const dataModel = {
     ...licenceData()

--- a/cypress/support/scenarios/licence-in-workflow.js
+++ b/cypress/support/scenarios/licence-in-workflow.js
@@ -1,5 +1,8 @@
 import licenceData from '../fixture-builder/licence.js'
 
+export const title = 'Licence in workflow'
+export const description = "Licence with a charge version workflow in 'to_setup' status"
+
 export default function () {
   return {
     ...licenceData(),

--- a/cypress/support/scenarios/licence-with-agreement.js
+++ b/cypress/support/scenarios/licence-with-agreement.js
@@ -1,5 +1,8 @@
 import licenceData from '../fixture-builder/licence.js'
 
+export const title = 'Licence with a section 127 agreement'
+export const description = 'Licence with an S127 two-part tariff financial agreement and a sent two-part tariff bill run'
+
 export default function () {
   return {
     ...licenceData(),

--- a/cypress/support/scenarios/licence-with-due-return-log-for-first-period.js
+++ b/cypress/support/scenarios/licence-with-due-return-log-for-first-period.js
@@ -4,6 +4,9 @@ import returnRequirements from '../fixture-builder/return-requirements.js'
 import returnVersion from '../fixture-builder/return-version.js'
 import { formatDateToIso } from '../helpers/date.helpers.js'
 
+export const title = 'Licence with a due return log (first return period)'
+export const description = 'Licence with a due return log set to the first current return period, with return requirements and version'
+
 export default function (currentServiceData) {
   const { firstReturnPeriod } = currentServiceData
 

--- a/cypress/support/scenarios/licence-with-due-return-log.js
+++ b/cypress/support/scenarios/licence-with-due-return-log.js
@@ -4,6 +4,9 @@ import returnRequirements from '../fixture-builder/return-requirements.js'
 import returnVersion from '../fixture-builder/return-version.js'
 import { compareDates, formatDateToIso, previousPeriod, today } from '../helpers/date.helpers.js'
 
+export const title = 'Licence with a due return log'
+export const description = 'Licence with a due return log on a submittable past return period, with return requirements and version'
+
 export default function (currentServiceData) {
   const { firstReturnPeriod } = currentServiceData
 

--- a/cypress/support/scenarios/licence-with-failed-renewal-invitation.js
+++ b/cypress/support/scenarios/licence-with-failed-renewal-invitation.js
@@ -6,6 +6,9 @@ import usersData from '../fixture-builder/users.js'
 import users from '../../fixtures/users.json' with { type: "json" }
 import { compareDates, formatDateToIso, previousPeriod, relativeToToday, today } from '../helpers/date.helpers.js'
 
+export const title = 'Failed renewal invitation'
+export const description = "Licence registered to a 'bad' external user with pending renewal and return invitations for notification failure testing"
+
 export default function (currentServiceData) {
   const { firstReturnPeriod } = currentServiceData
 

--- a/cypress/support/scenarios/licence-with-open-return-log-bad-primary-user.js
+++ b/cypress/support/scenarios/licence-with-open-return-log-bad-primary-user.js
@@ -5,6 +5,9 @@ import returnVersion from '../fixture-builder/return-version.js'
 import usersData from '../fixture-builder/users.js'
 import { compareDates, formatDateToIso, previousPeriod, today } from '../helpers/date.helpers.js'
 
+export const title = 'Open return log with bad primary user'
+export const description = "Licence registered to a 'bad' external user with a due return log for testing submissions with unverified contacts"
+
 export default function (currentServiceData) {
   const { firstReturnPeriod } = currentServiceData
 

--- a/cypress/support/scenarios/licence-with-presroc-chg-ver.js
+++ b/cypress/support/scenarios/licence-with-presroc-chg-ver.js
@@ -1,5 +1,8 @@
 import licenceData from '../fixture-builder/licence.js'
 
+export const title = 'Licence with a pre-SRoC charge version'
+export const description = 'Licence with an ALCS (pre-SRoC) charge version and a sent two-part tariff bill run'
+
 export default function () {
   return {
     ...licenceData(),

--- a/cypress/support/scenarios/licence-with-previous-return-log.js
+++ b/cypress/support/scenarios/licence-with-previous-return-log.js
@@ -4,6 +4,9 @@ import returnRequirements from '../fixture-builder/return-requirements.js'
 import returnVersion from '../fixture-builder/return-version.js'
 import { formatDateToIso, previousPeriod } from '../helpers/date.helpers.js'
 
+export const title = 'Licence with a previous period return log'
+export const description = 'Licence with a due return log set to the previous return period with no due date'
+
 export default function (currentServiceData) {
   const { firstReturnPeriod } = currentServiceData
 

--- a/cypress/support/scenarios/licence-with-return-log.js
+++ b/cypress/support/scenarios/licence-with-return-log.js
@@ -4,6 +4,9 @@ import returnRequirements from '../fixture-builder/return-requirements.js'
 import returnVersion from '../fixture-builder/return-version.js'
 import { formatDateToIso } from '../helpers/date.helpers.js'
 
+export const title = 'Licence with a return log (current period)'
+export const description = 'Licence with a due return log for the first current return period with no due date set'
+
 export default function (currentServiceData) {
   const { firstReturnPeriod } = currentServiceData
 

--- a/cypress/support/scenarios/monitoring-station-tagged.js
+++ b/cypress/support/scenarios/monitoring-station-tagged.js
@@ -1,6 +1,9 @@
 import licenceData from '../fixture-builder/licence.js'
 import monitoringStationData from '../fixture-builder/monitoring-stations.js'
 
+export const title = 'Monitoring station tagged to licence'
+export const description = 'Licence with a LEV licence condition linked to a monitoring station via a stop flow restriction'
+
 export default function () {
   return {
     ...licenceData(),

--- a/cypress/support/scenarios/monitoring-station-untagged.js
+++ b/cypress/support/scenarios/monitoring-station-untagged.js
@@ -1,6 +1,9 @@
 import licenceData from '../fixture-builder/licence.js'
 import monitoringStationData from '../fixture-builder/monitoring-stations.js'
 
+export const title = 'Monitoring station (untagged)'
+export const description = 'Licence and monitoring station created separately with no licence monitoring station link'
+
 export default function () {
   return {
     ...licenceData(),

--- a/cypress/support/scenarios/one-licence-only.js
+++ b/cypress/support/scenarios/one-licence-only.js
@@ -1,5 +1,8 @@
 import licenceData from '../fixture-builder/licence.js'
 
+export const title = 'One licence only'
+export const description = 'Minimal licence data with no return logs, bill runs, workflows, or user accounts'
+
 export default function () {
   return {
     ...licenceData()

--- a/cypress/support/scenarios/one-return-requirement-four-return-logs.js
+++ b/cypress/support/scenarios/one-return-requirement-four-return-logs.js
@@ -7,6 +7,9 @@ import returnRequirementPoints from '../fixture-builder/return-requirement-point
 import returnVersion from '../fixture-builder/return-version.js'
 import { currentFinancialYear } from '../helpers/date.helpers.js'
 
+export const title = 'One return requirement, four return logs'
+export const description = 'Licence with one return requirement and four annual return logs across consecutive financial years'
+
 export default function () {
   const dataModel = {
     ...licence(),

--- a/cypress/support/scenarios/one-return-requirement-quarterly-returns.js
+++ b/cypress/support/scenarios/one-return-requirement-quarterly-returns.js
@@ -7,6 +7,9 @@ import returnRequirementPoints from '../fixture-builder/return-requirement-point
 import returnVersion from '../fixture-builder/return-version.js'
 import { currentFinancialYear } from '../helpers/date.helpers.js'
 
+export const title = 'One return requirement, quarterly returns'
+export const description = 'Licence with one return requirement and four quarterly return logs for the current financial year'
+
 export default function () {
   const dataModel = {
     ...licence(),

--- a/cypress/support/scenarios/one-return-requirement-two-points.js
+++ b/cypress/support/scenarios/one-return-requirement-two-points.js
@@ -5,6 +5,9 @@ import returnRequirements from '../fixture-builder/return-requirements.js'
 import returnRequirementPoints from '../fixture-builder/return-requirement-points.js'
 import returnVersion from '../fixture-builder/return-version.js'
 
+export const title = 'One return requirement with two points'
+export const description = 'Licence with one return requirement linked to two abstraction points, with no return logs'
+
 export default function () {
   const dataModel = {
     ...licence(),

--- a/cypress/support/scenarios/one-return-requirement.js
+++ b/cypress/support/scenarios/one-return-requirement.js
@@ -2,6 +2,9 @@ import licence from '../fixture-builder/licence.js'
 import returnRequirements from '../fixture-builder/return-requirements.js'
 import returnVersion from '../fixture-builder/return-version.js'
 
+export const title = 'One return requirement'
+export const description = 'Licence with a single return requirement and version, but no return logs'
+
 export default function () {
   return {
     ...licence(),

--- a/cypress/support/scenarios/return-statuses.js
+++ b/cypress/support/scenarios/return-statuses.js
@@ -1,6 +1,9 @@
 import licenceData from '../fixture-builder/licence.js'
 import { formatDateToIso } from '../helpers/date.helpers.js'
 
+export const title = 'All return statuses'
+export const description = 'Licence with return logs covering every status: due, overdue, not yet due, completed, open, and void'
+
 function _returnLog (startDate, endDate, dueDate, returnReference) {
   const startDateString = formatDateToIso(startDate)
   const endDateString = formatDateToIso(endDate)

--- a/cypress/support/scenarios/sharing-access.js
+++ b/cypress/support/scenarios/sharing-access.js
@@ -1,6 +1,9 @@
 import licence from '../fixture-builder/licence.js'
 import usersData from '../fixture-builder/users.js'
 
+export const title = 'Sharing access'
+export const description = 'Licence with two external users: a primary user and a second user with shared (agent) access'
+
 export default function () {
   return {
     users: [

--- a/cypress/support/scenarios/two-part-tariff-supplementary.js
+++ b/cypress/support/scenarios/two-part-tariff-supplementary.js
@@ -10,6 +10,9 @@ import licenceVersionPurposesData from '../fixture-builder/licence-version-purpo
 import returnLogsData from '../fixture-builder/return-logs.js'
 import { currentFinancialYear } from '../helpers/date.helpers.js'
 
+export const title = 'Two-part tariff supplementary'
+export const description = 'Full two-part tariff supplementary setup: billing account, SROC charge version, S127 agreement, and two due return logs'
+
 export default function () {
   const licenceRecords = _licenceRecords()
   const licenceRef = licenceRecords.licences[0].licenceRef

--- a/cypress/support/scenarios/two-return-requirements-three-return-logs.js
+++ b/cypress/support/scenarios/two-return-requirements-three-return-logs.js
@@ -7,6 +7,9 @@ import returnRequirementPoints from '../fixture-builder/return-requirement-point
 import returnVersion from '../fixture-builder/return-version.js'
 import { currentFinancialYear } from '../helpers/date.helpers.js'
 
+export const title = 'Two return requirements, three return logs each'
+export const description = 'Two return requirements each with three annual return logs: one due (current year) and two completed (previous years)'
+
 export default function () {
   const dataModel = {
     ...licence(),

--- a/cypress/support/scenarios/two-return-requirements-two-return-logs.js
+++ b/cypress/support/scenarios/two-return-requirements-two-return-logs.js
@@ -7,6 +7,9 @@ import returnRequirementPoints from '../fixture-builder/return-requirement-point
 import returnVersion from '../fixture-builder/return-version.js'
 import { currentFinancialYear } from '../helpers/date.helpers.js'
 
+export const title = 'Two return requirements, two return logs each'
+export const description = 'Two return requirements each with two return logs across winter and summer cycles (two due, two from previous year)'
+
 export default function () {
   const dataModel = {
     ...licence(),

--- a/cypress/support/scenarios/two-return-requirements-with-points.js
+++ b/cypress/support/scenarios/two-return-requirements-with-points.js
@@ -5,6 +5,9 @@ import returnRequirements from '../fixture-builder/return-requirements.js'
 import returnRequirementPoints from '../fixture-builder/return-requirement-points.js'
 import returnVersion from '../fixture-builder/return-version.js'
 
+export const title = 'Two return requirements with points'
+export const description = 'Two return requirements and two abstraction points with no return logs'
+
 export default function () {
   return {
     ...licence(),

--- a/cypress/support/scenarios/user-registered-to-licence.js
+++ b/cypress/support/scenarios/user-registered-to-licence.js
@@ -1,6 +1,9 @@
 import licenceData from '../fixture-builder/licence.js'
 import usersData from '../fixture-builder/users.js'
 
+export const title = 'User registered to licence'
+export const description = 'Licence with a registered external user linked as the primary licence entity holder'
+
 export default function () {
   const dataModel = {
     ...licenceData()


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5621

## Summary

- Each scenario file now exports a `title` and `description` constant alongside its default function
- The seed CLI (`cli/seed.cli.js`) reads these at startup via dynamic import and uses them in the searchable dropdown — titles replace filenames as the display name, and descriptions appear below each highlighted option
- Search still matches against both the title and the original filename, so existing muscle memory works
- The loading message now shows the scenario title rather than the filename

🤖 Generated with [Claude Code](https://claude.com/claude-code)