### PR TITLE
Add test for a user needing both int & ext access 

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
     "prettier": "3.3.3"
   },
   "allowScripts": {
-    "cypress@15.18.0": true,
     "fsevents@2.3.2": true,
-    "unrs-resolver@1.12.2": true
+    "unrs-resolver@1.12.2": true,
+    "cypress@15.18.1": true
   }
 }

--- a/tests/internal/user/create-user-with-external-account.spec.js
+++ b/tests/internal/user/create-user-with-external-account.spec.js
@@ -20,23 +20,30 @@ test.describe('Creating internal user with existing external account (internal)'
     await login(users.super)
   })
 
-  test('can create an internal user even if they have an external user account with the same email', async ({
-    page
-  }) => {
-    await page.goto('/account/create-user')
+  test(
+    'can create an internal user even if they have an external user account with the same email',
+    {
+      annotation: {
+        type: 'issue',
+        description: 'https://eaflood.atlassian.net/browse/WATER-5739'
+      }
+    },
+    async ({ page }) => {
+      await page.goto('/account/create-user')
 
-    // Enter the same username as the existing external user with a 'gov.uk' address
-    await expect(page.locator('.govuk-label')).toContainText('Enter a gov.uk email address')
-    await page.locator('input#email').fill(user.username)
-    await page.locator('form > .govuk-button').click()
+      // Enter the same username as the existing external user with a 'gov.uk' address
+      await expect(page.locator('.govuk-label')).toContainText('Enter a gov.uk email address')
+      await page.locator('input#email').fill(user.username)
+      await page.locator('form > .govuk-button').click()
 
-    // Confirm we see 8 permission types. Then pick one for our user
-    await expect(page.locator('div.govuk-radios').locator('> *')).toHaveCount(8)
-    await page.locator('[type="radio"][value="basic"]').check()
-    await page.locator('form > .govuk-button').click()
+      // Confirm we see 8 permission types. Then pick one for our user
+      await expect(page.locator('div.govuk-radios').locator('> *')).toHaveCount(8)
+      await page.locator('[type="radio"][value="basic"]').check()
+      await page.locator('form > .govuk-button').click()
 
-    // Confirm we see confirmation of the new account created
-    await expect(page.locator('h1.govuk-heading-l')).toContainText('New account created')
-    await expect(page.locator("span[class='govuk-!-font-weight-bold']")).toContainText(user.username)
-  })
+      // Confirm we see confirmation of the new account created
+      await expect(page.locator('h1.govuk-heading-l')).toContainText('New account created')
+      await expect(page.locator("span[class='govuk-!-font-weight-bold']")).toContainText(user.username)
+    }
+  )
 })

--- a/tests/internal/user/create-user-with-external-account.spec.js
+++ b/tests/internal/user/create-user-with-external-account.spec.js
@@ -1,0 +1,42 @@
+import scenarioData from '../../support/scenarios/external-gov-uk-user.scenario.js'
+import { test, expect } from '../../support/fixtures.js'
+
+test.describe('Creating internal user with existing external account (internal)', () => {
+  let user
+
+  test.beforeAll(async ({ setup }) => {
+    const scenario = scenarioData()
+
+    const {
+      users: [scenarioUser]
+    } = scenario
+
+    user = scenarioUser
+
+    await setup(scenario)
+  })
+
+  test.beforeEach(async ({ login, users }) => {
+    await login(users.super)
+  })
+
+  test('can create an internal user even if they have an external user account with the same email', async ({
+    page
+  }) => {
+    await page.goto('/account/create-user')
+
+    // Enter the same username as the existing external user with a 'gov.uk' address
+    await expect(page.locator('.govuk-label')).toContainText('Enter a gov.uk email address')
+    await page.locator('input#email').fill(user.username)
+    await page.locator('form > .govuk-button').click()
+
+    // Confirm we see 8 permission types. Then pick one for our user
+    await expect(page.locator('div.govuk-radios').locator('> *')).toHaveCount(8)
+    await page.locator('[type="radio"][value="basic"]').check()
+    await page.locator('form > .govuk-button').click()
+
+    // Confirm we see confirmation of the new account created
+    await expect(page.locator('h1.govuk-heading-l')).toContainText('New account created')
+    await expect(page.locator("span[class='govuk-!-font-weight-bold']")).toContainText(user.username)
+  })
+})

--- a/tests/support/helpers/date.helpers.js
+++ b/tests/support/helpers/date.helpers.js
@@ -275,3 +275,29 @@ export function today() {
 
   return todaysDate
 }
+
+/**
+ * Returns a date object representing tomorrow's date
+ *
+ * @returns {Date} tomorrow's date
+ */
+export function tomorrow() {
+  const tomorrow = today()
+
+  tomorrow.setDate(tomorrow.getDate() + 1)
+
+  return tomorrow
+}
+
+/**
+ * Returns a date object representing yesterday's date
+ *
+ * @returns {Date} yesterday's date
+ */
+export function yesterday() {
+  const yesterday = today()
+
+  yesterday.setDate(yesterday.getDate() - 1)
+
+  return yesterday
+}

--- a/tests/support/scenarios/external-gov-uk-user.scenario.js
+++ b/tests/support/scenarios/external-gov-uk-user.scenario.js
@@ -7,7 +7,7 @@ export const description = 'A single external user with a gov.uk address and no 
 export default function () {
   const externalUser = externalUserData()
 
-  externalUser.users[0].username = 'both.sides@wrls.gov.uk'
+  externalUser.users[0].username = `regression.tests.${Date.now()}@defra.gov.uk`
   externalUser.users[0].lastLogin = yesterday()
 
   return {

--- a/tests/support/scenarios/external-gov-uk-user.scenario.js
+++ b/tests/support/scenarios/external-gov-uk-user.scenario.js
@@ -1,0 +1,16 @@
+import externalUserData from '../data/external-user.data.js'
+import { yesterday } from '../helpers/date.helpers.js'
+
+export const title = 'External gov.uk user only'
+export const description = 'A single external user with a gov.uk address and no associated licence or return data'
+
+export default function () {
+  const externalUser = externalUserData()
+
+  externalUser.users[0].username = 'both.sides@wrls.gov.uk'
+  externalUser.users[0].lastLogin = yesterday()
+
+  return {
+    ...externalUser
+  }
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5739

We recently [migrated the internal create user functionality from the legacy service](https://eaflood.atlassian.net/browse/WATER-5515).

Part of the 'create user' journey is checking whether the email address is already used by another user.

But there is a complication. WRLS has both internal and external users, and they all live in the same table. They are differentiated by the `application` field. And there are Environment Agency users who have to submit returns on behalf of the EA because the EA holds abstraction licences!

So, the legacy service allowed you to create an internal user, even if the email address matched an external account. We've overlooked that in our validation, so we're blocking the creation of internal users if the email address is already used by an external user.

We've [fixed it](https://github.com/DEFRA/water-abstraction-system/pull/3551) but want a test that highlights this behaviour and ensures we have some coverage.

<details>
<summary>Annotations in Playwright</summary>

<img width="862" height="446" alt="Screenshot 2026-07-20 at 17 35 28" src="https://github.com/user-attachments/assets/82412d9d-29a7-4b83-9c16-b1708fb31520" />

<img width="749" height="977" alt="Screenshot 2026-07-20 at 17 35 46" src="https://github.com/user-attachments/assets/94b91b03-fd29-4e6d-a2f1-f8e6fe99299c" />

</details>