### PR TITLE
Add missing current return logs to scenarios

### DIFF
--- a/tests/internal/notices/ad-hoc/returns-invitation-alternate.spec.js
+++ b/tests/internal/notices/ad-hoc/returns-invitation-alternate.spec.js
@@ -4,9 +4,17 @@ import { test, expect } from '../../../support/fixtures.js'
 import { reloadUntilTextFound } from '../../../support/helpers/wait.helpers.js'
 
 test.describe('Ad-hoc returns invitation alternate journey (internal)', () => {
+  let returnLog
+
   test.beforeAll(async ({ setup, calculatedDates }) => {
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
+
+    const {
+      returnLogs: [scenarioReturnLog]
+    } = scenario
+
+    returnLog = scenarioReturnLog
 
     await setup(scenario)
   })
@@ -22,6 +30,7 @@ test.describe('Ad-hoc returns invitation alternate journey (internal)', () => {
     test.setTimeout(180000)
 
     const expectedDueDate = formatLongDate(relativeToToday(29))
+    const updatedReturnLogDates = `${formatLongDate(returnLog.startDate)} to ${formatLongDate(returnLog.endDate)}`
 
     // Navigate to the Notices page
     await page.goto('/system/notices')
@@ -101,8 +110,12 @@ test.describe('Ad-hoc returns invitation alternate journey (internal)', () => {
     await page.locator('#search-button').click()
     await page.locator('.searchresult-link', { hasText: 'AT/TE/ST/01/01' }).click()
     await page.locator(':nth-child(4) > .x-govuk-sub-navigation__link').click()
-    await expect(page.locator('[data-test="return-reference-0"] > .govuk-link')).toContainText('9999990')
 
-    await expect(page.locator('[data-test="return-due-date-0"]')).toContainText(expectedDueDate)
+    // Depending on whether the first period is quarterly or annual, and if quarterly, which quarter it is, the return
+    // log that was included in the notice and had a due date applied will be in a different position in the list. So we
+    // search for it by its start and end dates.
+    const row = page.getByRole('row').filter({ hasText: updatedReturnLogDates })
+
+    await expect(row.getByRole('cell').nth(2)).toContainText(expectedDueDate)
   })
 })

--- a/tests/internal/return-logs/record-receipt.spec.js
+++ b/tests/internal/return-logs/record-receipt.spec.js
@@ -48,6 +48,6 @@ test.describe('Record receipt for return (internal)', () => {
     await page.locator('#viewReturns', { hasText: `View returns for ${returnLog.licenceRef}` }).click()
 
     // confirm we see the received return
-    await expect(page.locator('[data-test="return-status-0"] > .govuk-tag')).toContainText('received')
+    await expect(page.locator('[data-test="return-status-1"] > .govuk-tag')).toContainText('received')
   })
 })

--- a/tests/support/data/return-log.data.js
+++ b/tests/support/data/return-log.data.js
@@ -1,4 +1,4 @@
-import { formatDateToIso } from '../helpers/date.helpers.js'
+import { determineReturnCycleStartDate, formatDateToIso } from '../helpers/date.helpers.js'
 import { generateUUID } from '../helpers/generate-uuid.js'
 
 export default function (licenceData, returnRequirementData, period) {
@@ -20,6 +20,8 @@ export default function (licenceData, returnRequirementData, period) {
   const startDateString = formatDateToIso(startDate)
   const endDateString = formatDateToIso(endDate)
   const dueDateString = period.dueDate ? formatDateToIso(new Date(period.dueDate)) : null
+
+  const returnCycleStartDate = determineReturnCycleStartDate(startDate, returnRequirement.summer)
 
   return {
     returnLogs: [
@@ -67,7 +69,7 @@ export default function (licenceData, returnRequirementData, period) {
           schema: 'returns',
           table: 'returnCycles',
           lookup: 'startDate',
-          value: `${startDate.getFullYear()}-04-01`,
+          value: formatDateToIso(returnCycleStartDate),
           select: 'returnCycleId'
         },
         returnRequirementId: returnRequirement.id,

--- a/tests/support/helpers/date.helpers.js
+++ b/tests/support/helpers/date.helpers.js
@@ -18,6 +18,48 @@ export function compareDates(dateA, dateB) {
 }
 
 /**
+ * Returns the start date of the return cycle for a given return log start date.
+ *
+ * Summer cycle is November to October. But if the start date is between January and October, the cycle year is the
+ * previous year. For example, a return log with a start date of 2024-03-01 would have a return cycle start date of
+ * 2023-11-01. A return log with a start date of 2024-11-01 would have a return cycle start date of 2024-11-01.
+ *
+ * Winter cycle is April to March. But if the start date is between January and March, the cycle year is the previous
+ * year. For example, a return log with a start date of 2024-02-01 would have a return cycle start date of 2023-04-01. A
+ * return log with a start date of 2024-04-01 would have a return cycle start date of 2024-04-01.
+ *
+ * @param {string|Date} returnLogStartDate - The start date of the return log
+ * @param {boolean} summer - Whether the return cycle is a summer cycle
+ *
+ * @returns {Date} The start date of the return cycle
+ */
+export function determineReturnCycleStartDate(returnLogStartDate, summer) {
+  // Just in case the date is passed directly from calculate dates response
+  const startDate = new Date(returnLogStartDate)
+  const startDateMonth = startDate.getUTCMonth()
+  const startDateYear = startDate.getUTCFullYear()
+
+  let cycleYear = startDateYear
+  let cycleMonth
+
+  if (summer) {
+    cycleMonth = '11'
+
+    if (startDateMonth < 11) {
+      cycleYear = startDateYear - 1
+    }
+  } else {
+    cycleMonth = '04'
+
+    if (startDateMonth < 3) {
+      cycleYear = startDateYear - 1
+    }
+  }
+
+  return new Date(`${cycleYear}-${cycleMonth}-01`)
+}
+
+/**
  * Formats a date to ISO 8601 date format (YYYY-MM-DD)
  *
  * @param {Date} date - The date to format

--- a/tests/support/scenarios/unregistered-licence-with-all-return-log-statuses.scenario.js
+++ b/tests/support/scenarios/unregistered-licence-with-all-return-log-statuses.scenario.js
@@ -180,7 +180,6 @@ function _returnLog(licence, returnVersion, period) {
   const returnLog = returnLogData(licence, returnRequirement, period)
 
   returnLog.returnLogs[0].status = period.status
-  returnLog.returnLogs[0].returnCycleId.value = period.startDate
 
   return mergeByKey(returnRequirement, returnLog)
 }

--- a/tests/support/scenarios/unregistered-licence-with-open-return-log-for-first-period.scenario.js
+++ b/tests/support/scenarios/unregistered-licence-with-open-return-log-for-first-period.scenario.js
@@ -2,6 +2,7 @@ import returnLogData from '../data/return-log.data.js'
 import returnRequirementData from '../data/return-requirement.data.js'
 import returnVersionData from '../data/return-version.data.js'
 import unregisteredLicenceScenario from './unregistered-licence.scenario.js'
+import { compareDates } from '../helpers/date.helpers.js'
 import { mergeByKey } from '../helpers/scenario.helpers.js'
 
 export const title = 'Unregistered licence with open return log (first period)'
@@ -11,9 +12,9 @@ export const description =
 export default function (calculatedDates) {
   const { firstReturnPeriod } = calculatedDates
 
-  const period0 = {
-    startDate: firstReturnPeriod.startDate,
-    endDate: firstReturnPeriod.endDate,
+  const firstPeriod = {
+    startDate: new Date(firstReturnPeriod.startDate),
+    endDate: new Date(firstReturnPeriod.endDate),
     dueDate: null,
     quarterly: firstReturnPeriod.quarterly
   }
@@ -23,17 +24,75 @@ export default function (calculatedDates) {
   // We want the return logs for the licence to match with the first quarter shown in the journey. This is dynamically
   // calculated based on the current date, so could be a quarterly period, or the winter or summer cycle.
   // Only licences flagged as water undertakers are eligible for quarterly returns, so we ensure the licence aligns.
-  unregisteredLicence.licences[0].waterUndertaker = firstReturnPeriod.quarterly
+  unregisteredLicence.licences[0].waterUndertaker = firstPeriod.quarterly
 
   const returnVersion = returnVersionData(unregisteredLicence)
 
   // In the service return logs will cover the whole period of their matching return version. To ensure our test data is
   // realistic, we alter the start date of the return version to match the first return log we're seeding.
-  returnVersion.returnVersions[0].startDate = period0.startDate
+  returnVersion.returnVersions[0].startDate = firstPeriod.startDate
 
   const returnRequirement = returnRequirementData(returnVersion, unregisteredLicence)
 
-  const returnLog = returnLogData(unregisteredLicence, returnRequirement, period0)
+  const periods = _periods(firstPeriod, calculatedDates)
+  const returnLogs = _returnLogs(unregisteredLicence, returnRequirement, periods)
 
-  return mergeByKey(unregisteredLicence, returnVersion, returnRequirement, returnLog)
+  const result = mergeByKey(unregisteredLicence, returnVersion, returnRequirement, returnLogs)
+
+  return result
+}
+
+/**
+ * Determines which quarterly periods (if any) need covering with return logs
+ *
+ * If the first period is not a quarterly period, then we will be generating an annual (winter or summer) return log
+ * that covers the entire cycle.
+ *
+ * If it's quarterly though, it will only cover a 3 month period of the cycle. That's fine if its the last one (Jan to
+ * Mar), but if its an earlier one, we need to generate return logs for the remaining quarterly periods in the cycle.
+ *
+ * This function determines which periods we need to generate return logs for, and returns them in an array.
+ *
+ * @private
+ */
+function _periods(firstPeriod, calculatedDates) {
+  const periods = [firstPeriod]
+
+  if (!firstPeriod.quarterly) {
+    return periods
+  }
+
+  for (const quarterlyPeriod of calculatedDates.quarterlyPeriods) {
+    if (compareDates(new Date(quarterlyPeriod.startDate), firstPeriod.startDate) === 1) {
+      periods.push({
+        startDate: new Date(quarterlyPeriod.startDate),
+        endDate: new Date(quarterlyPeriod.endDate),
+        dueDate: null,
+        quarterly: true
+      })
+    }
+  }
+
+  return periods
+}
+
+/**
+ * Generate the return logs for the determined periods
+ *
+ * The complexity is we need an object with a property `returnLogs:` for `mergeKeys()` to work. But that's how
+ * `returnLogData()` returns its data!
+ *
+ * So we need to pluck each new return log out of it, and add it to our own array of return logs, before returning it
+ * in a new object!
+ *
+ * @private
+ */
+function _returnLogs(unregisteredLicence, returnRequirement, periods) {
+  const returnLogs = []
+
+  for (const period of periods) {
+    returnLogs.push(returnLogData(unregisteredLicence, returnRequirement, period).returnLogs[0])
+  }
+
+  return { returnLogs }
 }

--- a/tests/support/scenarios/unregistered-licence-with-open-winter-return-log.scenario.js
+++ b/tests/support/scenarios/unregistered-licence-with-open-winter-return-log.scenario.js
@@ -12,12 +12,19 @@ export const description =
 export default function (calculatedDates) {
   const { currentWinterReturnCycle } = calculatedDates
 
-  const period = previousPeriod({
+  const previousPeriodDetails = previousPeriod({
     startDate: currentWinterReturnCycle.startDate,
     endDate: currentWinterReturnCycle.endDate,
     dueDate: null,
     quarterly: false
   })
+
+  const currentPeriodDetails = {
+    startDate: new Date(currentWinterReturnCycle.startDate),
+    endDate: new Date(currentWinterReturnCycle.endDate),
+    dueDate: null,
+    quarterly: false
+  }
 
   const licence = unregisteredLicenceScenario()
 
@@ -25,11 +32,12 @@ export default function (calculatedDates) {
 
   // In the service return logs will cover the whole period of their matching return version. To ensure our test data is
   // realistic, we alter the start date of the return version to match the first return log we're seeding.
-  returnVersion.returnVersions[0].startDate = period.startDate
+  returnVersion.returnVersions[0].startDate = previousPeriodDetails.startDate
 
   const returnRequirement = returnRequirementData(returnVersion, licence)
 
-  const returnLog = returnLogData(licence, returnRequirement, period)
+  const previousReturnLog = returnLogData(licence, returnRequirement, previousPeriodDetails)
+  const currentReturnLog = returnLogData(licence, returnRequirement, currentPeriodDetails)
 
-  return mergeByKey(licence, returnVersion, returnRequirement, returnLog)
+  return mergeByKey(licence, returnVersion, returnRequirement, previousReturnLog, currentReturnLog)
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5722

In our previous change, [Align ret. vers. start date with first return log](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/299), we ensured that the return version start date aligned with the start date of the first seeded return log (in applicable scenarios).

The reasoning is that in the service, we would expect return logs to exist for the whole period a return version covers, up to and including the current return cycle. However, in our 'open' and 'due' winter return log scenarios, we've taken pains to create a return log for the previous period, but not the current one. Doh!

Sticking with our principle of 'real' data, this change updates the relevant scenarios to ensure they seed return logs for the full period covered by their associated return version.