### PR TITLE
Fix Cypress two-part tariff billing tests

### DIFF
--- a/cypress/e2e/internal/billing/two-part-tariff/journey.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/journey.cy.js
@@ -124,7 +124,7 @@ describe('Create and send PRESROC two-part tariff bill run (internal)', () => {
     // we have to wait till the bill run has finished generating. The thing we wait on is the READY label. Once that
     // is present we can check the rest of the details before confirming the bill run
     cy.get('#main-content > p > .govuk-tag', { timeout: 20000 }).should('contain.text', 'ready')
-    cy.get('[data-test="bill-total"]').should('contain.text', '£660.24')
+    cy.get('[data-test="bill-total"]').should('contain.text', '£412.65')
     cy.get('[data-test="bills-count"]').should('contain.text', '1 Two-part tariff winter and all year bill')
     cy.get('.govuk-button').contains('Send bill run').click()
 

--- a/cypress/e2e/internal/billing/two-part-tariff/review/scenario-04.cy.js
+++ b/cypress/e2e/internal/billing/two-part-tariff/review/scenario-04.cy.js
@@ -79,16 +79,9 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
 
     // Review licences ~ Test you can filter by licence issue
     cy.get('.govuk-details__summary').click()
-    cy.get('[data-test="returns-late"]').click()
-    cy.contains('Apply filters').click()
-    cy.get('#main-content').should('contain.text', 'No licences found')
-    cy.contains('Clear filters').click()
-
-    cy.get('.govuk-details__summary').click()
     cy.get('[data-test="aggregate-factor"]').click()
     cy.contains('Apply filters').click()
     cy.get('.govuk-table__caption').should('contain.text', 'Showing all 1 licences')
-    cy.contains('Clear filters').click()
 
     // Review licences ~ Test it has the correct licence
     cy.get('[data-test="licence-1"]').should('contain.text', 'AT/TE/ST/01/01')
@@ -175,15 +168,13 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
     )
     cy.get('[data-test="total-billable-returns"]').should('contain.text', '32 ML')
     cy.get('[data-test="authorised-volume"]').should('contain.text', '32 ML')
-    cy.get('[data-test="additional-charges"]').should('contain.text', 'Public Water Supply')
     cy.get('[data-test="adjustment-0"]').should('contain.text', 'Aggregate factor (0.5 / 0.5)')
     cy.get('[data-test="adjustment-1"]').should('contain.text', 'Charge adjustment (1 / 1)')
     cy.contains('Change factors').click()
 
     // Change factors page ~ Amend the aggregate
     cy.get('.govuk-heading-xl').should('contain.text', 'Set the adjustment factors')
-    cy.get('[data-test="adjustment-0"]').should('contain.text', 'Public Water Supply')
-    cy.get('[data-test="adjustment-1"]').should('contain.text', 'Two part tariff agreement')
+    cy.get('[data-test="adjustment-0"]').should('contain.text', 'Two part tariff agreement')
     cy.get('#amended-aggregate').should('have.value', '0.5')
     cy.get('#amended-charge-adjustment').should('have.value', '1')
     // By changing the aggregate factor to 1 this removes it
@@ -201,8 +192,7 @@ describe('Testing a two-part tariff bill run with a similar licence to scenario 
 
     // Change factors page ~ Amend the charge adjustment
     cy.get('.govuk-heading-xl').should('contain.text', 'Set the adjustment factors')
-    cy.get('[data-test="adjustment-0"]').should('contain.text', 'Public Water Supply')
-    cy.get('[data-test="adjustment-1"]').should('contain.text', 'Two part tariff agreement')
+    cy.get('[data-test="adjustment-0"]').should('contain.text', 'Two part tariff agreement')
     cy.get('#amended-aggregate').should('have.value', '1')
     cy.get('#amended-charge-adjustment').should('have.value', '1')
     cy.get('#amended-charge-adjustment').clear().type('0.5')

--- a/cypress/fixtures/pre-sroc-two-part-tariff-bill-run.json
+++ b/cypress/fixtures/pre-sroc-two-part-tariff-bill-run.json
@@ -223,8 +223,8 @@
       "abstractionPeriodEndMonth": 10,
       "authorisedAnnualQuantity": 30,
       "billableAnnualQuantity": 25,
-      "season": "summer",
-      "seasonDerived": "summer",
+      "season": "all year",
+      "seasonDerived": "all year",
       "source": "unsupported",
       "loss": "high",
       "purposePrimaryId": {
@@ -253,7 +253,7 @@
       "scheme": "alcs",
       "adjustments": null,
       "eiucRegion": null,
-      "section127Agreement": null,
+      "section127Agreement": true,
       "restrictedSource": false,
       "volume": 0
     }

--- a/cypress/support/scenarios/two-part-tariff-review-04.js
+++ b/cypress/support/scenarios/two-part-tariff-review-04.js
@@ -1,11 +1,17 @@
 import chargeVersionData from '../fixture-builder/two-part-tariff-review-charge-version.js'
 import reviewLicenceData from '../fixture-builder/two-part-tariff-review-licence.js'
+import { currentFinancialYear } from '../helpers/date.helpers.js'
 
 export const title = 'Two-part tariff review 04'
 export const description =
   'Testing a two-part tariff bill run with a similar licence to scenario one, licence is current and not in workflow, it has one applicable charge version with a single charge reference and one charge element. The charge reference has an aggregate value. It has one return that matches.'
 
-export default function (endYear, startYear) {
+export default function () {
+  const previousFinancialYearInfo = currentFinancialYear(31, 3, -1)
+
+  const endYear = previousFinancialYearInfo.end.year
+  const startYear = previousFinancialYearInfo.start.year
+
   return {
     ...reviewLicenceData(),
     chargeVersions: [chargeVersionData()],


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5722

Possibly in the changes we made in [Update 2PT review scenario tests to be dynamic](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/284), two tests are now failing.

`cypress/e2e/internal/billing/two-part-tariff/review/scenario-04.cy.js` was failing because of something going on with the filter. It was trying to set an option that was no longer displayed because the click to open the filters section was not triggering.

With that resolved, it then exposed that a number of the assertions needed to be dropped due to our change in [Stop defaulting licence as a water company](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/293).

To be honest, we're not sure how `cypress/e2e/internal/billing/two-part-tariff/journey.cy.js` was ever passing, but again perhaps other changes to make the data more realistic have exposed this was passing by fluke.

It was failing because the bill run was not matching any charge versions and therefore returning `EMPTY`. It wasn't returning anything because the charge version being seeded was set as summer, yet the test was choosing winter in the create bill run journey.

We've corrected the existing fixture data, and that has got the bill run matching again.