### PR TITLE
Add pre-SRoC supplementary billing flag test for new licence agreements

### DIFF
--- a/cypress/support/scenarios/licence-with-presroc-chg-ver.js
+++ b/cypress/support/scenarios/licence-with-presroc-chg-ver.js
@@ -1,6 +1,6 @@
 import licenceData from '../fixture-builder/licence.js'
 
-export const title = 'Licence with a pre-SRoC charge version'
+export const title = 'Licence with a pre-SRoC charge version (cypress)'
 export const description = 'Licence with an ALCS (pre-SRoC) charge version and a sent two-part tariff bill run'
 
 export default function () {

--- a/tests/internal/licence-agreements/new-licence-agreement-with-charge-version.spec.js
+++ b/tests/internal/licence-agreements/new-licence-agreement-with-charge-version.spec.js
@@ -1,0 +1,99 @@
+import scenarioData from '../../support/scenarios/licence-with-pre-sroc-charge-version.scenario.js'
+import { formatLongDate } from '../../support/helpers/date.helpers.js'
+import { test, expect } from '../../support/fixtures.js'
+
+test.describe('New licence agreement with charge version journey (internal)', () => {
+  let licence
+  let chargeVersionStartDate
+
+  test.beforeAll(async ({ setup }) => {
+    const scenario = scenarioData()
+
+    const {
+      licences: [scenarioLicence],
+      chargeVersions: [scenarioChargeVersion]
+    } = scenario
+
+    licence = scenarioLicence
+
+    // With existing charge information, the app accepts a custom start date that matches it, so we use the charge
+    // version's start date for the agreement's custom start date. It also pre-dates the SROC scheme, so setting up
+    // the agreement against it flags the licence for the next old charge scheme supplementary bill run.
+    chargeVersionStartDate = scenarioChargeVersion.startDate
+
+    await setup(scenario)
+  })
+
+  test.beforeEach(async ({ login, users }) => {
+    await login(users.billingAndData)
+  })
+
+  test('setup a new agreement for a license, view it, and confirm it flags the licence for supplementary billing', async ({
+    page
+  }) => {
+    await page.goto(`/system/licences/${licence.id}/summary`)
+
+    // Check there are no notification banners present initially
+    await expect(page.locator('.govuk-notification-banner__content')).toHaveCount(0)
+
+    // Navigate to the Licence set up page
+    await page.locator('nav a', { hasText: 'Licence set up' }).click()
+    await expect(page.locator('h1')).toContainText('Licence set up')
+
+    // Confirm we are on the tab page and then click Set up a new agreement
+    await expect(page.getByText('Charge information', { exact: true })).toBeVisible()
+    await page.getByText('Set up a new agreement').click()
+
+    // Select agreement
+    // select Two-part tariff then continue
+    // NOTE: the "Two-part tariff" radio has no accessible name in the rendered markup (its <label> shares an id
+    // with two other elements, breaking the label association), so it can't be targeted by role/name. Target it by
+    // its value instead, which is the S127 financial agreement code used to seed this scenario.
+    await page.locator('input[value="S127"]').check()
+    await page.locator('form > .govuk-button').click()
+
+    // Do you know the date the agreement was signed?
+    // select No and continue
+    await page.locator('#isDateSignedKnown-2').check()
+    await page.locator('form > .govuk-button').click()
+
+    // Check agreement start date
+    // select Yes to set a different agreement start date. A section appears allowing the user to enter the custom
+    // date, matching the licence's existing charge version, then continue
+    const [year, month, day] = chargeVersionStartDate.split('-')
+
+    await page.locator('input#isCustomStartDate').check()
+    await page.locator('#startDate-day').fill(day)
+    await page.locator('#startDate-month').fill(month)
+    await page.locator('#startDate-year').fill(year)
+    await page.locator('form > .govuk-button').click()
+
+    // Check agreement details
+    // confirm the details match what was entered and continue
+    await expect(page.locator('.govuk-heading-l', { hasText: 'Check agreement details' })).toBeVisible()
+    await expect(page.locator('.govuk-summary-list__value', { hasText: 'Two-part tariff' })).toBeVisible()
+    await page.locator('form > .govuk-button').click()
+
+    // Charge information
+    // confirm we are back on the Charge Information page and our licence agreement is present
+    await expect(page.locator('h1')).toContainText('Licence set up')
+
+    const row = page.getByRole('row').filter({ hasText: 'Two-part tariff' })
+
+    // start date, agreement
+    await expect(row.getByRole('cell', { name: formatLongDate(chargeVersionStartDate), exact: true })).toBeVisible()
+    await expect(row.getByRole('cell', { name: 'Two-part tariff', exact: true })).toBeVisible()
+
+    // actions
+    await expect(page.locator('[data-test="delete-agreement-0"]')).toBeVisible()
+    await expect(page.locator('[data-test="end-agreement-0"]')).toBeVisible()
+
+    // Navigate to back to the Licence summary page
+    await page.locator('nav a', { hasText: 'Licence summary' }).click()
+
+    // Check the new licence agreement has flagged the licence for supplementary billing
+    await expect(page.locator('.govuk-notification-banner__content')).toContainText(
+      'This licence has been marked for the next supplementary bill run for the old charge scheme.'
+    )
+  })
+})

--- a/tests/support/data/charge-reference-presroc.data.js
+++ b/tests/support/data/charge-reference-presroc.data.js
@@ -1,0 +1,63 @@
+import { convertCubicMetresToMegalitres } from '../helpers/conversion.helpers.js'
+import { generateUUID } from '../helpers/generate-uuid.js'
+
+export default function (chargeVersionData, licenceData) {
+  const chargeReferenceId = generateUUID()
+
+  const {
+    chargeVersions: [chargeVersion]
+  } = chargeVersionData
+
+  const {
+    licenceVersionPurposes: [licenceVersionPurpose]
+  } = licenceData
+
+  // We make an assumption that if the purpose is not 400 (the default), then we have been passed our alternate which
+  // is typically 280 (Make-Up Or Top Up Water). Both have a high loss, and assuming non-tidal and the same volume, both
+  // would fall under charge category 4.6.1. Obviously, the calling scenario is free to override any of these values.
+  const twoPartTariff = licenceVersionPurpose.purposeId.value === '400'
+  const description = twoPartTariff ? 'Spray Irrigation - Direct' : 'Make-Up Or Top Up Water'
+
+  return {
+    chargeReferences: [
+      {
+        id: chargeReferenceId,
+        chargeVersionId: chargeVersion.id,
+        abstractionPeriodStartDay: licenceVersionPurpose.abstractionPeriodStartDay,
+        abstractionPeriodStartMonth: licenceVersionPurpose.abstractionPeriodStartMonth,
+        abstractionPeriodEndDay: licenceVersionPurpose.abstractionPeriodEndDay,
+        abstractionPeriodEndMonth: licenceVersionPurpose.abstractionPeriodEndMonth,
+        authorisedAnnualQuantity: convertCubicMetresToMegalitres(licenceVersionPurpose.annualQuantity),
+        season: 'all year',
+        seasonDerived: 'all year',
+        description: `Test PRESROC charge element 1 - ${description}`,
+        source: 'unsupported',
+        loss: 'high',
+        purposeId: {
+          schema: 'public',
+          table: 'purposes',
+          lookup: 'legacyId',
+          value: licenceVersionPurpose.purposeId.value,
+          select: 'id'
+        },
+        purposePrimaryId: {
+          schema: 'water',
+          table: 'purposesPrimary',
+          lookup: 'legacyId',
+          value: 'A',
+          select: 'purposePrimaryId'
+        },
+        purposeSecondaryId: {
+          schema: 'water',
+          table: 'purposesSecondary',
+          lookup: 'legacyId',
+          value: 'AGR',
+          select: 'purposeSecondaryId'
+        },
+        section127Agreement: twoPartTariff,
+        scheme: 'alcs',
+        restrictedSource: false
+      }
+    ]
+  }
+}

--- a/tests/support/scenarios/licence-with-pre-sroc-charge-version.scenario.js
+++ b/tests/support/scenarios/licence-with-pre-sroc-charge-version.scenario.js
@@ -1,0 +1,85 @@
+import billingAccountData from '../data/billing-account.data.js'
+import chargeVersionData from '../data/charge-version.data.js'
+import licenceScenario from './licence.scenario.js'
+import { generateUUID } from '../helpers/generate-uuid.js'
+import { mergeByKey } from '../helpers/scenario.helpers.js'
+
+export const title = 'Licence with a pre-SRoC charge version'
+export const description =
+  'Licence with one charge version and reference pre-dating the SRoC scheme, so it can be used to test old charge scheme behaviour'
+
+export default function () {
+  const licence = licenceScenario()
+
+  // charge-version.data.js derives the charge version's startDate from the licence's own startDate, so we move it
+  // before the start of SRoC to get a pre-SRoC charge version
+  licence.licences[0].startDate = '2018-04-01'
+
+  const billingAccount = billingAccountData(licence)
+  const chargeVersion = chargeVersionData(billingAccount, licence)
+  const chargeReference = _chargeReference(chargeVersion)
+
+  // charge-version.data.js hardcodes the scheme to sroc, so we override it to alcs to match the pre-SRoC start date
+  chargeVersion.chargeVersions[0].scheme = 'alcs'
+
+  return mergeByKey(licence, billingAccount, chargeVersion, chargeReference)
+}
+
+// charge-reference.data.js is SRoC-only (charge category, adjustments, and a separate charge element), whereas an
+// ALCS charge reference is a flatter, older shape with the abstraction period and purpose held directly on the
+// reference and no equivalent charge element, so we build it here rather than adapting the shared builder
+function _chargeReference(chargeVersionData) {
+  const chargeReferenceId = generateUUID()
+
+  const {
+    chargeVersions: [chargeVersion]
+  } = chargeVersionData
+
+  return {
+    chargeReferences: [
+      {
+        id: chargeReferenceId,
+        chargeVersionId: chargeVersion.id,
+        factorsOverridden: false,
+        abstractionPeriodStartDay: 1,
+        abstractionPeriodStartMonth: 4,
+        description: 'Test Charge Element!',
+        abstractionPeriodEndDay: 31,
+        abstractionPeriodEndMonth: 3,
+        authorisedAnnualQuantity: 15.54,
+        season: 'all year',
+        seasonDerived: 'all year',
+        source: 'unsupported',
+        loss: 'medium',
+        purposePrimaryId: {
+          schema: 'water',
+          table: 'purposesPrimary',
+          lookup: 'legacyId',
+          value: 'A',
+          select: 'purposePrimaryId'
+        },
+        purposeSecondaryId: {
+          schema: 'water',
+          table: 'purposesSecondary',
+          lookup: 'legacyId',
+          value: 'AGR',
+          select: 'purposeSecondaryId'
+        },
+        purposeId: {
+          schema: 'public',
+          table: 'purposes',
+          lookup: 'legacyId',
+          value: '140',
+          select: 'id'
+        },
+        chargeCategoryId: null,
+        additionalCharges: {},
+        scheme: 'alcs',
+        adjustments: null,
+        eiucRegion: null,
+        section127Agreement: null,
+        restrictedSource: false
+      }
+    ]
+  }
+}

--- a/tests/support/scenarios/licence-with-pre-sroc-charge-version.scenario.js
+++ b/tests/support/scenarios/licence-with-pre-sroc-charge-version.scenario.js
@@ -1,7 +1,7 @@
 import billingAccountData from '../data/billing-account.data.js'
 import chargeVersionData from '../data/charge-version.data.js'
+import chargeReferenceData from '../data/charge-reference-presroc.data.js'
 import licenceScenario from './licence.scenario.js'
-import { generateUUID } from '../helpers/generate-uuid.js'
 import { mergeByKey } from '../helpers/scenario.helpers.js'
 
 export const title = 'Licence with a pre-SRoC charge version'
@@ -12,74 +12,19 @@ export default function () {
   const licence = licenceScenario()
 
   // charge-version.data.js derives the charge version's startDate from the licence's own startDate, so we move it
-  // before the start of SRoC to get a pre-SRoC charge version
+  // before the start of SRoC to get a pre-SRoC charge version. We also align all the licence data to the new start date
   licence.licences[0].startDate = '2018-04-01'
+  licence.licenceVersions[0].startDate = '2018-04-01'
+  licence.licenceDocuments[0].startDate = '2018-04-01'
+  licence.licenceDocumentRoles[0].startDate = '2018-04-01'
 
   const billingAccount = billingAccountData(licence)
   const chargeVersion = chargeVersionData(billingAccount, licence)
-  const chargeReference = _chargeReference(chargeVersion)
 
   // charge-version.data.js hardcodes the scheme to sroc, so we override it to alcs to match the pre-SRoC start date
   chargeVersion.chargeVersions[0].scheme = 'alcs'
 
+  const chargeReference = chargeReferenceData(chargeVersion, licence)
+
   return mergeByKey(licence, billingAccount, chargeVersion, chargeReference)
-}
-
-// charge-reference.data.js is SRoC-only (charge category, adjustments, and a separate charge element), whereas an
-// ALCS charge reference is a flatter, older shape with the abstraction period and purpose held directly on the
-// reference and no equivalent charge element, so we build it here rather than adapting the shared builder
-function _chargeReference(chargeVersionData) {
-  const chargeReferenceId = generateUUID()
-
-  const {
-    chargeVersions: [chargeVersion]
-  } = chargeVersionData
-
-  return {
-    chargeReferences: [
-      {
-        id: chargeReferenceId,
-        chargeVersionId: chargeVersion.id,
-        factorsOverridden: false,
-        abstractionPeriodStartDay: 1,
-        abstractionPeriodStartMonth: 4,
-        description: 'Test Charge Element!',
-        abstractionPeriodEndDay: 31,
-        abstractionPeriodEndMonth: 3,
-        authorisedAnnualQuantity: 15.54,
-        season: 'all year',
-        seasonDerived: 'all year',
-        source: 'unsupported',
-        loss: 'medium',
-        purposePrimaryId: {
-          schema: 'water',
-          table: 'purposesPrimary',
-          lookup: 'legacyId',
-          value: 'A',
-          select: 'purposePrimaryId'
-        },
-        purposeSecondaryId: {
-          schema: 'water',
-          table: 'purposesSecondary',
-          lookup: 'legacyId',
-          value: 'AGR',
-          select: 'purposeSecondaryId'
-        },
-        purposeId: {
-          schema: 'public',
-          table: 'purposes',
-          lookup: 'legacyId',
-          value: '140',
-          select: 'id'
-        },
-        chargeCategoryId: null,
-        additionalCharges: {},
-        scheme: 'alcs',
-        adjustments: null,
-        eiucRegion: null,
-        section127Agreement: null,
-        restrictedSource: false
-      }
-    ]
-  }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5722

The Cypress to Playwright migration of new-licence-agreement.cy.js (#278) dropped its final check that a new agreement set up against a pre-SRoC charge version flags the licence for the next old charge scheme supplementary bill run.

Adds licence-with-pre-sroc-charge-version.scenario.js, which builds on the shared licence and billing account builders but overrides the licence's start date so charge-version.data.js produces a pre-SRoC charge version, and includes a private helper for the ALCS-shaped charge reference since it differs structurally from the SRoC one (charge category and adjustments vs a flatter shape with abstraction period and purpose held directly on the reference).

Adds new-licence-agreement-with-charge-version.spec.js, which sets up a two-part tariff agreement against that charge version and confirms the "marked for the next supplementary bill run for the old charge scheme" banner appears on the licence summary page.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>