### PR TITLE
Align ret. vers. start date with first return log 

### DIFF
--- a/tests/support/scenarios/unregistered-licence-with-all-return-log-statuses.scenario.js
+++ b/tests/support/scenarios/unregistered-licence-with-all-return-log-statuses.scenario.js
@@ -15,6 +15,10 @@ export default function (calculatedDates) {
   const licence = unregisteredLicenceScenario()
   const returnVersion = returnVersionData(licence)
 
+  // In the service return logs will cover the whole period of their matching return version. To ensure our test data is
+  // realistic, we alter the start date of the return version to match the first return log we're seeding.
+  returnVersion.returnVersions[0].startDate = previousPeriod.startDate
+
   return mergeByKey(
     licence,
     returnVersion,

--- a/tests/support/scenarios/unregistered-licence-with-open-return-log-for-first-period.scenario.js
+++ b/tests/support/scenarios/unregistered-licence-with-open-return-log-for-first-period.scenario.js
@@ -27,6 +27,10 @@ export default function (calculatedDates) {
 
   const returnVersion = returnVersionData(unregisteredLicence)
 
+  // In the service return logs will cover the whole period of their matching return version. To ensure our test data is
+  // realistic, we alter the start date of the return version to match the first return log we're seeding.
+  returnVersion.returnVersions[0].startDate = period0.startDate
+
   const returnRequirement = returnRequirementData(returnVersion, unregisteredLicence)
 
   const returnLog = returnLogData(unregisteredLicence, returnRequirement, period0)

--- a/tests/support/scenarios/unregistered-licence-with-open-winter-return-log.scenario.js
+++ b/tests/support/scenarios/unregistered-licence-with-open-winter-return-log.scenario.js
@@ -20,7 +20,12 @@ export default function (calculatedDates) {
   })
 
   const licence = unregisteredLicenceScenario()
+
   const returnVersion = returnVersionData(licence)
+
+  // In the service return logs will cover the whole period of their matching return version. To ensure our test data is
+  // realistic, we alter the start date of the return version to match the first return log we're seeding.
+  returnVersion.returnVersions[0].startDate = period.startDate
 
   const returnRequirement = returnRequirementData(returnVersion, licence)
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5722

In the real service, return logs will cover the same period as the return version. So, to make the data we seed 'real', we want to set the return version start date to match the start date used for the first return log.

It is worth noting that it is common for return-version periods not to cover the full history of a licence. This is why we do not align the licence start date as well.
