### PR TITLE
Stop defaulting licence as a water company 

### DIFF
--- a/tests/internal/return-versions/submit-using-abstraction-data-journey.spec.js
+++ b/tests/internal/return-versions/submit-using-abstraction-data-journey.spec.js
@@ -64,8 +64,8 @@ test.describe('Submit return version using abstraction data (internal)', () => {
     await expect(page.locator('[data-test="abstraction-period-0"]')).toContainText('From 1 April to 31 March')
     await expect(page.locator('[data-test="returns-cycle-0"]')).toContainText('Winter and all year')
     await expect(page.locator('[data-test="site-description-0"]')).toContainText('Example point 1')
-    await expect(page.locator('[data-test="frequency-collected-0"]')).toContainText('Daily')
-    await expect(page.locator('[data-test="frequency-reported-0"]')).toContainText('Daily')
+    await expect(page.locator('[data-test="frequency-collected-0"]')).toContainText('Monthly')
+    await expect(page.locator('[data-test="frequency-reported-0"]')).toContainText('Monthly')
     await expect(page.locator('[data-test="agreements-exceptions-0"]')).toContainText('None')
 
     // Return requirement 2
@@ -77,8 +77,8 @@ test.describe('Submit return version using abstraction data (internal)', () => {
     await expect(page.locator('[data-test="abstraction-period-1"]')).toContainText('From 1 April to 31 March')
     await expect(page.locator('[data-test="returns-cycle-1"]')).toContainText('Winter and all year')
     await expect(page.locator('[data-test="site-description-1"]')).toContainText('Example point 2')
-    await expect(page.locator('[data-test="frequency-collected-1"]')).toContainText('Daily')
-    await expect(page.locator('[data-test="frequency-reported-1"]')).toContainText('Daily')
+    await expect(page.locator('[data-test="frequency-collected-1"]')).toContainText('Monthly')
+    await expect(page.locator('[data-test="frequency-reported-1"]')).toContainText('Monthly')
     await expect(page.locator('[data-test="agreements-exceptions-1"]')).toContainText('None')
 
     // choose the approve return requirement button
@@ -111,8 +111,8 @@ test.describe('Submit return version using abstraction data (internal)', () => {
     await expect(page.locator('[data-test="abstraction-period-0"]')).toContainText('1 April to 31 March')
     await expect(page.locator('[data-test="returns-cycle-0"]')).toContainText('Winter and all year')
     await expect(page.locator('[data-test="site-description-0"]')).toContainText('Example point 1')
-    await expect(page.locator('[data-test="frequency-collected-0"]')).toContainText('Daily')
-    await expect(page.locator('[data-test="frequency-reported-0"]')).toContainText('Daily')
+    await expect(page.locator('[data-test="frequency-collected-0"]')).toContainText('Monthly')
+    await expect(page.locator('[data-test="frequency-reported-0"]')).toContainText('Monthly')
     await expect(page.locator('[data-test="agreements-exceptions-0"]')).toContainText('None')
 
     // Return requirement 2
@@ -124,8 +124,8 @@ test.describe('Submit return version using abstraction data (internal)', () => {
     await expect(page.locator('[data-test="abstraction-period-1"]')).toContainText('1 April to 31 March')
     await expect(page.locator('[data-test="returns-cycle-1"]')).toContainText('Winter and all year')
     await expect(page.locator('[data-test="site-description-1"]')).toContainText('Example point 2')
-    await expect(page.locator('[data-test="frequency-collected-1"]')).toContainText('Daily')
-    await expect(page.locator('[data-test="frequency-reported-1"]')).toContainText('Daily')
+    await expect(page.locator('[data-test="frequency-collected-1"]')).toContainText('Monthly')
+    await expect(page.locator('[data-test="frequency-reported-1"]')).toContainText('Monthly')
     await expect(page.locator('[data-test="agreements-exceptions-1"]')).toContainText('None')
   })
 })

--- a/tests/support/data/licence.data.js
+++ b/tests/support/data/licence.data.js
@@ -107,7 +107,7 @@ export default function (licenceRef, companyData) {
           regionalChargeArea: 'Southern'
         },
         startDate: '2018-01-01',
-        waterUndertaker: true
+        waterUndertaker: false
       }
     ],
     licenceVersions: [


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5722

The Playwright licence data builder was derived from the Cypress fixture builder, which in turn was based on the JSON seed data we inherited from the previous team.

It's been altered and refined over time, but one thing that has remained constant is that it defaults the licence to a water company (`waterUndertaker: true`). Originally, that would only result in a slight change in the calculated charges, but now it can lead to a real difference in how many return logs the service generates when a return version is submitted.

The default really should be that the licence is _not_ a water company, unless the scenario requires one.