### PR TITLE
Separate Charge Element from Charge Reference

### DIFF
--- a/tests/support/data/charge-element.data.js
+++ b/tests/support/data/charge-element.data.js
@@ -1,0 +1,56 @@
+import { convertCubicMetresToMegalitres } from '../helpers/conversion.helpers.js'
+import { generateUUID } from '../helpers/generate-uuid.js'
+
+export default function (chargeReferenceData, licenceData, noOfElements = 1) {
+  const {
+    chargeReferences: [chargeReference]
+  } = chargeReferenceData
+
+  const {
+    licenceVersionPurposes: [licenceVersionPurpose]
+  } = licenceData
+
+  // We make an assumption that if the purpose is not 400 (the default), then we have been passed our alternate which
+  // is typically 280 (Make-Up Or Top Up Water). Both have a high loss, and assuming non-tidal and the same volume, both
+  // would fall under charge category 4.6.1. Obviously, the calling scenario is free to override any of these values.
+  const twoPartTariff = licenceVersionPurpose.purposeId.value === '400'
+  const description = twoPartTariff ? 'Spray Irrigation - Direct' : 'Make-Up Or Top Up Water'
+
+  return {
+    chargeElements: [
+      {
+        id: generateUUID(),
+        chargeReferenceId: chargeReference.id,
+        abstractionPeriodStartDay: licenceVersionPurpose.abstractionPeriodStartDay,
+        abstractionPeriodStartMonth: licenceVersionPurpose.abstractionPeriodStartMonth,
+        abstractionPeriodEndDay: licenceVersionPurpose.abstractionPeriodEndDay,
+        abstractionPeriodEndMonth: licenceVersionPurpose.abstractionPeriodEndMonth,
+        authorisedAnnualQuantity: convertCubicMetresToMegalitres(licenceVersionPurpose.annualQuantity / noOfElements),
+        loss: 'high',
+        section127Agreement: twoPartTariff,
+        description,
+        purposeId: {
+          schema: 'public',
+          table: 'purposes',
+          lookup: 'legacyId',
+          value: licenceVersionPurpose.purposeId.value,
+          select: 'id'
+        },
+        purposePrimaryId: {
+          schema: 'water',
+          table: 'purposesPrimary',
+          lookup: 'legacyId',
+          value: 'A',
+          select: 'purposePrimaryId'
+        },
+        purposeSecondaryId: {
+          schema: 'water',
+          table: 'purposesSecondary',
+          lookup: 'legacyId',
+          value: 'AGR',
+          select: 'purposeSecondaryId'
+        }
+      }
+    ]
+  }
+}

--- a/tests/support/data/charge-element.data.js
+++ b/tests/support/data/charge-element.data.js
@@ -1,14 +1,10 @@
 import { convertCubicMetresToMegalitres } from '../helpers/conversion.helpers.js'
 import { generateUUID } from '../helpers/generate-uuid.js'
 
-export default function (chargeReferenceData, licenceData, noOfElements = 1) {
+export default function (chargeReferenceData, licenceVersionPurpose) {
   const {
     chargeReferences: [chargeReference]
   } = chargeReferenceData
-
-  const {
-    licenceVersionPurposes: [licenceVersionPurpose]
-  } = licenceData
 
   // We make an assumption that if the purpose is not 400 (the default), then we have been passed our alternate which
   // is typically 280 (Make-Up Or Top Up Water). Both have a high loss, and assuming non-tidal and the same volume, both
@@ -25,7 +21,7 @@ export default function (chargeReferenceData, licenceData, noOfElements = 1) {
         abstractionPeriodStartMonth: licenceVersionPurpose.abstractionPeriodStartMonth,
         abstractionPeriodEndDay: licenceVersionPurpose.abstractionPeriodEndDay,
         abstractionPeriodEndMonth: licenceVersionPurpose.abstractionPeriodEndMonth,
-        authorisedAnnualQuantity: convertCubicMetresToMegalitres(licenceVersionPurpose.annualQuantity / noOfElements),
+        authorisedAnnualQuantity: convertCubicMetresToMegalitres(licenceVersionPurpose.annualQuantity),
         loss: 'high',
         section127Agreement: twoPartTariff,
         description,

--- a/tests/support/data/charge-reference.data.js
+++ b/tests/support/data/charge-reference.data.js
@@ -2,9 +2,6 @@ import { convertCubicMetresToMegalitres } from '../helpers/conversion.helpers.js
 import { generateUUID } from '../helpers/generate-uuid.js'
 
 export default function (chargeVersionData, licenceData) {
-  const chargeElementId = generateUUID()
-  const chargeReferenceId = generateUUID()
-
   const {
     chargeVersions: [chargeVersion]
   } = chargeVersionData
@@ -22,7 +19,7 @@ export default function (chargeVersionData, licenceData) {
   return {
     chargeReferences: [
       {
-        id: chargeReferenceId,
+        id: generateUUID(),
         chargeVersionId: chargeVersion.id,
         description: `Test charge reference 1 - ${description}`,
         source: 'non-tidal',
@@ -49,41 +46,6 @@ export default function (chargeVersionData, licenceData) {
         volume: convertCubicMetresToMegalitres(licenceVersionPurpose.annualQuantity),
         eiucRegion: 'Southern',
         section127Agreement: twoPartTariff
-      }
-    ],
-    chargeElements: [
-      {
-        id: chargeElementId,
-        chargeReferenceId,
-        abstractionPeriodStartDay: licenceVersionPurpose.abstractionPeriodStartDay,
-        abstractionPeriodStartMonth: licenceVersionPurpose.abstractionPeriodStartMonth,
-        abstractionPeriodEndDay: licenceVersionPurpose.abstractionPeriodEndDay,
-        abstractionPeriodEndMonth: licenceVersionPurpose.abstractionPeriodEndMonth,
-        authorisedAnnualQuantity: convertCubicMetresToMegalitres(licenceVersionPurpose.annualQuantity),
-        loss: 'high',
-        section127Agreement: twoPartTariff,
-        description,
-        purposeId: {
-          schema: 'public',
-          table: 'purposes',
-          lookup: 'legacyId',
-          value: licenceVersionPurpose.purposeId.value,
-          select: 'id'
-        },
-        purposePrimaryId: {
-          schema: 'water',
-          table: 'purposesPrimary',
-          lookup: 'legacyId',
-          value: 'A',
-          select: 'purposePrimaryId'
-        },
-        purposeSecondaryId: {
-          schema: 'water',
-          table: 'purposesSecondary',
-          lookup: 'legacyId',
-          value: 'AGR',
-          select: 'purposeSecondaryId'
-        }
       }
     ]
   }

--- a/tests/support/data/charge-reference.data.js
+++ b/tests/support/data/charge-reference.data.js
@@ -1,14 +1,10 @@
 import { convertCubicMetresToMegalitres } from '../helpers/conversion.helpers.js'
 import { generateUUID } from '../helpers/generate-uuid.js'
 
-export default function (chargeVersionData, licenceData) {
+export default function (chargeVersionData, licenceVersionPurpose) {
   const {
     chargeVersions: [chargeVersion]
   } = chargeVersionData
-
-  const {
-    licenceVersionPurposes: [licenceVersionPurpose]
-  } = licenceData
 
   // We make an assumption that if the purpose is not 400 (the default), then we have been passed our alternate which
   // is typically 280 (Make-Up Or Top Up Water). Both have a high loss, and assuming non-tidal and the same volume, both

--- a/tests/support/scenarios/licence-with-charge-version.scenario.js
+++ b/tests/support/scenarios/licence-with-charge-version.scenario.js
@@ -1,6 +1,7 @@
 import billingAccountData from '../data/billing-account.data.js'
-import chargeVersionData from '../data/charge-version.data.js'
+import chargeElementData from '../data/charge-element.data.js'
 import chargeReferenceData from '../data/charge-reference.data.js'
+import chargeVersionData from '../data/charge-version.data.js'
 import licenceScenario from './licence.scenario.js'
 import { mergeByKey } from '../helpers/scenario.helpers.js'
 
@@ -13,6 +14,7 @@ export default function () {
   const billingAccount = billingAccountData(licence)
   const chargeVersion = chargeVersionData(billingAccount, licence)
   const chargeReference = chargeReferenceData(chargeVersion, licence)
+  const chargeElement = chargeElementData(chargeReference, licence)
 
-  return mergeByKey(licence, billingAccount, chargeVersion, chargeReference)
+  return mergeByKey(licence, billingAccount, chargeVersion, chargeReference, chargeElement)
 }

--- a/tests/support/scenarios/licence-with-charge-version.scenario.js
+++ b/tests/support/scenarios/licence-with-charge-version.scenario.js
@@ -13,8 +13,13 @@ export default function () {
 
   const billingAccount = billingAccountData(licence)
   const chargeVersion = chargeVersionData(billingAccount, licence)
-  const chargeReference = chargeReferenceData(chargeVersion, licence)
-  const chargeElement = chargeElementData(chargeReference, licence)
+
+  const {
+    licenceVersionPurposes: [licenceVersionPurpose]
+  } = licence
+
+  const chargeReference = chargeReferenceData(chargeVersion, licenceVersionPurpose)
+  const chargeElement = chargeElementData(chargeReference, licenceVersionPurpose)
 
   return mergeByKey(licence, billingAccount, chargeVersion, chargeReference, chargeElement)
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5579

Whilst working on migrating the Two-part tariff scenarios to Playwright. It has become apparent that the Charge Element data needs to be separated from the Charge Reference data.

This will enable us to easily add multiple Charge Elements to a single Charge Reference.