### PR TITLE
Nest scenario setup inside test.describe across internal specs

### DIFF
--- a/.agents/skills/standards/SKILL.md
+++ b/.agents/skills/standards/SKILL.md
@@ -33,6 +33,81 @@ This document defines the standards an agent must apply when reviewing or writin
 - Private functions must be ordered alphabetically by name
 - In spec files and data files, destructure entities out of scenario/data-file results with array patterns rather than indexing directly, e.g. prefer `const { companies: [company], licences: [licence] } = scenario` over `const company = scenario.companies[0]`, and prefer `const { companies: [company], addresses: [address] } = companyData` over `const company = companyData.companies[0]`
 
+## Spec file structure (Playwright)
+
+- Every spec file must have a single `test.describe` block containing everything: entity variables declared with `let`, then `test.beforeAll`, then `test.beforeEach`, then the `test`s. Nothing scenario-related lives at module scope above the `describe`.
+- `test.beforeAll` builds the scenario, destructures the entities the tests need (using temporary `scenario`-prefixed names to avoid shadowing), assigns them to the outer `let` variables, then loads the scenario. Use the `setup` fixture when the scenario needs no calculated dates; use `tearDown` + `calculatedDates` + `load` individually when it does.
+
+```js
+// Bad — scenario built and destructured at module scope, outside the describe
+const scenario = scenarioData()
+
+const {
+  licences: [licence]
+} = scenario
+
+test.describe('Delete licence agreement journey (internal)', () => {
+  test.beforeAll(async ({ setup }) => {
+    await setup(scenario)
+  })
+
+  test.beforeEach(async ({ login, users }) => {
+    await login(users.billingAndData)
+  })
+
+  test('deletes a licence agreement', async ({ page }) => { ... })
+})
+
+// Good — entities declared with let inside the describe, scenario built inside beforeAll
+test.describe('Delete licence agreement journey (internal)', () => {
+  let licence
+
+  test.beforeAll(async ({ setup }) => {
+    const scenario = scenarioData()
+
+    const {
+      licences: [scenarioLicence]
+    } = scenario
+
+    licence = scenarioLicence
+
+    await setup(scenario)
+  })
+
+  test.beforeEach(async ({ login, users }) => {
+    await login(users.billingAndData)
+  })
+
+  test('deletes a licence agreement', async ({ page }) => { ... })
+})
+
+// Good — scenario needs calculated dates, so tearDown/calculatedDates/load are used directly instead of setup
+test.describe('Submit a return with no meter readings (internal)', () => {
+  let returnLog
+
+  test.beforeAll(async ({ tearDown, calculatedDates, load }) => {
+    await tearDown()
+
+    const dates = await calculatedDates()
+    const scenario = scenarioData(dates)
+
+    const {
+      returnLogs: [scenarioReturnLog]
+    } = scenario
+
+    returnLog = scenarioReturnLog
+
+    await load(scenario)
+  })
+
+  test.beforeEach(async ({ login, users }) => {
+    await login(users.billingAndData)
+  })
+
+  test('attempt to submit a return without entering any readings', async ({ page }) => { ... })
+})
+```
+
 ## Locators (Playwright)
 
 - Prefer role- and label-based locators (`getByRole`, `getByLabel`, `getByText`) over positional or structural CSS selectors like `:nth-child(n)`

--- a/.agents/skills/standards/SKILL.md
+++ b/.agents/skills/standards/SKILL.md
@@ -36,7 +36,7 @@ This document defines the standards an agent must apply when reviewing or writin
 ## Spec file structure (Playwright)
 
 - Every spec file must have a single `test.describe` block containing everything: entity variables declared with `let`, then `test.beforeAll`, then `test.beforeEach`, then the `test`s. Nothing scenario-related lives at module scope above the `describe`.
-- `test.beforeAll` builds the scenario, destructures the entities the tests need (using temporary `scenario`-prefixed names to avoid shadowing), assigns them to the outer `let` variables, then loads the scenario. Use the `setup` fixture when the scenario needs no calculated dates; use `tearDown` + `calculatedDates` + `load` individually when it does.
+- `test.beforeAll` builds the scenario, destructures the entities the tests need (using temporary `scenario`-prefixed names to avoid shadowing), assigns them to the outer `let` variables, then loads the scenario via the `setup` fixture. When the scenario needs calculated dates, call `calculatedDates` first to get the dates and pass them into the scenario builder, but still load the result with `setup` rather than calling `tearDown` + `load` individually.
 
 ```js
 // Bad — scenario built and destructured at module scope, outside the describe
@@ -81,13 +81,11 @@ test.describe('Delete licence agreement journey (internal)', () => {
   test('deletes a licence agreement', async ({ page }) => { ... })
 })
 
-// Good — scenario needs calculated dates, so tearDown/calculatedDates/load are used directly instead of setup
+// Good — scenario needs calculated dates, so calculatedDates is called before building it, but setup still loads it
 test.describe('Submit a return with no meter readings (internal)', () => {
   let returnLog
 
-  test.beforeAll(async ({ tearDown, calculatedDates, load }) => {
-    await tearDown()
-
+  test.beforeAll(async ({ setup, calculatedDates }) => {
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
 
@@ -97,7 +95,7 @@ test.describe('Submit a return with no meter readings (internal)', () => {
 
     returnLog = scenarioReturnLog
 
-    await load(scenario)
+    await setup(scenario)
   })
 
   test.beforeEach(async ({ login, users }) => {

--- a/tests/internal/licence-agreements/delete-licence-agreement.spec.js
+++ b/tests/internal/licence-agreements/delete-licence-agreement.spec.js
@@ -1,14 +1,18 @@
 import scenarioData from '../../support/scenarios/unregistered-licence-with-agreement.scenario.js'
 import { test, expect } from '../../support/fixtures.js'
 
-const scenario = scenarioData()
-
-const {
-  licences: [licence]
-} = scenario
-
 test.describe('Delete licence agreement journey (internal)', () => {
+  let licence
+
   test.beforeAll(async ({ setup }) => {
+    const scenario = scenarioData()
+
+    const {
+      licences: [scenarioLicence]
+    } = scenario
+
+    licence = scenarioLicence
+
     await setup(scenario)
   })
 

--- a/tests/internal/licence-agreements/end-licence-agreement.spec.js
+++ b/tests/internal/licence-agreements/end-licence-agreement.spec.js
@@ -1,14 +1,18 @@
 import scenarioData from '../../support/scenarios/unregistered-licence-with-agreement.scenario.js'
 import { test, expect } from '../../support/fixtures.js'
 
-const scenario = scenarioData()
-
-const {
-  licences: [licence]
-} = scenario
-
 test.describe('End licence agreement journey (internal)', () => {
+  let licence
+
   test.beforeAll(async ({ setup }) => {
+    const scenario = scenarioData()
+
+    const {
+      licences: [scenarioLicence]
+    } = scenario
+
+    licence = scenarioLicence
+
     await setup(scenario)
   })
 

--- a/tests/internal/licence-agreements/new-licence-agreement.spec.js
+++ b/tests/internal/licence-agreements/new-licence-agreement.spec.js
@@ -1,14 +1,18 @@
 import scenarioData from '../../support/scenarios/unregistered-licence.scenario.js'
 import { test, expect } from '../../support/fixtures.js'
 
-const scenario = scenarioData()
-
-const {
-  licences: [licence]
-} = scenario
-
 test.describe('New licence agreement journey (internal)', () => {
+  let licence
+
   test.beforeAll(async ({ setup }) => {
+    const scenario = scenarioData()
+
+    const {
+      licences: [scenarioLicence]
+    } = scenario
+
+    licence = scenarioLicence
+
     await setup(scenario)
   })
 

--- a/tests/internal/licence-holder-contacts/licence-holder-contacts.spec.js
+++ b/tests/internal/licence-holder-contacts/licence-holder-contacts.spec.js
@@ -2,16 +2,30 @@ import scenarioData from '../../support/scenarios/company-contact.scenario.js'
 import { test, expect } from '../../support/fixtures.js'
 import { formatLongDate } from '../../support/helpers/date.helpers.js'
 
-const scenario = scenarioData()
-
-const {
-  companies: [company],
-  licences: [licence],
-  contacts: [contact, editContact, removeContact, restoreContact]
-} = scenario
-
 test.describe('Licence holder contacts (internal)', () => {
+  let company
+  let licence
+  let contact
+  let editContact
+  let removeContact
+  let restoreContact
+
   test.beforeAll(async ({ setup }) => {
+    const scenario = scenarioData()
+
+    const {
+      companies: [scenarioCompany],
+      licences: [scenarioLicence],
+      contacts: [scenarioContact, scenarioEditContact, scenarioRemoveContact, scenarioRestoreContact]
+    } = scenario
+
+    company = scenarioCompany
+    licence = scenarioLicence
+    contact = scenarioContact
+    editContact = scenarioEditContact
+    removeContact = scenarioRemoveContact
+    restoreContact = scenarioRestoreContact
+
     await setup(scenario)
   })
 

--- a/tests/internal/licence-holder-contacts/licence-holder-contacts.spec.js
+++ b/tests/internal/licence-holder-contacts/licence-holder-contacts.spec.js
@@ -1,6 +1,7 @@
 import scenarioData from '../../support/scenarios/company-contact.scenario.js'
-import { test, expect } from '../../support/fixtures.js'
 import { formatLongDate } from '../../support/helpers/date.helpers.js'
+import { summaryRow } from '../../support/helpers/govuk.helpers.js'
+import { test, expect } from '../../support/fixtures.js'
 
 test.describe('Licence holder contacts (internal)', () => {
   let company
@@ -330,7 +331,7 @@ test.describe('Licence holder contacts (internal)', () => {
  * Locates the value cell of a govuk-summary-list row identified by its label
  */
 function _summaryValue(page, label) {
-  return page.locator('.govuk-summary-list__row', { hasText: label }).locator('.govuk-summary-list__value')
+  return summaryRow(page, label).locator('.govuk-summary-list__value')
 }
 
 /**

--- a/tests/internal/licence-holder/licence-holder.spec.js
+++ b/tests/internal/licence-holder/licence-holder.spec.js
@@ -2,15 +2,21 @@ import scenarioData from '../../support/scenarios/unregistered-licence.scenario.
 import { test, expect } from '../../support/fixtures.js'
 import { formatLongDate } from '../../support/helpers/date.helpers.js'
 
-const scenario = scenarioData()
-
-const {
-  companies: [company],
-  licences: [licence]
-} = scenario
-
 test.describe('Licence holder (internal)', () => {
+  let company
+  let licence
+
   test.beforeAll(async ({ setup }) => {
+    const scenario = scenarioData()
+
+    const {
+      companies: [scenarioCompany],
+      licences: [scenarioLicence]
+    } = scenario
+
+    company = scenarioCompany
+    licence = scenarioLicence
+
     await setup(scenario)
   })
 

--- a/tests/internal/licence/search.spec.js
+++ b/tests/internal/licence/search.spec.js
@@ -1,14 +1,18 @@
 import scenarioData from '../../support/scenarios/unregistered-licence.scenario.js'
 import { test, expect } from '../../support/fixtures.js'
 
-const scenario = scenarioData()
-
-const {
-  licences: [licence]
-} = scenario
-
 test.describe('Search for a licence (internal)', () => {
+  let licence
+
   test.beforeAll(async ({ setup }) => {
+    const scenario = scenarioData()
+
+    const {
+      licences: [scenarioLicence]
+    } = scenario
+
+    licence = scenarioLicence
+
     await setup(scenario)
   })
 

--- a/tests/internal/licence/unregister.spec.js
+++ b/tests/internal/licence/unregister.spec.js
@@ -1,16 +1,24 @@
 import scenarioData from '../../support/scenarios/registered-licence.scenario.js'
 import { test, expect } from '../../support/fixtures.js'
 
-const scenario = scenarioData()
-
-const {
-  companies: [company],
-  licences: [licence],
-  users: [user]
-} = scenario
-
 test.describe('Unregister a licence (internal)', () => {
+  let company
+  let licence
+  let user
+
   test.beforeAll(async ({ setup }) => {
+    const scenario = scenarioData()
+
+    const {
+      companies: [scenarioCompany],
+      licences: [scenarioLicence],
+      users: [scenarioUser]
+    } = scenario
+
+    company = scenarioCompany
+    licence = scenarioLicence
+    user = scenarioUser
+
     await setup(scenario)
   })
 

--- a/tests/internal/notices/ad-hoc/paper-returns.spec.js
+++ b/tests/internal/notices/ad-hoc/paper-returns.spec.js
@@ -2,13 +2,11 @@ import scenarioData from '../../../support/scenarios/registered-licence-with-pre
 import { test, expect } from '../../../support/fixtures.js'
 
 test.describe('Ad-hoc Paper returns journey (internal)', () => {
-  test.beforeAll(async ({ tearDown, calculatedDates, load }) => {
-    await tearDown()
-
+  test.beforeAll(async ({ setup, calculatedDates }) => {
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
 
-    await load(scenario)
+    await setup(scenario)
   })
 
   test.beforeEach(async ({ login, users }) => {

--- a/tests/internal/notices/ad-hoc/renewal-invitation.spec.js
+++ b/tests/internal/notices/ad-hoc/renewal-invitation.spec.js
@@ -2,12 +2,10 @@ import scenarioData from '../../../support/scenarios/registered-licence-for-rene
 import { test, expect } from '../../../support/fixtures.js'
 
 test.describe('Ad-hoc renewal invitation journey (internal)', () => {
-  test.beforeAll(async ({ tearDown, load }) => {
-    await tearDown()
-
+  test.beforeAll(async ({ setup }) => {
     const scenario = scenarioData()
 
-    await load(scenario)
+    await setup(scenario)
   })
 
   test.beforeEach(async ({ login, users }) => {

--- a/tests/internal/notices/ad-hoc/returns-invitation-alternate.spec.js
+++ b/tests/internal/notices/ad-hoc/returns-invitation-alternate.spec.js
@@ -4,13 +4,11 @@ import { test, expect } from '../../../support/fixtures.js'
 import { reloadUntilTextFound } from '../../../support/helpers/wait.helpers.js'
 
 test.describe('Ad-hoc returns invitation alternate journey (internal)', () => {
-  test.beforeAll(async ({ tearDown, calculatedDates, load }) => {
-    await tearDown()
-
+  test.beforeAll(async ({ setup, calculatedDates }) => {
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
 
-    await load(scenario)
+    await setup(scenario)
   })
 
   test.beforeEach(async ({ login, users }) => {

--- a/tests/internal/notices/ad-hoc/returns-invitation.spec.js
+++ b/tests/internal/notices/ad-hoc/returns-invitation.spec.js
@@ -2,13 +2,11 @@ import scenarioData from '../../../support/scenarios/registered-licence-with-pre
 import { test, expect } from '../../../support/fixtures.js'
 
 test.describe('Ad-hoc returns invitation journey (internal)', () => {
-  test.beforeAll(async ({ tearDown, calculatedDates, load }) => {
-    await tearDown()
-
+  test.beforeAll(async ({ setup, calculatedDates }) => {
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
 
-    await load(scenario)
+    await setup(scenario)
   })
 
   test.beforeEach(async ({ login, users }) => {

--- a/tests/internal/notices/ad-hoc/returns-reminder.spec.js
+++ b/tests/internal/notices/ad-hoc/returns-reminder.spec.js
@@ -2,13 +2,11 @@ import scenarioData from '../../../support/scenarios/registered-licence-with-due
 import { test, expect } from '../../../support/fixtures.js'
 
 test.describe('Ad-hoc returns reminder journey (internal)', () => {
-  test.beforeAll(async ({ tearDown, calculatedDates, load }) => {
-    await tearDown()
-
+  test.beforeAll(async ({ setup, calculatedDates }) => {
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
 
-    await load(scenario)
+    await setup(scenario)
   })
 
   test.beforeEach(async ({ login, users }) => {

--- a/tests/internal/notices/standard/returns-invitation.spec.js
+++ b/tests/internal/notices/standard/returns-invitation.spec.js
@@ -2,13 +2,11 @@ import scenarioData from '../../../support/scenarios/unregistered-licence-with-r
 import { test, expect } from '../../../support/fixtures.js'
 
 test.describe('Standard returns invitation journey (internal)', () => {
-  test.beforeAll(async ({ tearDown, calculatedDates, load }) => {
-    await tearDown()
-
+  test.beforeAll(async ({ setup, calculatedDates }) => {
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
 
-    await load(scenario)
+    await setup(scenario)
   })
 
   test.beforeEach(async ({ login, users }) => {

--- a/tests/internal/notices/standard/returns-reminder.spec.js
+++ b/tests/internal/notices/standard/returns-reminder.spec.js
@@ -2,13 +2,11 @@ import scenarioData from '../../../support/scenarios/unregistered-licence-with-d
 import { test, expect } from '../../../support/fixtures.js'
 
 test.describe('Standard returns reminder journey (internal)', () => {
-  test.beforeAll(async ({ tearDown, calculatedDates, load }) => {
-    await tearDown()
-
+  test.beforeAll(async ({ setup, calculatedDates }) => {
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
 
-    await load(scenario)
+    await setup(scenario)
   })
 
   test.beforeEach(async ({ login, users }) => {

--- a/tests/internal/return-logs/record-receipt.spec.js
+++ b/tests/internal/return-logs/record-receipt.spec.js
@@ -4,9 +4,7 @@ import { test, expect } from '../../support/fixtures.js'
 test.describe('Record receipt for return (internal)', () => {
   let returnLog
 
-  test.beforeAll(async ({ tearDown, calculatedDates, load }) => {
-    await tearDown()
-
+  test.beforeAll(async ({ setup, calculatedDates }) => {
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
 
@@ -16,7 +14,7 @@ test.describe('Record receipt for return (internal)', () => {
 
     returnLog = scenarioReturnLog
 
-    await load(scenario)
+    await setup(scenario)
   })
 
   test.beforeEach(async ({ login, users }) => {

--- a/tests/internal/return-logs/submit-edit-zero-abstraction-volumes.spec.js
+++ b/tests/internal/return-logs/submit-edit-zero-abstraction-volumes.spec.js
@@ -4,9 +4,7 @@ import { test, expect } from '../../support/fixtures.js'
 test.describe('Submit then edit an abstraction volumes return with zero quantities (internal)', () => {
   let returnLog
 
-  test.beforeAll(async ({ tearDown, calculatedDates, load }) => {
-    await tearDown()
-
+  test.beforeAll(async ({ setup, calculatedDates }) => {
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
 
@@ -16,7 +14,7 @@ test.describe('Submit then edit an abstraction volumes return with zero quantiti
 
     returnLog = scenarioReturnLog
 
-    await load(scenario)
+    await setup(scenario)
   })
 
   test.beforeEach(async ({ login, users }) => {

--- a/tests/internal/return-logs/submit-edit-zero-meter-readings.spec.js
+++ b/tests/internal/return-logs/submit-edit-zero-meter-readings.spec.js
@@ -4,9 +4,7 @@ import { test, expect } from '../../support/fixtures.js'
 test.describe('Submit then edit a meter readings return with zero reading (internal)', () => {
   let returnLog
 
-  test.beforeAll(async ({ tearDown, calculatedDates, load }) => {
-    await tearDown()
-
+  test.beforeAll(async ({ setup, calculatedDates }) => {
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
 
@@ -16,7 +14,7 @@ test.describe('Submit then edit a meter readings return with zero reading (inter
 
     returnLog = scenarioReturnLog
 
-    await load(scenario)
+    await setup(scenario)
   })
 
   test.beforeEach(async ({ login, users }) => {

--- a/tests/internal/return-logs/submit-meter-readings.spec.js
+++ b/tests/internal/return-logs/submit-meter-readings.spec.js
@@ -4,9 +4,7 @@ import { test, expect } from '../../support/fixtures.js'
 test.describe('Submit a meter readings return (internal)', () => {
   let returnLog
 
-  test.beforeAll(async ({ tearDown, calculatedDates, load }) => {
-    await tearDown()
-
+  test.beforeAll(async ({ setup, calculatedDates }) => {
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
 
@@ -16,7 +14,7 @@ test.describe('Submit a meter readings return (internal)', () => {
 
     returnLog = scenarioReturnLog
 
-    await load(scenario)
+    await setup(scenario)
   })
 
   test.beforeEach(async ({ login, users }) => {

--- a/tests/internal/return-logs/submit-nil-return.spec.js
+++ b/tests/internal/return-logs/submit-nil-return.spec.js
@@ -1,4 +1,5 @@
 import scenarioData from '../../support/scenarios/unregistered-licence-with-due-return-log.scenario.js'
+import { summaryRow } from '../../support/helpers/govuk.helpers.js'
 import { test, expect } from '../../support/fixtures.js'
 
 test.describe('Submit a nil return (internal)', () => {
@@ -42,7 +43,7 @@ test.describe('Submit a nil return (internal)', () => {
 
     // Reporting details
     // Confirm the return is nil and continue
-    await expect(_summaryRow(page, 'Nil return').locator('.govuk-summary-list__value')).toContainText('Yes')
+    await expect(summaryRow(page, 'Nil return').locator('.govuk-summary-list__value')).toContainText('Yes')
     await page.locator('.govuk-button').first().click()
 
     // Return submitted
@@ -60,10 +61,3 @@ test.describe('Submit a nil return (internal)', () => {
     )
   })
 })
-
-/**
- * Locates the govuk-summary-list row whose label matches the given text
- */
-function _summaryRow(page, label) {
-  return page.locator('.govuk-summary-list__row', { hasText: label })
-}

--- a/tests/internal/return-logs/submit-nil-return.spec.js
+++ b/tests/internal/return-logs/submit-nil-return.spec.js
@@ -5,9 +5,7 @@ import { test, expect } from '../../support/fixtures.js'
 test.describe('Submit a nil return (internal)', () => {
   let returnLog
 
-  test.beforeAll(async ({ tearDown, calculatedDates, load }) => {
-    await tearDown()
-
+  test.beforeAll(async ({ setup, calculatedDates }) => {
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
 
@@ -17,7 +15,7 @@ test.describe('Submit a nil return (internal)', () => {
 
     returnLog = scenarioReturnLog
 
-    await load(scenario)
+    await setup(scenario)
   })
 
   test.beforeEach(async ({ login, users }) => {

--- a/tests/internal/return-logs/submit-no-quantities.spec.js
+++ b/tests/internal/return-logs/submit-no-quantities.spec.js
@@ -4,9 +4,7 @@ import { test, expect } from '../../support/fixtures.js'
 test.describe('Submit a return with no quantities - validation errors (internal)', () => {
   let returnLog
 
-  test.beforeAll(async ({ tearDown, calculatedDates, load }) => {
-    await tearDown()
-
+  test.beforeAll(async ({ setup, calculatedDates }) => {
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
 
@@ -16,7 +14,7 @@ test.describe('Submit a return with no quantities - validation errors (internal)
 
     returnLog = scenarioReturnLog
 
-    await load(scenario)
+    await setup(scenario)
   })
 
   test.beforeEach(async ({ login, users }) => {

--- a/tests/internal/return-logs/submit-no-readings.spec.js
+++ b/tests/internal/return-logs/submit-no-readings.spec.js
@@ -4,9 +4,7 @@ import { test, expect } from '../../support/fixtures.js'
 test.describe('Submit a return with no meter readings - validation errors (internal)', () => {
   let returnLog
 
-  test.beforeAll(async ({ tearDown, calculatedDates, load }) => {
-    await tearDown()
-
+  test.beforeAll(async ({ setup, calculatedDates }) => {
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
 
@@ -16,7 +14,7 @@ test.describe('Submit a return with no meter readings - validation errors (inter
 
     returnLog = scenarioReturnLog
 
-    await load(scenario)
+    await setup(scenario)
   })
 
   test.beforeEach(async ({ login, users }) => {

--- a/tests/internal/return-logs/submit-single-volume.spec.js
+++ b/tests/internal/return-logs/submit-single-volume.spec.js
@@ -4,9 +4,7 @@ import { test, expect } from '../../support/fixtures.js'
 test.describe('Submit a single volume return (internal)', () => {
   let returnLog
 
-  test.beforeAll(async ({ tearDown, calculatedDates, load }) => {
-    await tearDown()
-
+  test.beforeAll(async ({ setup, calculatedDates }) => {
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
 
@@ -16,7 +14,7 @@ test.describe('Submit a single volume return (internal)', () => {
 
     returnLog = scenarioReturnLog
 
-    await load(scenario)
+    await setup(scenario)
   })
 
   test.beforeEach(async ({ login, users }) => {

--- a/tests/internal/return-logs/view-status.spec.js
+++ b/tests/internal/return-logs/view-status.spec.js
@@ -5,9 +5,7 @@ test.describe('View returns and their status (internal)', () => {
   let licence
   let returnLogs
 
-  test.beforeAll(async ({ tearDown, calculatedDates, load }) => {
-    await tearDown()
-
+  test.beforeAll(async ({ setup, calculatedDates }) => {
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
 
@@ -19,7 +17,7 @@ test.describe('View returns and their status (internal)', () => {
     licence = licenceScenario
     returnLogs = returnLogsScenario
 
-    await load(scenario)
+    await setup(scenario)
   })
 
   test.beforeEach(async ({ login, users }) => {

--- a/tests/internal/return-versions/cancel-using-copy-from-journey.spec.js
+++ b/tests/internal/return-versions/cancel-using-copy-from-journey.spec.js
@@ -1,15 +1,21 @@
 import scenarioData from '../../support/scenarios/unregistered-licence-with-two-purposes-and-requirements.scenario.js'
 import { test, expect } from '../../support/fixtures.js'
 
-const scenario = scenarioData()
-
-const {
-  licences: [licence],
-  returnRequirements: [returnRequirement]
-} = scenario
-
 test.describe('Cancel a return version using copy from existing (internal)', () => {
+  let licence
+  let returnRequirement
+
   test.beforeAll(async ({ setup }) => {
+    const scenario = scenarioData()
+
+    const {
+      licences: [scenarioLicence],
+      returnRequirements: [scenarioReturnRequirement]
+    } = scenario
+
+    licence = scenarioLicence
+    returnRequirement = scenarioReturnRequirement
+
     await setup(scenario)
   })
 

--- a/tests/internal/return-versions/submit-no-returns-required-journey.spec.js
+++ b/tests/internal/return-versions/submit-no-returns-required-journey.spec.js
@@ -1,14 +1,18 @@
 import scenarioData from '../../support/scenarios/unregistered-licence.scenario.js'
 import { test, expect } from '../../support/fixtures.js'
 
-const scenario = scenarioData()
-
-const {
-  licences: [licence]
-} = scenario
-
 test.describe('Submit no returns requirement (internal)', () => {
+  let licence
+
   test.beforeAll(async ({ setup }) => {
+    const scenario = scenarioData()
+
+    const {
+      licences: [scenarioLicence]
+    } = scenario
+
+    licence = scenarioLicence
+
     await setup(scenario)
   })
 

--- a/tests/internal/return-versions/submit-using-abstraction-data-journey.spec.js
+++ b/tests/internal/return-versions/submit-using-abstraction-data-journey.spec.js
@@ -1,14 +1,18 @@
 import scenarioData from '../../support/scenarios/unregistered-licence-with-two-purposes.scenario.js'
 import { test, expect } from '../../support/fixtures.js'
 
-const scenario = scenarioData()
-
-const {
-  licences: [licence]
-} = scenario
-
 test.describe('Submit return version using abstraction data (internal)', () => {
+  let licence
+
   test.beforeAll(async ({ setup }) => {
+    const scenario = scenarioData()
+
+    const {
+      licences: [scenarioLicence]
+    } = scenario
+
+    licence = scenarioLicence
+
     await setup(scenario)
   })
 

--- a/tests/internal/return-versions/submit-using-manual-journey.spec.js
+++ b/tests/internal/return-versions/submit-using-manual-journey.spec.js
@@ -1,14 +1,18 @@
 import scenarioData from '../../support/scenarios/unregistered-licence-with-two-purposes.scenario.js'
 import { test, expect } from '../../support/fixtures.js'
 
-const scenario = scenarioData()
-
-const {
-  licences: [licence]
-} = scenario
-
 test.describe('Submit return version manually (internal)', () => {
+  let licence
+
   test.beforeAll(async ({ setup }) => {
+    const scenario = scenarioData()
+
+    const {
+      licences: [scenarioLicence]
+    } = scenario
+
+    licence = scenarioLicence
+
     await setup(scenario)
   })
 

--- a/tests/internal/return-versions/update-requirement-purpose-and-points-journey.spec.js
+++ b/tests/internal/return-versions/update-requirement-purpose-and-points-journey.spec.js
@@ -1,14 +1,18 @@
 import scenarioData from '../../support/scenarios/unregistered-licence-with-two-purposes-and-requirements.scenario.js'
 import { test, expect } from '../../support/fixtures.js'
 
-const scenario = scenarioData()
-
-const {
-  licences: [licence]
-} = scenario
-
 test.describe('Update the purpose and points of a copied return requirement and add another manually (internal)', () => {
+  let licence
+
   test.beforeAll(async ({ setup }) => {
+    const scenario = scenarioData()
+
+    const {
+      licences: [scenarioLicence]
+    } = scenario
+
+    licence = scenarioLicence
+
     await setup(scenario)
   })
 

--- a/tests/internal/user/change-permissions.spec.js
+++ b/tests/internal/user/change-permissions.spec.js
@@ -1,14 +1,18 @@
 import scenarioData from '../../support/scenarios/internal-user.scenario.js'
 import { test, expect } from '../../support/fixtures.js'
 
-const scenario = scenarioData()
-
-const {
-  users: [userToUpdate]
-} = scenario
-
 test.describe('Change user permissions (internal)', () => {
+  let userToUpdate
+
   test.beforeAll(async ({ setup }) => {
+    const scenario = scenarioData()
+
+    const {
+      users: [scenarioUserToUpdate]
+    } = scenario
+
+    userToUpdate = scenarioUserToUpdate
+
     await setup(scenario)
   })
 

--- a/tests/internal/user/change-permissions.spec.js
+++ b/tests/internal/user/change-permissions.spec.js
@@ -1,4 +1,5 @@
 import scenarioData from '../../support/scenarios/internal-user.scenario.js'
+import { summaryRow } from '../../support/helpers/govuk.helpers.js'
 import { test, expect } from '../../support/fixtures.js'
 
 test.describe('Change user permissions (internal)', () => {
@@ -39,7 +40,7 @@ test.describe('Change user permissions (internal)', () => {
     await page.locator('.govuk-button').click()
 
     // Click the permissions change link
-    await _summaryRow(page, 'Permission').getByRole('link', { name: 'Change' }).click()
+    await summaryRow(page, 'Permission').getByRole('link', { name: 'Change' }).click()
 
     // Select permissions for the user
     // Change from Basic to Environment officer
@@ -48,7 +49,7 @@ test.describe('Change user permissions (internal)', () => {
 
     // Confirm notification shown and new permission shown, then submit
     await expect(page.locator('.govuk-notification-banner__heading')).toContainText('Permissions updated')
-    await expect(_summaryRow(page, 'Permission').locator('.govuk-summary-list__value')).toContainText(
+    await expect(summaryRow(page, 'Permission').locator('.govuk-summary-list__value')).toContainText(
       'Environment Officer'
     )
     await page.locator('.govuk-button', { hasText: 'Confirm' }).click()
@@ -61,10 +62,3 @@ test.describe('Change user permissions (internal)', () => {
     await expect(page.locator('[data-test="user-permissions-0"]')).toContainText('Environment Officer')
   })
 })
-
-/**
- * Locates the govuk-summary-list row whose label matches the given text
- */
-function _summaryRow(page, label) {
-  return page.locator('.govuk-summary-list__row', { hasText: label })
-}

--- a/tests/internal/user/permissions.spec.js
+++ b/tests/internal/user/permissions.spec.js
@@ -1,14 +1,18 @@
 import scenarioData from '../../support/scenarios/unregistered-licence.scenario.js'
 import { test, expect } from '../../support/fixtures.js'
 
-const scenario = scenarioData()
-
-const {
-  licences: [licence]
-} = scenario
-
 test.describe('User permissions (internal)', () => {
+  let licence
+
   test.beforeAll(async ({ setup }) => {
+    const scenario = scenarioData()
+
+    const {
+      licences: [scenarioLicence]
+    } = scenario
+
+    licence = scenarioLicence
+
     await setup(scenario)
   })
 

--- a/tests/support/helpers/govuk.helpers.js
+++ b/tests/support/helpers/govuk.helpers.js
@@ -1,0 +1,11 @@
+/**
+ * Locates the govuk-summary-list row whose label matches the given text
+ *
+ * @param {import('@playwright/test').Page} page - The page to search
+ * @param {string} label - The text the row's label must match
+ *
+ * @returns {import('@playwright/test').Locator} The matching `.govuk-summary-list__row`
+ */
+export function summaryRow(page, label) {
+  return page.locator('.govuk-summary-list__row', { hasText: label })
+}


### PR DESCRIPTION
Several internal specs built and destructured their scenario at module scope, outside the test.describe block, which was inconsistent with the rest of the suite. This moves that setup into beforeAll with entities declared as let inside the describe, matching the established pattern used elsewhere. Also documents the convention as a standard in the standards skill so it stays consistent going forward.

A follow-up commit removes a duplicated _summaryRow helper that two specs had copy-pasted, extracting it to a shared tests/support/helpers/govuk.helpers.js, and switches renewal-invitation.spec.js to the setup fixture instead of manually calling tearDown/load, matching every other spec that doesn't need calculated dates.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>