### PR TITLE
Dynamically set return req. purposes from licence

### DIFF
--- a/tests/internal/return-versions/cancel-using-copy-from-journey.spec.js
+++ b/tests/internal/return-versions/cancel-using-copy-from-journey.spec.js
@@ -4,17 +4,20 @@ import { test, expect } from '../../support/fixtures.js'
 test.describe('Cancel a return version using copy from existing (internal)', () => {
   let licence
   let returnRequirement
+  let returnRequirementPurpose
 
   test.beforeAll(async ({ setup }) => {
     const scenario = scenarioData()
 
     const {
       licences: [scenarioLicence],
-      returnRequirements: [scenarioReturnRequirement]
+      returnRequirements: [scenarioReturnRequirement],
+      returnRequirementPurposes: [scenarioReturnRequirementPurpose]
     } = scenario
 
     licence = scenarioLicence
     returnRequirement = scenarioReturnRequirement
+    returnRequirementPurpose = scenarioReturnRequirementPurpose
 
     await setup(scenario)
   })
@@ -67,9 +70,7 @@ test.describe('Cancel a return version using copy from existing (internal)', () 
     await expect(page.locator('[data-test="reason"]')).toContainText('Change to special agreement')
 
     // confirm we see the purposes copied from the existing requirement
-    await expect(page.locator('[data-test="purposes-0"]')).toContainText(
-      'Spray Irrigation - Storage (SPRAY IRRIGATION STORAGE)'
-    )
+    await expect(page.locator('[data-test="purposes-0"]')).toContainText(returnRequirementPurpose.alias)
 
     // confirm we see the points copied from the existing requirement
     await expect(page.locator('[data-test="points-0"]')).toContainText(

--- a/tests/internal/return-versions/update-requirement-purpose-and-points-journey.spec.js
+++ b/tests/internal/return-versions/update-requirement-purpose-and-points-journey.spec.js
@@ -3,15 +3,18 @@ import { test, expect } from '../../support/fixtures.js'
 
 test.describe('Update the purpose and points of a copied return requirement and add another manually (internal)', () => {
   let licence
+  let returnRequirementPurpose
 
   test.beforeAll(async ({ setup }) => {
     const scenario = scenarioData()
 
     const {
-      licences: [scenarioLicence]
+      licences: [scenarioLicence],
+      returnRequirementPurposes: [scenarioReturnRequirementPurpose]
     } = scenario
 
     licence = scenarioLicence
+    returnRequirementPurpose = scenarioReturnRequirementPurpose
 
     await setup(scenario)
   })
@@ -62,9 +65,7 @@ test.describe('Update the purpose and points of a copied return requirement and 
     await expect(page.locator('[data-test="reason"]')).toContainText('Minor change')
 
     // confirm we see the purpose and purpose description for the requirement copied from existing
-    await expect(page.locator('[data-test="purposes-0"]')).toContainText(
-      'Spray Irrigation - Storage (SPRAY IRRIGATION STORAGE)'
-    )
+    await expect(page.locator('[data-test="purposes-0"]')).toContainText(returnRequirementPurpose.alias)
 
     // choose the change link for the purpose and confirm we are on the purpose page
     await page.locator('[data-test="change-purposes-0"]').click()

--- a/tests/support/data/return-requirement.data.js
+++ b/tests/support/data/return-requirement.data.js
@@ -5,7 +5,10 @@ export default function (returnVersionData, licence, reference = 9999990) {
     returnVersions: [returnVersion]
   } = returnVersionData
 
-  const { points } = licence
+  const {
+    licenceVersionPurposes: [licenceVersionPurpose],
+    points
+  } = licence
 
   const returnRequirementId = generateUUID()
 
@@ -36,26 +39,26 @@ export default function (returnVersionData, licence, reference = 9999990) {
     returnRequirementPurposes: [
       {
         returnRequirementId,
-        alias: 'SPRAY IRRIGATION STORAGE',
+        alias: `TEST RET REQ PURPOSE ${licenceVersionPurpose.purposeId.value}`,
         primaryPurposeId: {
           schema: 'water',
           table: 'purposesPrimary',
           lookup: 'legacyId',
-          value: 'A',
+          value: licenceVersionPurpose.primaryPurposeId.value,
           select: 'purposePrimaryId'
         },
         secondaryPurposeId: {
           schema: 'water',
           table: 'purposesSecondary',
           lookup: 'legacyId',
-          value: 'AGR',
+          value: licenceVersionPurpose.secondaryPurposeId.value,
           select: 'purposeSecondaryId'
         },
         purposeId: {
           schema: 'public',
           table: 'purposes',
           lookup: 'legacyId',
-          value: '420',
+          value: licenceVersionPurpose.purposeId.value,
           select: 'id'
         }
       }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5722

Our base `unregistered-licence` scenario sets the licence with a licence version purpose, as a licence version needs at least one.

But then, in the `return-requirement` data module, we populate it with a different purpose than the one set in the licence. In the service, you can only select from the purposes assigned to the corresponding licence version when creating a new return version (and, therefore, a requirement).

At the very least, they should be the same. But we can make it a little cleverer and follow the example of 'points', by making it dynamic based on the licence data.

In 'real life', most return versions match their corresponding licence version, with a requirement per purpose. So, setting the return requirement's purpose to match the first in the licence gets us closer to that by default.