### PR TITLE
Fix migrated licence agreement tests

### DIFF
--- a/tests/internal/licence-agreements/end-licence-agreement.spec.js
+++ b/tests/internal/licence-agreements/end-licence-agreement.spec.js
@@ -90,7 +90,8 @@ test.describe('End licence agreement journey (internal)', () => {
       formatLongDate(licence.startDate),
       formatLongDate(validEndDateYear + '-03-31'),
       'Two-part tariff',
-      ''
+      '',
+      'Delete'
     ])
     await expect(page.locator('[data-test="delete-agreement-0"]')).toBeVisible()
     await expect(page.locator('[data-test="end-agreement-0"]')).toHaveCount(0)

--- a/tests/internal/licence-agreements/new-licence-agreement.spec.js
+++ b/tests/internal/licence-agreements/new-licence-agreement.spec.js
@@ -80,7 +80,8 @@ test.describe('New licence agreement journey (internal)', () => {
       formatLongDate(startDateYear + '-04-01'),
       '',
       'Two-part tariff',
-      ''
+      '',
+      'Delete | End'
     ])
 
     // actions


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5722

In the last change, [Default return version start date to the licence's own start date](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/314), we updated the migrated licence agreement tests to use role-based row/cell queries.

The key difference is that the previous versions asserted specific cells. The updated version asserts the whole row, but has missed that there is another column, **Action**.

This means the assertion is failing for two of the tests. This change fixes the assertion.