### PR TITLE
Add two unregistered licence scenarios for testing 

### DIFF
--- a/cypress/support/fixture-builder/return-logs.js
+++ b/cypress/support/fixture-builder/return-logs.js
@@ -52,6 +52,7 @@ export default function returnLogs (howMany = 4) {
       startDate: '2020-01-01',
       endDate: '2020-03-31',
       dueDate: '2020-04-28',
+      source: 'WRLS',
       status: 'due',
       underQuery: false,
       returnCycleId: {
@@ -114,6 +115,7 @@ export default function returnLogs (howMany = 4) {
       startDate: '2020-04-01',
       endDate: '2021-03-31',
       dueDate: '2021-04-28',
+      source: 'WRLS',
       status: 'completed',
       underQuery: false,
       returnCycleId: {
@@ -176,6 +178,7 @@ export default function returnLogs (howMany = 4) {
       startDate: '2021-04-01',
       endDate: '2022-03-31',
       dueDate: '2022-04-28',
+      source: 'WRLS',
       status: 'completed',
       underQuery: false,
       returnCycleId: {
@@ -238,6 +241,7 @@ export default function returnLogs (howMany = 4) {
       startDate: '2022-04-01',
       endDate: '2023-03-31',
       dueDate: '2023-04-28',
+      source: 'WRLS',
       status: 'completed',
       underQuery: false,
       returnCycleId: {
@@ -300,6 +304,7 @@ export default function returnLogs (howMany = 4) {
       startDate: '2024-04-01',
       endDate: '2025-03-31',
       dueDate: '2025-04-28',
+      source: 'WRLS',
       status: 'completed',
       underQuery: false,
       returnCycleId: {
@@ -362,6 +367,7 @@ export default function returnLogs (howMany = 4) {
       startDate: '2025-04-01',
       endDate: '2026-03-31',
       dueDate: '2026-04-28',
+      source: 'WRLS',
       status: 'completed',
       underQuery: false,
       returnCycleId: {

--- a/cypress/support/scenarios/unregistered-licence-with-completed-return-log.js
+++ b/cypress/support/scenarios/unregistered-licence-with-completed-return-log.js
@@ -1,0 +1,45 @@
+import licenceData from '../fixture-builder/licence.js'
+import returnLogs from '../fixture-builder/return-logs.js'
+import returnRequirements from '../fixture-builder/return-requirements.js'
+import returnVersion from '../fixture-builder/return-version.js'
+import { formatDateToIso } from '../helpers/date.helpers.js'
+
+export const title = 'Unregistered licence with a completed return log (current period)'
+export const description = 'Unregistered licence with a completed return log for the first current return period with no due date set'
+
+export default function (currentServiceData) {
+  const { firstReturnPeriod } = currentServiceData
+
+  const endDate = new Date(firstReturnPeriod.endDate)
+  const startDate = new Date(firstReturnPeriod.startDate)
+
+  const endDateString = formatDateToIso(endDate)
+  const startDateString = formatDateToIso(startDate)
+
+  const dataModel = {
+    ...licenceData(),
+    ...returnVersion(),
+    ...returnRequirements(),
+    ...returnLogs(1)
+  }
+
+  // Update the licence data to reflect this is unregistered
+  dataModel.licenceDocumentHeaders[0].companyEntityId = null
+  delete dataModel.licenceEntityRoles
+  delete dataModel.licenceEntities
+
+  dataModel.returnLogs[0].dueDate = null
+  dataModel.returnLogs[0].endDate = endDateString
+  dataModel.returnLogs[0].id = '7f6ff22b-f7f6-4f37-a29e-244fad5a22eb'
+  dataModel.returnLogs[0].metadata.description = dataModel.returnRequirements[0].siteDescription
+  dataModel.returnLogs[0].metadata.isSummer = dataModel.returnRequirements[0].summer
+  dataModel.returnLogs[0].returnCycleId.value = `${startDate.getFullYear()}-04-01`
+  dataModel.returnLogs[0].returnId = `v1:8:AT/TE/ST/01/01:9999990:${startDateString}:${endDateString}`
+  dataModel.returnLogs[0].returnReference = dataModel.returnRequirements[0].legacyId
+  dataModel.returnLogs[0].returnRequirementId = dataModel.returnRequirements[0].id
+  dataModel.returnLogs[0].startDate = startDateString
+  dataModel.returnLogs[0].status = 'completed'
+  dataModel.returnLogs[0].quarterly = firstReturnPeriod.quarterly
+
+  return dataModel
+}

--- a/cypress/support/scenarios/unregistered-licence-with-due-return-log.js
+++ b/cypress/support/scenarios/unregistered-licence-with-due-return-log.js
@@ -1,0 +1,45 @@
+import licenceData from '../fixture-builder/licence.js'
+import returnLogs from '../fixture-builder/return-logs.js'
+import returnRequirements from '../fixture-builder/return-requirements.js'
+import returnVersion from '../fixture-builder/return-version.js'
+import { formatDateToIso } from '../helpers/date.helpers.js'
+
+export const title = 'Unregistered licence with a due return log (current period)'
+export const description = 'Unregistered licence with a due return log for the first current return period with no due date set'
+
+export default function (currentServiceData) {
+  const { firstReturnPeriod } = currentServiceData
+
+  const endDate = new Date(firstReturnPeriod.endDate)
+  const startDate = new Date(firstReturnPeriod.startDate)
+
+  const endDateString = formatDateToIso(endDate)
+  const startDateString = formatDateToIso(startDate)
+
+  const dataModel = {
+    ...licenceData(),
+    ...returnVersion(),
+    ...returnRequirements(),
+    ...returnLogs(1)
+  }
+
+  // Update the licence data to reflect this is unregistered
+  dataModel.licenceDocumentHeaders[0].companyEntityId = null
+  delete dataModel.licenceEntityRoles
+  delete dataModel.licenceEntities
+
+  dataModel.returnLogs[0].dueDate = null
+  dataModel.returnLogs[0].endDate = endDateString
+  dataModel.returnLogs[0].id = '7f6ff22b-f7f6-4f37-a29e-244fad5a22eb'
+  dataModel.returnLogs[0].metadata.description = dataModel.returnRequirements[0].siteDescription
+  dataModel.returnLogs[0].metadata.isSummer = dataModel.returnRequirements[0].summer
+  dataModel.returnLogs[0].returnCycleId.value = `${startDate.getFullYear()}-04-01`
+  dataModel.returnLogs[0].returnId = `v1:8:AT/TE/ST/01/01:9999990:${startDateString}:${endDateString}`
+  dataModel.returnLogs[0].returnReference = dataModel.returnRequirements[0].legacyId
+  dataModel.returnLogs[0].returnRequirementId = dataModel.returnRequirements[0].id
+  dataModel.returnLogs[0].startDate = startDateString
+  dataModel.returnLogs[0].status = 'due'
+  dataModel.returnLogs[0].quarterly = firstReturnPeriod.quarterly
+
+  return dataModel
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5677

To test changes we made to the 'clean' step in [water-abstraction-import](https://github.com/DEFRA/water-abstraction-import/pull/1205), we needed to populate the DB with two kinds of licence.

The licence could not exist in NALD, which is fine, as we can just use our test licence. But it also could not be linked to a bill run or be registered.

The licence fixture builder always creates the licence as registered, and all the existing scenarios use this.

So, we're adding two new scenarios to help manually test the overnight import. We want to ensure that it deletes licences that don't exist in NALD only if they don't have a 'completed' return log.