### PR TITLE
Fix Playwright tests that have started failing

### DIFF
--- a/tests/internal/notices/ad-hoc/returns-invitation.spec.js
+++ b/tests/internal/notices/ad-hoc/returns-invitation.spec.js
@@ -1,4 +1,4 @@
-import scenarioData from '../../../support/scenarios/registered-licence-with-open-return-log-for-first-period.scenario.js'
+import scenarioData from '../../../support/scenarios/registered-licence-with-open-winter-return-log.scenario.js'
 import { test, expect } from '../../../support/fixtures.js'
 
 test.describe('Ad-hoc returns invitation journey (internal)', () => {

--- a/tests/internal/notices/ad-hoc/returns-reminder.spec.js
+++ b/tests/internal/notices/ad-hoc/returns-reminder.spec.js
@@ -1,4 +1,4 @@
-import scenarioData from '../../../support/scenarios/registered-licence-with-due-return-log-for-first-period.scenario.js'
+import scenarioData from '../../../support/scenarios/registered-licence-with-due-winter-return-log.scenario.js'
 import { test, expect } from '../../../support/fixtures.js'
 
 test.describe('Ad-hoc returns reminder journey (internal)', () => {

--- a/tests/internal/return-logs/submit-meter-readings.spec.js
+++ b/tests/internal/return-logs/submit-meter-readings.spec.js
@@ -60,7 +60,7 @@ test.describe('Submit a meter readings return (internal)', () => {
 
     // Summary of monthly readings
     // choose enter monthly readings for
-    await page.locator('[data-test="action-0"]').click()
+    await page.getByRole('link', { name: 'Enter monthly readings   for April' }).click()
 
     // Water abstracted
     // enter meter reading of 120 and continue

--- a/tests/support/scenarios/licence-with-due-winter-return-log.scenario.js
+++ b/tests/support/scenarios/licence-with-due-winter-return-log.scenario.js
@@ -1,0 +1,43 @@
+import returnLogData from '../data/return-log.data.js'
+import returnRequirementData from '../data/return-requirement.data.js'
+import returnVersionData from '../data/return-version.data.js'
+import licenceScenario from './licence.scenario.js'
+import { previousPeriod } from '../helpers/date.helpers.js'
+import { mergeByKey } from '../helpers/scenario.helpers.js'
+
+export const title = 'Licence with an open return log (winter cycle)'
+export const description =
+  'Licence with one return requirement and an open winter return log for the previous winter cycle'
+
+export default function (calculatedDates) {
+  const { currentWinterReturnCycle } = calculatedDates
+
+  const previousPeriodDetails = previousPeriod({
+    startDate: currentWinterReturnCycle.startDate,
+    endDate: currentWinterReturnCycle.endDate,
+    dueDate: currentWinterReturnCycle.dueDate,
+    quarterly: false
+  })
+
+  const currentPeriodDetails = {
+    startDate: new Date(currentWinterReturnCycle.startDate),
+    endDate: new Date(currentWinterReturnCycle.endDate),
+    dueDate: null,
+    quarterly: false
+  }
+
+  const licence = licenceScenario()
+
+  const returnVersion = returnVersionData(licence)
+
+  // In the service return logs will cover the whole period of their matching return version. To ensure our test data is
+  // realistic, we alter the start date of the return version to match the first return log we're seeding.
+  returnVersion.returnVersions[0].startDate = previousPeriodDetails.startDate
+
+  const returnRequirement = returnRequirementData(returnVersion, licence)
+
+  const previousReturnLog = returnLogData(licence, returnRequirement, previousPeriodDetails)
+  const currentReturnLog = returnLogData(licence, returnRequirement, currentPeriodDetails)
+
+  return mergeByKey(licence, returnVersion, returnRequirement, previousReturnLog, currentReturnLog)
+}

--- a/tests/support/scenarios/registered-licence-with-due-winter-return-log.scenario.js
+++ b/tests/support/scenarios/registered-licence-with-due-winter-return-log.scenario.js
@@ -1,0 +1,21 @@
+import primaryUserData from '../data/primary-user.data.js'
+import licenceWithDueWinterReturnLog from './licence-with-due-winter-return-log.scenario.js'
+import { mergeByKey } from '../helpers/scenario.helpers.js'
+
+export const title = 'Registered licence with a due return log (winter cycle)'
+export const description =
+  'Registered licence with one return requirement and a due winter return log for the previous winter cycle'
+
+export default function (calculatedDates) {
+  // We load in the unregistered open scenario because it has 99% of the data we need
+  const licence = licenceWithDueWinterReturnLog(calculatedDates)
+
+  // We then add the primary user, which is what makes the licence 'registered'
+  const primaryUser = primaryUserData('external@example.com', licence)
+
+  // Linking a primary user's company entity to the licence's 'licenceDocumentHeaders' is the only way we can link a
+  // registered licence to a licence holder.
+  licence.licenceDocumentHeaders[0].companyEntityId = primaryUser.licenceEntityRoles[0].companyEntityId
+
+  return mergeByKey(licence, primaryUser)
+}


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5722

The date has changed, specifically from 28 July to 29 July. So whadda you know, some tests are failing!

> Though that's not the only reason. Skip to the end for that

In this case it's the ad-hoc returns invitation and reminder tests. It was a mistake to use the 'first-period' scenarios because there would come points where that period would not be applicable.

For example, on 28 July the first two periods would be:

- Quarterly 1 April 2026 to 30 June 2026
- Winter annual 1 April 2025 to 31 March 2026

Now, on 29 July 2026, they're:

- Quarterly 1 July 2026 to 30 September 2026
- Summer annual 1 November 2025 to 31 October 2026

When the first period was '1 April 2026 to 30 June 2026 ', and we were creating a return log based on that, it would pass because the current date is later than its end date.

Now the first period is '1 July 2026 to 30 September 2026'; the current date is earlier than its end date, so the return log is `NOT DUE YET`.

We should have just used the 'winter-return-log' scenarios. Then we would always have a valid return log that would be picked up for a notification. Only, there is only the 'open-winter-return-log' scenario!

So, the first step is adding a base `licence-with-due-winter-return-log.scenario.js`, which we can then build a `registered-licence-with-due-winter-return-log.scenario.js` on top of.

We then update the ad-returns invite to use the existing `registered-licence-with-open-winter-return-log.scenario.js`, and the ad-hoc returns reminder to use the new `registered-licence-with-due-winter-return-log.scenario.js`.

The other reason is that one of the tests has decided to stop registering a click on an element. It's worked up until now, and the locator is finding the element to click, but it's just stopped failing. Even the AI doesn't know why (and before you say anything, the solution is not to scroll it into view!)

Switching to `getByRole()` does the trick. And because we know the scenario and that it's using a winter return log, we know the first line to 'click' will always be April.

<img width="421" height="59" alt="Screenshot 2026-07-29 at 13 43 12" src="https://github.com/user-attachments/assets/a00a28c4-f525-41cb-93f2-058d64d299b9" />
