### PR TITLE
Migrate second-level scenarios built on the licence.scenario.js chain

### DIFF
--- a/tests/external/account/change-email.spec.js
+++ b/tests/external/account/change-email.spec.js
@@ -7,11 +7,7 @@ test.describe('Change user email address (external)', () => {
   test.beforeAll(async ({ setup }) => {
     const scenario = scenarioData()
 
-    const {
-      users: [scenarioUser]
-    } = scenario
-
-    user = scenarioUser
+    user = scenario.user
 
     await setup(scenario)
   })

--- a/tests/external/account/sharing-access-with-existing-user.spec.js
+++ b/tests/external/account/sharing-access-with-existing-user.spec.js
@@ -9,12 +9,9 @@ test.describe('Sharing licence access with another user (external)', () => {
   test.beforeAll(async ({ setup }) => {
     const scenario = scenarioData()
 
-    const {
-      licences: [scenarioLicence],
-      users: [scenarioFirstUser, scenarioSecondUser]
-    } = scenario
+    const [scenarioFirstUser, scenarioSecondUser] = scenario.users
 
-    licence = scenarioLicence
+    licence = scenario.licence
     firstUser = scenarioFirstUser
     secondUser = scenarioSecondUser
 

--- a/tests/external/returns/nil-return.spec.js
+++ b/tests/external/returns/nil-return.spec.js
@@ -10,12 +10,11 @@ test.describe('Submit a nil return (external)', () => {
     const scenario = scenarioData(dates)
 
     const {
-      returnLogs: [scenarioReturnLog],
-      users: [scenarioUser]
+      returnLogs: [scenarioReturnLog]
     } = scenario
 
     returnLog = scenarioReturnLog
-    user = scenarioUser
+    user = scenario.user
 
     await setup(scenario)
   })

--- a/tests/external/returns/readings-return.spec.js
+++ b/tests/external/returns/readings-return.spec.js
@@ -11,12 +11,11 @@ test.describe('Submit a readings return (external)', () => {
     const scenario = scenarioData(dates)
 
     const {
-      returnLogs: [scenarioReturnLog],
-      users: [scenarioUser]
+      returnLogs: [scenarioReturnLog]
     } = scenario
 
     returnLog = scenarioReturnLog
-    user = scenarioUser
+    user = scenario.user
 
     await setup(scenario)
   })

--- a/tests/external/returns/return-statuses.spec.js
+++ b/tests/external/returns/return-statuses.spec.js
@@ -10,15 +10,9 @@ test.describe('View return statuses (external)', () => {
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
 
-    const {
-      licences: [scenarioLicence],
-      returnLogs: scenarioReturnLogs,
-      users: [scenarioUser]
-    } = scenario
-
-    licence = scenarioLicence
-    returnLogs = scenarioReturnLogs
-    user = scenarioUser
+    licence = scenario.licence
+    returnLogs = scenario.returnLogs
+    user = scenario.user
 
     await setup(scenario)
   })

--- a/tests/external/returns/volumes-return.spec.js
+++ b/tests/external/returns/volumes-return.spec.js
@@ -11,12 +11,11 @@ test.describe('Submit a volumes return (external)', () => {
     const scenario = scenarioData(dates)
 
     const {
-      returnLogs: [scenarioReturnLog],
-      users: [scenarioUser]
+      returnLogs: [scenarioReturnLog]
     } = scenario
 
     returnLog = scenarioReturnLog
-    user = scenarioUser
+    user = scenario.user
 
     await setup(scenario)
   })

--- a/tests/external/user/reset-password.spec.js
+++ b/tests/external/user/reset-password.spec.js
@@ -8,11 +8,7 @@ test.describe('Reset password journey (external)', () => {
   test.beforeAll(async ({ setup }) => {
     const scenario = scenarioData()
 
-    const {
-      users: [scenarioUser]
-    } = scenario
-
-    user = scenarioUser
+    user = scenario.user
 
     await setup(scenario)
   })

--- a/tests/internal/billing/two-part-tariff/review/simple-licence-and-return-no-issues.spec.js
+++ b/tests/internal/billing/two-part-tariff/review/simple-licence-and-return-no-issues.spec.js
@@ -22,11 +22,7 @@ test.describe('Simple Licence and Returns with No Issues (internal)', { tag: '@s
 
     const scenario = scenarioData(dates)
 
-    const {
-      licences: [scenarioLicence]
-    } = scenario
-
-    licence = scenarioLicence
+    licence = scenario.licence
 
     await setup(scenario)
   })

--- a/tests/internal/billing/two-part-tariff/review/simple-licence-and-two-returns-no-issues.spec.js
+++ b/tests/internal/billing/two-part-tariff/review/simple-licence-and-two-returns-no-issues.spec.js
@@ -22,11 +22,7 @@ test.describe('Simple Licence and Two Returns with No Issues (internal)', () => 
 
     const scenario = scenarioData(dates)
 
-    const {
-      licences: [scenarioLicence]
-    } = scenario
-
-    licence = scenarioLicence
+    licence = scenario.licence
 
     await setup(scenario)
   })

--- a/tests/internal/charge-information/presroc-licence-transfer.spec.js
+++ b/tests/internal/charge-information/presroc-licence-transfer.spec.js
@@ -11,15 +11,9 @@ test.describe('Presroc licence transfer journey (internal)', { tag: ['@supplemen
   test.beforeAll(async ({ setup }) => {
     const scenario = scenarioData()
 
-    const {
-      chargeVersions: [scenarioChargeVersion],
-      licences: [scenarioLicence],
-      licenceVersionPurposes: [scenarioLicenceVersionPurpose]
-    } = scenario
-
-    chargeVersion = scenarioChargeVersion
-    licence = scenarioLicence
-    licenceVersionPurpose = scenarioLicenceVersionPurpose
+    chargeVersion = scenario.chargeVersion
+    licence = scenario.licence
+    licenceVersionPurpose = scenario.licenceVersionPurpose
 
     await setup(scenario)
   })

--- a/tests/internal/licence-agreements/presroc-delete-licence-agreement.spec.js
+++ b/tests/internal/licence-agreements/presroc-delete-licence-agreement.spec.js
@@ -18,11 +18,7 @@ test.describe(
     test.beforeAll(async ({ setup }) => {
       const scenario = scenarioData()
 
-      const {
-        licences: [scenarioLicence]
-      } = scenario
-
-      licence = scenarioLicence
+      licence = scenario.licence
 
       await setup(scenario)
     })

--- a/tests/internal/licence-agreements/presroc-end-licence-agreement.spec.js
+++ b/tests/internal/licence-agreements/presroc-end-licence-agreement.spec.js
@@ -20,11 +20,7 @@ test.describe(
     test.beforeAll(async ({ setup }) => {
       const scenario = scenarioData()
 
-      const {
-        licences: [scenarioLicence]
-      } = scenario
-
-      licence = scenarioLicence
+      licence = scenario.licence
 
       // The agreement's start date matches the licence's start date, which is always 1 April. A valid end date must
       // either match existing charge information or be 31 March, and cannot be before the agreement start date, so we

--- a/tests/internal/licence-agreements/presroc-new-licence-agreement.spec.js
+++ b/tests/internal/licence-agreements/presroc-new-licence-agreement.spec.js
@@ -19,17 +19,12 @@ test.describe(
     test.beforeAll(async ({ setup }) => {
       const scenario = scenarioData()
 
-      const {
-        licences: [scenarioLicence],
-        chargeVersions: [scenarioChargeVersion]
-      } = scenario
-
-      licence = scenarioLicence
+      licence = scenario.licence
 
       // With existing charge information, the app accepts a custom start date that matches it, so we use the charge
       // version's start date for the agreement's custom start date. It also pre-dates the SROC scheme, so setting up
       // the agreement against it flags the licence for the next old charge scheme supplementary bill run.
-      chargeVersionStartDate = scenarioChargeVersion.startDate
+      chargeVersionStartDate = scenario.chargeVersion.startDate
 
       await setup(scenario)
     })

--- a/tests/internal/licence-set-up/recalculate-bills-link.spec.js
+++ b/tests/internal/licence-set-up/recalculate-bills-link.spec.js
@@ -18,13 +18,8 @@ test.describe(
     test.beforeAll(async ({ setup }) => {
       const scenario = scenarioData()
 
-      const {
-        licences: [scenarioLicence],
-        billRuns: [scenarioBillRun]
-      } = scenario
-
-      licence = scenarioLicence
-      billRun = scenarioBillRun
+      licence = scenario.licence
+      billRun = scenario.billRun
 
       await setup(scenario)
     })

--- a/tests/internal/monitoring-stations/abstraction-alerts/cancel-alert.spec.js
+++ b/tests/internal/monitoring-stations/abstraction-alerts/cancel-alert.spec.js
@@ -9,13 +9,8 @@ test.describe('Set up but then cancel an abstraction alert (internal)', () => {
   test.beforeAll(async ({ setup }) => {
     const scenario = scenarioData()
 
-    const {
-      licences: [scenarioLicence],
-      monitoringStations: [scenarioMonitoringStation]
-    } = scenario
-
-    licence = scenarioLicence
-    monitoringStation = scenarioMonitoringStation
+    licence = scenario.licence
+    monitoringStation = scenario.monitoringStation
 
     await setup(scenario)
   })

--- a/tests/internal/monitoring-stations/abstraction-alerts/no-thresholds.spec.js
+++ b/tests/internal/monitoring-stations/abstraction-alerts/no-thresholds.spec.js
@@ -7,11 +7,7 @@ test.describe('Attempt set up of abstraction alert with no thresholds (internal)
   test.beforeAll(async ({ setup }) => {
     const scenario = scenarioData()
 
-    const {
-      monitoringStations: [scenarioMonitoringStation]
-    } = scenario
-
-    monitoringStation = scenarioMonitoringStation
+    monitoringStation = scenario.monitoringStation
 
     await setup(scenario)
   })

--- a/tests/internal/monitoring-stations/abstraction-alerts/send-alert.spec.js
+++ b/tests/internal/monitoring-stations/abstraction-alerts/send-alert.spec.js
@@ -8,13 +8,8 @@ test.describe('Send an abstraction alert (internal)', () => {
   test.beforeAll(async ({ setup }) => {
     const scenario = scenarioData()
 
-    const {
-      licences: [scenarioLicence],
-      monitoringStations: [scenarioMonitoringStation]
-    } = scenario
-
-    licence = scenarioLicence
-    monitoringStation = scenarioMonitoringStation
+    licence = scenario.licence
+    monitoringStation = scenario.monitoringStation
 
     await setup(scenario)
   })

--- a/tests/internal/monitoring-stations/licence-tagging/change-type.spec.js
+++ b/tests/internal/monitoring-stations/licence-tagging/change-type.spec.js
@@ -9,13 +9,8 @@ test.describe('Tag a licence but attempt to change the tag type during the journ
   test.beforeAll(async ({ setup }) => {
     const scenario = scenarioData()
 
-    const {
-      licences: [scenarioLicence],
-      monitoringStations: [scenarioMonitoringStation]
-    } = scenario
-
-    licence = scenarioLicence
-    monitoringStation = scenarioMonitoringStation
+    licence = scenario.licence
+    monitoringStation = scenario.monitoringStation
 
     await setup(scenario)
   })

--- a/tests/internal/monitoring-stations/licence-tagging/linked-condition-manual-abs-period.spec.js
+++ b/tests/internal/monitoring-stations/licence-tagging/linked-condition-manual-abs-period.spec.js
@@ -9,13 +9,8 @@ test.describe('Tag a licence linked to a condition but manually enter the abstra
   test.beforeAll(async ({ setup }) => {
     const scenario = scenarioData()
 
-    const {
-      licences: [scenarioLicence],
-      monitoringStations: [scenarioMonitoringStation]
-    } = scenario
-
-    licence = scenarioLicence
-    monitoringStation = scenarioMonitoringStation
+    licence = scenario.licence
+    monitoringStation = scenario.monitoringStation
 
     await setup(scenario)
   })

--- a/tests/internal/monitoring-stations/licence-tagging/linked-condition.spec.js
+++ b/tests/internal/monitoring-stations/licence-tagging/linked-condition.spec.js
@@ -10,15 +10,9 @@ test.describe('Tag a licence linked to a condition. The abstraction period is de
   test.beforeAll(async ({ setup }) => {
     const scenario = scenarioData()
 
-    const {
-      licences: [scenarioLicence],
-      licenceVersionPurposeConditions: [scenarioLicenceVersionPurposeCondition],
-      monitoringStations: [scenarioMonitoringStation]
-    } = scenario
-
-    licence = scenarioLicence
-    licenceVersionPurposeCondition = scenarioLicenceVersionPurposeCondition
-    monitoringStation = scenarioMonitoringStation
+    licence = scenario.licence
+    licenceVersionPurposeCondition = scenario.licenceVersionPurposeCondition
+    monitoringStation = scenario.monitoringStation
 
     await setup(scenario)
   })

--- a/tests/internal/monitoring-stations/licence-tagging/no-linked-condition.spec.js
+++ b/tests/internal/monitoring-stations/licence-tagging/no-linked-condition.spec.js
@@ -9,13 +9,8 @@ test.describe('Tag a licence that is not linked to a condition (internal)', () =
   test.beforeAll(async ({ setup }) => {
     const scenario = scenarioData()
 
-    const {
-      licences: [scenarioLicence],
-      monitoringStations: [scenarioMonitoringStation]
-    } = scenario
-
-    licence = scenarioLicence
-    monitoringStation = scenarioMonitoringStation
+    licence = scenario.licence
+    monitoringStation = scenario.monitoringStation
 
     await setup(scenario)
   })

--- a/tests/internal/monitoring-stations/licence-tagging/remove-tag.spec.js
+++ b/tests/internal/monitoring-stations/licence-tagging/remove-tag.spec.js
@@ -8,13 +8,8 @@ test.describe('Attempt to remove a tag from a monitoring station (internal)', ()
   test.beforeAll(async ({ setup }) => {
     const scenario = scenarioData()
 
-    const {
-      licences: [scenarioLicence],
-      monitoringStations: [scenarioMonitoringStation]
-    } = scenario
-
-    licence = scenarioLicence
-    monitoringStation = scenarioMonitoringStation
+    licence = scenario.licence
+    monitoringStation = scenario.monitoringStation
 
     await setup(scenario)
   })

--- a/tests/internal/return-versions/cancel-using-copy-from-journey.spec.js
+++ b/tests/internal/return-versions/cancel-using-copy-from-journey.spec.js
@@ -10,15 +10,9 @@ test.describe('Cancel a return version using copy from existing (internal)', () 
   test.beforeAll(async ({ setup }) => {
     const scenario = scenarioData()
 
-    const {
-      licences: [scenarioLicence],
-      returnRequirements: [scenarioReturnRequirement],
-      returnRequirementPurposes: [scenarioReturnRequirementPurpose]
-    } = scenario
-
-    licence = scenarioLicence
-    returnRequirement = scenarioReturnRequirement
-    returnRequirementPurpose = scenarioReturnRequirementPurpose
+    licence = scenario.licence
+    returnRequirement = scenario.returnRequirement
+    returnRequirementPurpose = scenario.returnRequirementPurpose
 
     await setup(scenario)
   })

--- a/tests/internal/return-versions/submit-historic-correction-quarterly-using-abstraction-data-journey.spec.js
+++ b/tests/internal/return-versions/submit-historic-correction-quarterly-using-abstraction-data-journey.spec.js
@@ -12,13 +12,8 @@ test.describe('Submit historic correction changing to quarterly on new return ve
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
 
-    const {
-      licences: [scenarioLicence],
-      returnLogs: scenarioReturnLogs
-    } = scenario
-
-    licence = scenarioLicence
-    returnLogs = scenarioReturnLogs
+    licence = scenario.licence
+    returnLogs = scenario.returnLogs
     startYear = new Date(dates.currentFinancialYear.startDate).getFullYear()
 
     expectedReturnLogs = {

--- a/tests/internal/return-versions/update-requirement-purpose-and-points-journey.spec.js
+++ b/tests/internal/return-versions/update-requirement-purpose-and-points-journey.spec.js
@@ -9,13 +9,8 @@ test.describe('Update the purpose and points of a copied return requirement and 
   test.beforeAll(async ({ setup }) => {
     const scenario = scenarioData()
 
-    const {
-      licences: [scenarioLicence],
-      returnRequirementPurposes: [scenarioReturnRequirementPurpose]
-    } = scenario
-
-    licence = scenarioLicence
-    returnRequirementPurpose = scenarioReturnRequirementPurpose
+    licence = scenario.licence
+    returnRequirementPurpose = scenario.returnRequirementPurpose
 
     await setup(scenario)
   })

--- a/tests/internal/returns/editing-a-return.spec.js
+++ b/tests/internal/returns/editing-a-return.spec.js
@@ -9,13 +9,8 @@ test.describe('Editing a return (internal)', { tag: '@supplementaryBilling' }, (
     const dates = await calculatedDates()
     const scenario = scenarioData(dates)
 
-    const {
-      licences: [scenarioLicence],
-      returnLogs: [scenarioReturnLog]
-    } = scenario
-
-    licence = scenarioLicence
-    returnLog = scenarioReturnLog
+    licence = scenario.licence
+    returnLog = scenario.returnLog
 
     await setup(scenario)
   })

--- a/tests/internal/user/change-permissions.spec.js
+++ b/tests/internal/user/change-permissions.spec.js
@@ -8,11 +8,7 @@ test.describe('Change user permissions (internal)', () => {
   test.beforeAll(async ({ setup }) => {
     const scenario = scenarioData()
 
-    const {
-      users: [scenarioUserToUpdate]
-    } = scenario
-
-    userToUpdate = scenarioUserToUpdate
+    userToUpdate = scenario.user
 
     await setup(scenario)
   })

--- a/tests/internal/user/create-user-with-external-account.spec.js
+++ b/tests/internal/user/create-user-with-external-account.spec.js
@@ -7,11 +7,7 @@ test.describe('Creating internal user with existing external account (internal)'
   test.beforeAll(async ({ setup }) => {
     const scenario = scenarioData()
 
-    const {
-      users: [scenarioUser]
-    } = scenario
-
-    user = scenarioUser
+    user = scenario.user
 
     await setup(scenario)
   })

--- a/tests/internal/workflow/cancelling-a-workflow-with-annual-bill-run.spec.js
+++ b/tests/internal/workflow/cancelling-a-workflow-with-annual-bill-run.spec.js
@@ -20,13 +20,8 @@ test.describe(
       const dates = await calculatedDates()
       const scenario = scenarioData(dates)
 
-      const {
-        licences: [scenarioLicence],
-        companies: [scenarioCompany]
-      } = scenario
-
-      licence = scenarioLicence
-      company = scenarioCompany
+      licence = scenario.licence
+      company = scenario.company
 
       await setup(scenario)
     })

--- a/tests/internal/workflow/cancelling-a-workflow-with-two-part-tariff-bill-run.spec.js
+++ b/tests/internal/workflow/cancelling-a-workflow-with-two-part-tariff-bill-run.spec.js
@@ -21,13 +21,8 @@ test.describe(
       const dates = await calculatedDates()
       const scenario = scenarioData(dates)
 
-      const {
-        licences: [scenarioLicence],
-        companies: [scenarioCompany]
-      } = scenario
-
-      licence = scenarioLicence
-      company = scenarioCompany
+      licence = scenario.licence
+      company = scenario.company
 
       await setup(scenario)
     })

--- a/tests/support/data/bill-run.data.js
+++ b/tests/support/data/bill-run.data.js
@@ -2,14 +2,10 @@ import { regionCode } from '../default-values.js'
 
 export default function () {
   return {
-    billRuns: [
-      {
-        regionId: { schema: 'public', table: 'regions', lookup: 'naldRegionId', value: regionCode, select: 'id' },
-        batchType: 'annual',
-        fromFinancialYearEnding: '2024',
-        toFinancialYearEnding: '2024',
-        status: 'sent'
-      }
-    ]
+    regionId: { schema: 'public', table: 'regions', lookup: 'naldRegionId', value: regionCode, select: 'id' },
+    batchType: 'annual',
+    fromFinancialYearEnding: '2024',
+    toFinancialYearEnding: '2024',
+    status: 'sent'
   }
 }

--- a/tests/support/data/charge-reference-presroc.data.js
+++ b/tests/support/data/charge-reference-presroc.data.js
@@ -1,16 +1,8 @@
 import { convertCubicMetresToMegalitres } from '../helpers/conversion.helpers.js'
 import { generateUUID } from '../helpers/generate-uuid.js'
 
-export default function (chargeVersionData, licenceData) {
+export default function (chargeVersion, licenceVersionPurpose) {
   const chargeReferenceId = generateUUID()
-
-  const {
-    chargeVersions: [chargeVersion]
-  } = chargeVersionData
-
-  const {
-    licenceVersionPurposes: [licenceVersionPurpose]
-  } = licenceData
 
   // We make an assumption that if the purpose is not 400 (the default), then we have been passed our alternate which
   // is typically 280 (Make-Up Or Top Up Water). Both have a high loss, and assuming non-tidal and the same volume, both
@@ -19,45 +11,41 @@ export default function (chargeVersionData, licenceData) {
   const description = twoPartTariff ? 'Spray Irrigation - Direct' : 'Make-Up Or Top Up Water'
 
   return {
-    chargeReferences: [
-      {
-        id: chargeReferenceId,
-        chargeVersionId: chargeVersion.id,
-        abstractionPeriodStartDay: licenceVersionPurpose.abstractionPeriodStartDay,
-        abstractionPeriodStartMonth: licenceVersionPurpose.abstractionPeriodStartMonth,
-        abstractionPeriodEndDay: licenceVersionPurpose.abstractionPeriodEndDay,
-        abstractionPeriodEndMonth: licenceVersionPurpose.abstractionPeriodEndMonth,
-        authorisedAnnualQuantity: convertCubicMetresToMegalitres(licenceVersionPurpose.annualQuantity),
-        season: 'all year',
-        seasonDerived: 'all year',
-        description: `Test PRESROC charge element 1 - ${description}`,
-        source: 'unsupported',
-        loss: 'high',
-        purposeId: {
-          schema: 'public',
-          table: 'purposes',
-          lookup: 'legacyId',
-          value: licenceVersionPurpose.purposeId.value,
-          select: 'id'
-        },
-        purposePrimaryId: {
-          schema: 'public',
-          table: 'primaryPurposes',
-          lookup: 'legacyId',
-          value: 'A',
-          select: 'id'
-        },
-        purposeSecondaryId: {
-          schema: 'public',
-          table: 'secondaryPurposes',
-          lookup: 'legacyId',
-          value: 'AGR',
-          select: 'id'
-        },
-        section127Agreement: twoPartTariff,
-        scheme: 'alcs',
-        restrictedSource: false
-      }
-    ]
+    id: chargeReferenceId,
+    chargeVersionId: chargeVersion.id,
+    abstractionPeriodStartDay: licenceVersionPurpose.abstractionPeriodStartDay,
+    abstractionPeriodStartMonth: licenceVersionPurpose.abstractionPeriodStartMonth,
+    abstractionPeriodEndDay: licenceVersionPurpose.abstractionPeriodEndDay,
+    abstractionPeriodEndMonth: licenceVersionPurpose.abstractionPeriodEndMonth,
+    authorisedAnnualQuantity: convertCubicMetresToMegalitres(licenceVersionPurpose.annualQuantity),
+    season: 'all year',
+    seasonDerived: 'all year',
+    description: `Test PRESROC charge element 1 - ${description}`,
+    source: 'unsupported',
+    loss: 'high',
+    purposeId: {
+      schema: 'public',
+      table: 'purposes',
+      lookup: 'legacyId',
+      value: licenceVersionPurpose.purposeId.value,
+      select: 'id'
+    },
+    purposePrimaryId: {
+      schema: 'public',
+      table: 'primaryPurposes',
+      lookup: 'legacyId',
+      value: 'A',
+      select: 'id'
+    },
+    purposeSecondaryId: {
+      schema: 'public',
+      table: 'secondaryPurposes',
+      lookup: 'legacyId',
+      value: 'AGR',
+      select: 'id'
+    },
+    section127Agreement: twoPartTariff,
+    scheme: 'alcs',
+    restrictedSource: false
   }
 }

--- a/tests/support/data/external-user.data.js
+++ b/tests/support/data/external-user.data.js
@@ -3,16 +3,12 @@ import { externalUserEmail, password } from '../default-values.js'
 
 export default function () {
   return {
-    users: [
-      {
-        username: externalUserEmail,
-        password,
-        resetRequired: 0,
-        application: 'water_vml',
-        badLogins: 0,
-        enabled: true,
-        lastLogin: yesterday()
-      }
-    ]
+    username: externalUserEmail,
+    password,
+    resetRequired: 0,
+    application: 'water_vml',
+    badLogins: 0,
+    enabled: true,
+    lastLogin: yesterday()
   }
 }

--- a/tests/support/data/internal-user.data.js
+++ b/tests/support/data/internal-user.data.js
@@ -3,16 +3,12 @@ import { internalUserEmail, password } from '../default-values.js'
 
 export default function () {
   return {
-    users: [
-      {
-        username: internalUserEmail,
-        password,
-        resetRequired: 0,
-        application: 'water_admin',
-        badLogins: 0,
-        enabled: true,
-        lastLogin: yesterday()
-      }
-    ]
+    username: internalUserEmail,
+    password,
+    resetRequired: 0,
+    application: 'water_admin',
+    badLogins: 0,
+    enabled: true,
+    lastLogin: yesterday()
   }
 }

--- a/tests/support/data/licence-monitoring-station.data.js
+++ b/tests/support/data/licence-monitoring-station.data.js
@@ -1,20 +1,11 @@
-export default function (licenceAndMonitoringStationData) {
-  const {
-    licences: [licence],
-    monitoringStations: [monitoringStation]
-  } = licenceAndMonitoringStationData
-
+export default function (licence, monitoringStation) {
   return {
-    licenceMonitoringStations: [
-      {
-        licenceId: licence.id,
-        monitoringStationId: monitoringStation.id,
-        abstractionPeriodStartDay: 10,
-        abstractionPeriodStartMonth: 10,
-        abstractionPeriodEndDay: 11,
-        abstractionPeriodEndMonth: 11,
-        restrictionType: 'stop'
-      }
-    ]
+    licenceId: licence.id,
+    monitoringStationId: monitoringStation.id,
+    abstractionPeriodStartDay: 10,
+    abstractionPeriodStartMonth: 10,
+    abstractionPeriodEndDay: 11,
+    abstractionPeriodEndMonth: 11,
+    restrictionType: 'stop'
   }
 }

--- a/tests/support/data/licence-version-purpose-condition.data.js
+++ b/tests/support/data/licence-version-purpose-condition.data.js
@@ -1,21 +1,13 @@
-export default function (licenceVersionPurposeData) {
-  const {
-    licenceVersionPurposes: [licenceVersionPurpose]
-  } = licenceVersionPurposeData
-
+export default function (licenceVersionPurpose) {
   return {
-    licenceVersionPurposeConditions: [
-      {
-        licenceVersionPurposeId: licenceVersionPurpose.id,
-        licenceVersionPurposeConditionTypeId: {
-          schema: 'public',
-          table: 'licenceVersionPurposeConditionTypes',
-          lookup: 'subcode',
-          value: 'LEV',
-          select: 'id'
-        },
-        notes: 'Test condition notes'
-      }
-    ]
+    licenceVersionPurposeId: licenceVersionPurpose.id,
+    licenceVersionPurposeConditionTypeId: {
+      schema: 'public',
+      table: 'licenceVersionPurposeConditionTypes',
+      lookup: 'subcode',
+      value: 'LEV',
+      select: 'id'
+    },
+    notes: 'Test condition notes'
   }
 }

--- a/tests/support/data/monitoring-station.data.js
+++ b/tests/support/data/monitoring-station.data.js
@@ -4,13 +4,9 @@ export default function () {
   const monitoringStationId = generateUUID()
 
   return {
-    monitoringStations: [
-      {
-        id: monitoringStationId,
-        catchmentName: 'Test Catchment',
-        gridReference: 'ST1234567890',
-        label: 'Test Station'
-      }
-    ]
+    id: monitoringStationId,
+    catchmentName: 'Test Catchment',
+    gridReference: 'ST1234567890',
+    label: 'Test Station'
   }
 }

--- a/tests/support/data/return-submission.data.js
+++ b/tests/support/data/return-submission.data.js
@@ -1,11 +1,7 @@
 import { splitTotalVolume } from '../helpers/conversion.helpers.js'
 import { generateUUID } from '../helpers/generate-uuid.js'
 
-export default function (period, returnLogData, totalVolume) {
-  const {
-    returnLogs: [returnLog]
-  } = returnLogData
-
+export default function (period, returnLog, totalVolume) {
   const returnSubmissionId = generateUUID()
 
   const startYear = period.startDate.getFullYear()
@@ -14,15 +10,13 @@ export default function (period, returnLogData, totalVolume) {
   const splitVolumes = splitTotalVolume(totalVolume, 12)
 
   return {
-    returnSubmissions: [
-      {
-        id: returnSubmissionId,
-        returnId: returnLog.returnId,
-        returnLogId: returnLog.id,
-        nilReturn: false,
-        current: true
-      }
-    ],
+    returnSubmission: {
+      id: returnSubmissionId,
+      returnId: returnLog.returnId,
+      returnLogId: returnLog.id,
+      nilReturn: false,
+      current: true
+    },
     returnSubmissionLines: [
       {
         id: generateUUID(),

--- a/tests/support/scenarios/external-gov-uk-user.scenario.js
+++ b/tests/support/scenarios/external-gov-uk-user.scenario.js
@@ -5,12 +5,12 @@ export const title = 'External gov.uk user only'
 export const description = 'A single external user with a gov.uk address and no associated licence or return data'
 
 export default function () {
-  const externalUser = externalUserData()
+  const user = externalUserData()
 
-  externalUser.users[0].username = `regression.tests.${Date.now()}@defra.gov.uk`
-  externalUser.users[0].lastLogin = yesterday()
+  user.username = `regression.tests.${Date.now()}@defra.gov.uk`
+  user.lastLogin = yesterday()
 
   return {
-    ...externalUser
+    user
   }
 }

--- a/tests/support/scenarios/external-sharing-access.scenario.js
+++ b/tests/support/scenarios/external-sharing-access.scenario.js
@@ -1,6 +1,5 @@
 import externalUserData from '../data/external-user.data.js'
 import registeredLicenceScenario from './registered-licence.scenario.js'
-import { mergeByKey } from '../helpers/scenario.helpers.js'
 
 export const title = 'Sharing access'
 export const description =
@@ -10,7 +9,10 @@ export default function () {
   const registeredLicence = registeredLicenceScenario()
   const sharingUser = externalUserData()
 
-  sharingUser.users[0].username = 'external.shared@example.com'
+  sharingUser.username = 'external.shared@example.com'
 
-  return mergeByKey(registeredLicence, sharingUser)
+  return {
+    ...registeredLicence,
+    users: [registeredLicence.user, sharingUser]
+  }
 }

--- a/tests/support/scenarios/external-user.scenario.js
+++ b/tests/support/scenarios/external-user.scenario.js
@@ -5,6 +5,6 @@ export const description = 'A single external user with no associated licence or
 
 export default function () {
   return {
-    ...externalUserData()
+    user: externalUserData()
   }
 }

--- a/tests/support/scenarios/internal-user.scenario.js
+++ b/tests/support/scenarios/internal-user.scenario.js
@@ -5,6 +5,6 @@ export const description = 'A single internal basic user with no associated lice
 
 export default function () {
   return {
-    ...internalUserData()
+    user: internalUserData()
   }
 }

--- a/tests/support/scenarios/licence-with-agreement-and-bill-run.scenario.js
+++ b/tests/support/scenarios/licence-with-agreement-and-bill-run.scenario.js
@@ -1,15 +1,17 @@
 import billRunData from '../data/bill-run.data.js'
 import licenceWithAgreementScenario from './licence-with-agreement.scenario.js'
-import { mergeByKey } from '../helpers/scenario.helpers.js'
 
 export const title = 'Licence with an agreement and a bill run'
 export const description =
   'A licence, licence holder (company), section 127 two-part tariff agreement, and a sent two-part tariff bill run.'
 
 export default function () {
-  const licenceAgreement = licenceWithAgreementScenario()
+  const licence = licenceWithAgreementScenario()
 
   const billRun = billRunData()
 
-  return mergeByKey(licenceAgreement, billRun)
+  return {
+    ...licence,
+    billRun
+  }
 }

--- a/tests/support/scenarios/licence-with-charge-version-and-two-purposes.scenario.js
+++ b/tests/support/scenarios/licence-with-charge-version-and-two-purposes.scenario.js
@@ -1,9 +1,9 @@
+import billingAccountAddressData from '../data/billing-account-address.data.js'
 import billingAccountData from '../data/billing-account.data.js'
 import chargeElementData from '../data/charge-element.data.js'
 import chargeReferenceData from '../data/charge-reference.data.js'
 import chargeVersionData from '../data/charge-version.data.js'
 import licenceWithTwoPurposesScenario from './licence-with-two-purposes.scenario.js'
-import { mergeByKey } from '../helpers/scenario.helpers.js'
 
 export const title = 'Licence with a charge version and two purposes'
 export const description =
@@ -12,15 +12,21 @@ export const description =
 export default function () {
   const licence = licenceWithTwoPurposesScenario()
 
-  const billingAccount = billingAccountData(licence)
-  const chargeVersion = chargeVersionData(billingAccount, licence)
-  const chargeReference = chargeReferenceData(chargeVersion, licence)
+  const billingAccount = billingAccountData(licence.company)
+  const billingAccountAddress = billingAccountAddressData(billingAccount, licence.address)
+  const chargeVersion = chargeVersionData(billingAccount, licence.licence)
+  const chargeReference = chargeReferenceData(chargeVersion, licence.licenceVersionPurposes)
 
-  const {
-    licenceVersionPurposes: [firstLicenceVersionPurpose, secondLicenceVersionPurpose]
-  } = licence
+  const [firstLicenceVersionPurpose, secondLicenceVersionPurpose] = licence.licenceVersionPurposes
   const firstChargeElement = chargeElementData(chargeReference, firstLicenceVersionPurpose)
   const secondChargeElement = chargeElementData(chargeReference, secondLicenceVersionPurpose)
 
-  return mergeByKey(licence, billingAccount, chargeVersion, chargeReference, firstChargeElement, secondChargeElement)
+  return {
+    ...licence,
+    billingAccount,
+    billingAccountAddress,
+    chargeVersion,
+    chargeReference,
+    chargeElements: [firstChargeElement, secondChargeElement]
+  }
 }

--- a/tests/support/scenarios/licence-with-tpt-chg-vers-and-completed-return-log.scenario.js
+++ b/tests/support/scenarios/licence-with-tpt-chg-vers-and-completed-return-log.scenario.js
@@ -1,10 +1,11 @@
 import returnLogData from '../data/return-log.data.js'
 import returnRequirementData from '../data/return-requirement.data.js'
+import returnRequirementPointData from '../data/return-requirement-point.data.js'
+import returnRequirementPurposeData from '../data/return-requirement-purpose.data.js'
 import returnSubmissionData from '../data/return-submission.data.js'
 import returnVersionData from '../data/return-version.data.js'
 import licenceWithChargeVersionScenario from './licence-with-charge-version.scenario.js'
 import { previousPeriod } from '../helpers/date.helpers.js'
-import { mergeByKey } from '../helpers/scenario.helpers.js'
 
 export const title = 'Licence with tpt charge version and completed return log'
 export const description =
@@ -29,29 +30,52 @@ export default function (calculatedDates) {
 
   const licence = licenceWithChargeVersionScenario()
 
-  const returnVersion = returnVersionData(licence)
+  const returnVersion = returnVersionData(licence.licence)
 
   // In the service return logs will cover the whole period of their matching return version. To ensure our test data is
   // realistic, we alter the start date of the return version to match the first return log we're seeding.
-  returnVersion.returnVersions[0].startDate = previousPeriodDetails.startDate
+  returnVersion.startDate = previousPeriodDetails.startDate
 
-  const {
-    licenceVersionPurposes: [licenceVersionPurpose],
-    points
-  } = licence
+  const returnRequirement = returnRequirementData(returnVersion, licence.licenceVersionPurpose)
 
-  const returnRequirement = returnRequirementData(returnVersion, licenceVersionPurpose, points)
+  returnRequirement.twoPartTariff = true
 
-  returnRequirement.returnRequirements[0].twoPartTariff = true
+  const returnRequirementPoint = returnRequirementPointData(returnRequirement, licence.point)
+  const returnRequirementPurpose = returnRequirementPurposeData(returnRequirement, licence.licenceVersionPurpose)
 
-  const previousReturnLog = returnLogData(licence, returnRequirement, previousPeriodDetails)
-  const currentReturnLog = returnLogData(licence, returnRequirement, currentPeriodDetails)
+  const previousReturnLog = returnLogData(
+    licence.licence,
+    returnRequirement,
+    [returnRequirementPurpose],
+    [licence.point],
+    previousPeriodDetails
+  )
+  const currentReturnLog = returnLogData(
+    licence.licence,
+    returnRequirement,
+    [returnRequirementPurpose],
+    [licence.point],
+    currentPeriodDetails
+  )
 
-  previousReturnLog.returnLogs[0].status = 'completed'
+  previousReturnLog.status = 'completed'
 
-  const totalVolume = licence.licenceVersionPurposes[0].annualQuantity
+  const totalVolume = licence.licenceVersionPurpose.annualQuantity
 
-  const returnSubmission = returnSubmissionData(previousPeriodDetails, previousReturnLog, totalVolume)
+  const { returnSubmission, returnSubmissionLines } = returnSubmissionData(
+    previousPeriodDetails,
+    previousReturnLog,
+    totalVolume
+  )
 
-  return mergeByKey(licence, returnVersion, returnRequirement, previousReturnLog, currentReturnLog, returnSubmission)
+  return {
+    ...licence,
+    returnVersion,
+    returnRequirement,
+    returnRequirementPoint,
+    returnRequirementPurpose,
+    returnLogs: [previousReturnLog, currentReturnLog],
+    returnSubmission,
+    returnSubmissionLines
+  }
 }

--- a/tests/support/scenarios/licence-with-tpt-chg-vers-and-two-completed-return-logs.scenario.js
+++ b/tests/support/scenarios/licence-with-tpt-chg-vers-and-two-completed-return-logs.scenario.js
@@ -1,10 +1,11 @@
 import returnLogData from '../data/return-log.data.js'
 import returnRequirementData from '../data/return-requirement.data.js'
+import returnRequirementPointData from '../data/return-requirement-point.data.js'
+import returnRequirementPurposeData from '../data/return-requirement-purpose.data.js'
 import returnSubmissionData from '../data/return-submission.data.js'
 import returnVersionData from '../data/return-version.data.js'
 import licenceWithChargeVersionAndTwoPurposesScenario from './licence-with-charge-version-and-two-purposes.scenario.js'
 import { previousPeriod } from '../helpers/date.helpers.js'
-import { mergeByKey } from '../helpers/scenario.helpers.js'
 
 export const title = 'Licence with tpt charge version and two completed return logs'
 export const description =
@@ -29,52 +30,79 @@ export default function (calculatedDates) {
 
   const licence = licenceWithChargeVersionAndTwoPurposesScenario()
 
-  const returnVersion = returnVersionData(licence)
+  const returnVersion = returnVersionData(licence.licence)
 
   // In the service return logs will cover the whole period of their matching return version. To ensure our test data is
   // realistic, we alter the start date of the return version to match the first return log we're seeding.
-  returnVersion.returnVersions[0].startDate = previousPeriodDetails.startDate
+  returnVersion.startDate = previousPeriodDetails.startDate
 
-  const {
-    licenceVersionPurposes: [firstLicenceVersionPurpose, secondLicenceVersionPurpose],
-    points: [firstPoint, secondPoint]
-  } = licence
+  const [firstLicenceVersionPurpose, secondLicenceVersionPurpose] = licence.licenceVersionPurposes
+  const [firstPoint, secondPoint] = licence.points
 
-  const firstReturnRequirement = returnRequirementData(returnVersion, firstLicenceVersionPurpose, [firstPoint])
+  const firstReturnRequirement = returnRequirementData(returnVersion, firstLicenceVersionPurpose)
+  const firstReturnRequirementPoint = returnRequirementPointData(firstReturnRequirement, firstPoint)
+  const firstReturnRequirementPurpose = returnRequirementPurposeData(firstReturnRequirement, firstLicenceVersionPurpose)
 
-  const previousFirstReturnLog = returnLogData(licence, firstReturnRequirement, previousPeriodDetails)
-  const currentFirstReturnLog = returnLogData(licence, firstReturnRequirement, currentPeriodDetails)
+  const previousFirstReturnLog = returnLogData(
+    licence.licence,
+    firstReturnRequirement,
+    [firstReturnRequirementPurpose],
+    [firstPoint],
+    previousPeriodDetails
+  )
+  const currentFirstReturnLog = returnLogData(
+    licence.licence,
+    firstReturnRequirement,
+    [firstReturnRequirementPurpose],
+    [firstPoint],
+    currentPeriodDetails
+  )
 
-  previousFirstReturnLog.returnLogs[0].status = 'completed'
+  previousFirstReturnLog.status = 'completed'
 
-  const secondReturnRequirement = returnRequirementData(returnVersion, secondLicenceVersionPurpose, [secondPoint])
+  const secondReturnRequirement = returnRequirementData(returnVersion, secondLicenceVersionPurpose)
+  const secondReturnRequirementPoint = returnRequirementPointData(secondReturnRequirement, secondPoint)
+  const secondReturnRequirementPurpose = returnRequirementPurposeData(
+    secondReturnRequirement,
+    secondLicenceVersionPurpose
+  )
 
-  const previousSecondReturnLog = returnLogData(licence, secondReturnRequirement, previousPeriodDetails)
-  const currentSecondReturnLog = returnLogData(licence, secondReturnRequirement, currentPeriodDetails)
+  const previousSecondReturnLog = returnLogData(
+    licence.licence,
+    secondReturnRequirement,
+    [secondReturnRequirementPurpose],
+    [secondPoint],
+    previousPeriodDetails
+  )
+  const currentSecondReturnLog = returnLogData(
+    licence.licence,
+    secondReturnRequirement,
+    [secondReturnRequirementPurpose],
+    [secondPoint],
+    currentPeriodDetails
+  )
 
-  previousSecondReturnLog.returnLogs[0].status = 'completed'
+  previousSecondReturnLog.status = 'completed'
 
-  const firstReturnSubmission = returnSubmissionData(
+  const firstSubmission = returnSubmissionData(
     previousPeriodDetails,
     previousFirstReturnLog,
     firstLicenceVersionPurpose.annualQuantity
   )
-  const secondReturnSubmission = returnSubmissionData(
+  const secondSubmission = returnSubmissionData(
     previousPeriodDetails,
     previousSecondReturnLog,
     secondLicenceVersionPurpose.annualQuantity
   )
 
-  return mergeByKey(
-    licence,
+  return {
+    ...licence,
     returnVersion,
-    firstReturnRequirement,
-    secondReturnRequirement,
-    previousFirstReturnLog,
-    previousSecondReturnLog,
-    currentFirstReturnLog,
-    currentSecondReturnLog,
-    firstReturnSubmission,
-    secondReturnSubmission
-  )
+    returnRequirements: [firstReturnRequirement, secondReturnRequirement],
+    returnRequirementPoints: [firstReturnRequirementPoint, secondReturnRequirementPoint],
+    returnRequirementPurposes: [firstReturnRequirementPurpose, secondReturnRequirementPurpose],
+    returnLogs: [previousFirstReturnLog, currentFirstReturnLog, previousSecondReturnLog, currentSecondReturnLog],
+    returnSubmissions: [firstSubmission.returnSubmission, secondSubmission.returnSubmission],
+    returnSubmissionLines: [...firstSubmission.returnSubmissionLines, ...secondSubmission.returnSubmissionLines]
+  }
 }

--- a/tests/support/scenarios/licence-with-tpt-return-log-and-bill-run.scenario.js
+++ b/tests/support/scenarios/licence-with-tpt-return-log-and-bill-run.scenario.js
@@ -1,10 +1,11 @@
 import billRunData from '../data/bill-run.data.js'
 import returnLogData from '../data/return-log.data.js'
 import returnRequirementData from '../data/return-requirement.data.js'
+import returnRequirementPointData from '../data/return-requirement-point.data.js'
+import returnRequirementPurposeData from '../data/return-requirement-purpose.data.js'
 import returnVersionData from '../data/return-version.data.js'
 import licenceWithChargeVersionScenario from './licence-with-charge-version.scenario.js'
 import { previousPeriod } from '../helpers/date.helpers.js'
-import { mergeByKey } from '../helpers/scenario.helpers.js'
 
 export const title = 'Licence with a two-part tariff return log and bill run'
 export const description =
@@ -22,27 +23,44 @@ export default function (calculatedDates) {
 
   const licence = licenceWithChargeVersionScenario()
 
-  const returnVersion = returnVersionData(licence)
+  const returnVersion = returnVersionData(licence.licence)
 
   // In the service return logs will cover the whole period of their matching return version. To ensure our test data is
   // realistic, we alter the start date of the return version to match the return log we're seeding.
-  returnVersion.returnVersions[0].startDate = previousPeriodDetails.startDate
+  returnVersion.startDate = previousPeriodDetails.startDate
 
-  const returnRequirement = returnRequirementData(returnVersion, licence)
+  const returnRequirement = returnRequirementData(returnVersion, licence.licenceVersionPurpose)
 
-  returnRequirement.returnRequirements[0].twoPartTariff = true
+  returnRequirement.twoPartTariff = true
 
-  const returnLog = returnLogData(licence, returnRequirement, previousPeriodDetails)
+  const returnRequirementPoint = returnRequirementPointData(returnRequirement, licence.point)
+  const returnRequirementPurpose = returnRequirementPurposeData(returnRequirement, licence.licenceVersionPurpose)
 
-  returnLog.returnLogs[0].status = 'completed'
+  const returnLog = returnLogData(
+    licence.licence,
+    returnRequirement,
+    [returnRequirementPurpose],
+    [licence.point],
+    previousPeriodDetails
+  )
+
+  returnLog.status = 'completed'
 
   const financialYearEnding = previousPeriodDetails.endDate.getFullYear()
 
   const billRun = billRunData()
 
-  billRun.billRuns[0].batchType = 'two_part_tariff'
-  billRun.billRuns[0].fromFinancialYearEnding = financialYearEnding
-  billRun.billRuns[0].toFinancialYearEnding = financialYearEnding
+  billRun.batchType = 'two_part_tariff'
+  billRun.fromFinancialYearEnding = financialYearEnding
+  billRun.toFinancialYearEnding = financialYearEnding
 
-  return mergeByKey(licence, returnVersion, returnRequirement, returnLog, billRun)
+  return {
+    ...licence,
+    returnVersion,
+    returnRequirement,
+    returnRequirementPoint,
+    returnRequirementPurpose,
+    returnLog,
+    billRun
+  }
 }

--- a/tests/support/scenarios/licence-with-two-purposes-and-requirements.scenario.js
+++ b/tests/support/scenarios/licence-with-two-purposes-and-requirements.scenario.js
@@ -1,7 +1,8 @@
 import returnRequirementData from '../data/return-requirement.data.js'
+import returnRequirementPointData from '../data/return-requirement-point.data.js'
+import returnRequirementPurposeData from '../data/return-requirement-purpose.data.js'
 import returnVersionData from '../data/return-version.data.js'
 import licenceWithTwoPurposesScenario from './licence-with-two-purposes.scenario.js'
-import { mergeByKey } from '../helpers/scenario.helpers.js'
 
 export const title = 'Licence with two purposes and a return requirement'
 export const description =
@@ -10,14 +11,21 @@ export const description =
 export default function () {
   const licence = licenceWithTwoPurposesScenario()
 
-  const returnVersion = returnVersionData(licence)
+  const returnVersion = returnVersionData(licence.licence)
 
-  const {
-    licenceVersionPurposes: [licenceVersionPurpose],
-    points
-  } = licence
+  const [licenceVersionPurpose] = licence.licenceVersionPurposes
 
-  const returnRequirement = returnRequirementData(returnVersion, licenceVersionPurpose, points)
+  const returnRequirement = returnRequirementData(returnVersion, licenceVersionPurpose)
+  const returnRequirementPoints = licence.points.map((point) => {
+    return returnRequirementPointData(returnRequirement, point)
+  })
+  const returnRequirementPurpose = returnRequirementPurposeData(returnRequirement, licenceVersionPurpose)
 
-  return mergeByKey(licence, returnVersion, returnRequirement)
+  return {
+    ...licence,
+    returnVersion,
+    returnRequirement,
+    returnRequirementPoints,
+    returnRequirementPurpose
+  }
 }

--- a/tests/support/scenarios/licence-with-workflow-and-annual-bill-run.scenario.js
+++ b/tests/support/scenarios/licence-with-workflow-and-annual-bill-run.scenario.js
@@ -2,7 +2,6 @@ import billRunData from '../data/bill-run.data.js'
 import licenceWithChargeVersionScenario from './licence-with-charge-version.scenario.js'
 import workflowData from '../data/workflow.data.js'
 import { today, yesterday } from '../helpers/date.helpers.js'
-import { mergeByKey } from '../helpers/scenario.helpers.js'
 
 export const title = 'Licence in workflow, and an annual bill run'
 export const description =
@@ -22,17 +21,21 @@ export default function (calculatedDates) {
     }
   } = calculatedDates
 
-  const annualBillRun = billRunData()
+  const billRun = billRunData()
 
-  annualBillRun.billRuns[0].createdAt = today()
-  annualBillRun.billRuns[0].fromFinancialYearEnding = new Date(annualDates.endDate).getUTCFullYear()
-  annualBillRun.billRuns[0].toFinancialYearEnding = new Date(annualDates.endDate).getUTCFullYear()
+  billRun.createdAt = today()
+  billRun.fromFinancialYearEnding = new Date(annualDates.endDate).getUTCFullYear()
+  billRun.toFinancialYearEnding = new Date(annualDates.endDate).getUTCFullYear()
 
-  const workflow = workflowData(licence)
+  const workflow = workflowData(licence.licence)
 
   // The workflow createdAt date is used to show the supplementary billing flag.
-  workflow.workflows[0].createdAt = yesterday()
-  workflow.workflows[0].updatedAt = yesterday()
+  workflow.createdAt = yesterday()
+  workflow.updatedAt = yesterday()
 
-  return mergeByKey(licence, annualBillRun, workflow)
+  return {
+    ...licence,
+    billRun,
+    workflow
+  }
 }

--- a/tests/support/scenarios/licence-with-workflow-and-two-part-tariff-bill-run.scenario.js
+++ b/tests/support/scenarios/licence-with-workflow-and-two-part-tariff-bill-run.scenario.js
@@ -2,7 +2,6 @@ import billRunData from '../data/bill-run.data.js'
 import licenceWithChargeVersionScenario from './licence-with-charge-version.scenario.js'
 import workflowData from '../data/workflow.data.js'
 import { today, yesterday } from '../helpers/date.helpers.js'
-import { mergeByKey } from '../helpers/scenario.helpers.js'
 
 export const title = 'Licence in workflow, and a two-part tariff bill run'
 export const description =
@@ -22,19 +21,23 @@ export default function (calculatedDates) {
     }
   } = calculatedDates
 
-  const twoPartTariffBillRun = billRunData()
+  const billRun = billRunData()
 
-  twoPartTariffBillRun.billRuns[0].createdAt = today()
-  twoPartTariffBillRun.billRuns[0].batchType = 'two_part_tariff'
-  twoPartTariffBillRun.billRuns[0].fromFinancialYearEnding = new Date(twoPartTariffDates.endDate).getUTCFullYear()
-  twoPartTariffBillRun.billRuns[0].toFinancialYearEnding = new Date(twoPartTariffDates.endDate).getUTCFullYear()
+  billRun.createdAt = today()
+  billRun.batchType = 'two_part_tariff'
+  billRun.fromFinancialYearEnding = new Date(twoPartTariffDates.endDate).getUTCFullYear()
+  billRun.toFinancialYearEnding = new Date(twoPartTariffDates.endDate).getUTCFullYear()
 
-  const workflow = workflowData(licence)
+  const workflow = workflowData(licence.licence)
 
   // The workflow createdAt date is used to show the supplementary billing flag.
   // It should be set to a date before the two-part tariff bill run's end date.
-  workflow.workflows[0].createdAt = `${new Date(twoPartTariffDates.endDate).getUTCFullYear()}-01-01`
-  workflow.workflows[0].updatedAt = yesterday()
+  workflow.createdAt = `${new Date(twoPartTariffDates.endDate).getUTCFullYear()}-01-01`
+  workflow.updatedAt = yesterday()
 
-  return mergeByKey(licence, twoPartTariffBillRun, workflow)
+  return {
+    ...licence,
+    billRun,
+    workflow
+  }
 }

--- a/tests/support/scenarios/presroc-licence-with-agreement.scenario.js
+++ b/tests/support/scenarios/presroc-licence-with-agreement.scenario.js
@@ -1,6 +1,5 @@
 import licenceAgreementData from '../data/licence-agreement.data.js'
 import presrocLicenceScenario from './presroc-licence.scenario.js'
-import { mergeByKey } from '../helpers/scenario.helpers.js'
 
 export const title = 'Presroc licence with an agreement'
 export const description = 'A presroc licence, licence holder (company) and a two-part tariff agreement'
@@ -8,7 +7,10 @@ export const description = 'A presroc licence, licence holder (company) and a tw
 export default function () {
   const licence = presrocLicenceScenario()
 
-  const licenceAgreement = licenceAgreementData(licence)
+  const licenceAgreement = licenceAgreementData(licence.licence)
 
-  return mergeByKey(licence, licenceAgreement)
+  return {
+    ...licence,
+    licenceAgreement
+  }
 }

--- a/tests/support/scenarios/presroc-licence-with-charge-version.scenario.js
+++ b/tests/support/scenarios/presroc-licence-with-charge-version.scenario.js
@@ -1,8 +1,8 @@
+import billingAccountAddressData from '../data/billing-account-address.data.js'
 import billingAccountData from '../data/billing-account.data.js'
-import chargeVersionData from '../data/charge-version.data.js'
 import chargeReferenceData from '../data/charge-reference-presroc.data.js'
+import chargeVersionData from '../data/charge-version.data.js'
 import presrocLicenceScenario from './presroc-licence.scenario.js'
-import { mergeByKey } from '../helpers/scenario.helpers.js'
 
 export const title = 'Presroc licence with a charge version'
 export const description =
@@ -11,13 +11,20 @@ export const description =
 export default function () {
   const licence = presrocLicenceScenario()
 
-  const billingAccount = billingAccountData(licence)
-  const chargeVersion = chargeVersionData(billingAccount, licence)
+  const billingAccount = billingAccountData(licence.company)
+  const billingAccountAddress = billingAccountAddressData(billingAccount, licence.address)
+  const chargeVersion = chargeVersionData(billingAccount, licence.licence)
 
   // charge-version.data.js hardcodes the scheme to sroc, so we override it to alcs to match the presroc start date
-  chargeVersion.chargeVersions[0].scheme = 'alcs'
+  chargeVersion.scheme = 'alcs'
 
-  const chargeReference = chargeReferenceData(chargeVersion, licence)
+  const chargeReference = chargeReferenceData(chargeVersion, licence.licenceVersionPurpose)
 
-  return mergeByKey(licence, billingAccount, chargeVersion, chargeReference)
+  return {
+    ...licence,
+    billingAccount,
+    billingAccountAddress,
+    chargeVersion,
+    chargeReference
+  }
 }

--- a/tests/support/scenarios/registered-licence-for-renewal-invitation.scenario.js
+++ b/tests/support/scenarios/registered-licence-for-renewal-invitation.scenario.js
@@ -8,16 +8,12 @@ export const description =
 export default function () {
   const registeredLicence = registeredLicenceScenario()
 
-  const {
-    licences: [licence]
-  } = registeredLicence
-
   // The expired date needs to be more than 90 days in the future for the licence to be eligible for a renewal invitation.
   const expiredDate = new Date()
 
   expiredDate.setDate(expiredDate.getDate() + 91)
 
-  licence.expiredDate = formatDateToIso(expiredDate)
+  registeredLicence.licence.expiredDate = formatDateToIso(expiredDate)
 
   return registeredLicence
 }

--- a/tests/support/scenarios/registered-licence-with-all-return-log-statuses.scenario.js
+++ b/tests/support/scenarios/registered-licence-with-all-return-log-statuses.scenario.js
@@ -1,6 +1,5 @@
 import primaryUserData from '../data/primary-user.data.js'
 import licenceWithAllReturnLogStatuses from './licence-with-all-return-log-statuses.scenario.js'
-import { mergeByKey } from '../helpers/scenario.helpers.js'
 import { externalUserEmail } from '../default-values.js'
 
 export const title = 'Registered licence with all return log statuses'
@@ -9,11 +8,14 @@ export const description = 'Registered licence with return logs covering all pos
 export default function (calculatedDates) {
   const licence = licenceWithAllReturnLogStatuses(calculatedDates)
 
-  const primaryUser = primaryUserData(externalUserEmail, licence)
+  const primaryUser = primaryUserData(externalUserEmail, licence.company)
 
-  // Linking a primary user's company entity to the licence's 'licenceDocumentHeaders' is the only way we can link a
+  // Linking a primary user's company entity to the licence's licence document header is the only way we can link a
   // registered licence to a licence holder.
-  licence.licenceDocumentHeaders[0].companyEntityId = primaryUser.licenceEntityRoles[0].companyEntityId
+  licence.licenceDocumentHeader.companyEntityId = primaryUser.licenceEntityRole.companyEntityId
 
-  return mergeByKey(licence, primaryUser)
+  return {
+    ...licence,
+    ...primaryUser
+  }
 }

--- a/tests/support/scenarios/registered-licence-with-due-winter-return-log.scenario.js
+++ b/tests/support/scenarios/registered-licence-with-due-winter-return-log.scenario.js
@@ -1,6 +1,5 @@
 import primaryUserData from '../data/primary-user.data.js'
 import licenceWithDueWinterReturnLog from './licence-with-due-winter-return-log.scenario.js'
-import { mergeByKey } from '../helpers/scenario.helpers.js'
 
 export const title = 'Registered licence with a due return log (winter cycle)'
 export const description =
@@ -11,11 +10,14 @@ export default function (calculatedDates) {
   const licence = licenceWithDueWinterReturnLog(calculatedDates)
 
   // We then add the primary user, which is what makes the licence 'registered'
-  const primaryUser = primaryUserData('external@example.com', licence)
+  const primaryUser = primaryUserData('external@example.com', licence.company)
 
-  // Linking a primary user's company entity to the licence's 'licenceDocumentHeaders' is the only way we can link a
+  // Linking a primary user's company entity to the licence's licence document header is the only way we can link a
   // registered licence to a licence holder.
-  licence.licenceDocumentHeaders[0].companyEntityId = primaryUser.licenceEntityRoles[0].companyEntityId
+  licence.licenceDocumentHeader.companyEntityId = primaryUser.licenceEntityRole.companyEntityId
 
-  return mergeByKey(licence, primaryUser)
+  return {
+    ...licence,
+    ...primaryUser
+  }
 }

--- a/tests/support/scenarios/registered-licence-with-monitoring-station-tagged.scenario.js
+++ b/tests/support/scenarios/registered-licence-with-monitoring-station-tagged.scenario.js
@@ -1,7 +1,6 @@
 import licenceMonitoringStationData from '../data/licence-monitoring-station.data.js'
 import licenceVersionPurposeConditionData from '../data/licence-version-purpose-condition.data.js'
 import registeredLicenceWithMonitoringStationUntaggedScenario from './registered-licence-with-monitoring-station-untagged.scenario.js'
-import { mergeByKey } from '../helpers/scenario.helpers.js'
 
 export const title = 'Registered licence with monitoring station tagged'
 export const description = 'Registered licence with a licence linked to a monitoring station'
@@ -12,16 +11,14 @@ export const description = 'Registered licence with a licence linked to a monito
  * We seed a separate 'licenceVersionPurposeCondition' on the licence, available for a test to select when tagging.
  */
 export default function () {
-  const registeredLicenceWithMonitoringStationUntagged = registeredLicenceWithMonitoringStationUntaggedScenario()
+  const licence = registeredLicenceWithMonitoringStationUntaggedScenario()
 
-  const licenceVersionPurposeCondition = licenceVersionPurposeConditionData(
-    registeredLicenceWithMonitoringStationUntagged
-  )
-  const licenceMonitoringStation = licenceMonitoringStationData(registeredLicenceWithMonitoringStationUntagged)
+  const licenceVersionPurposeCondition = licenceVersionPurposeConditionData(licence.licenceVersionPurpose)
+  const licenceMonitoringStation = licenceMonitoringStationData(licence.licence, licence.monitoringStation)
 
-  return mergeByKey(
-    registeredLicenceWithMonitoringStationUntagged,
+  return {
+    ...licence,
     licenceVersionPurposeCondition,
     licenceMonitoringStation
-  )
+  }
 }

--- a/tests/support/scenarios/registered-licence-with-monitoring-station-untagged.scenario.js
+++ b/tests/support/scenarios/registered-licence-with-monitoring-station-untagged.scenario.js
@@ -1,6 +1,5 @@
 import monitoringStationData from '../data/monitoring-station.data.js'
 import registeredLicenceScenario from './registered-licence.scenario.js'
-import { mergeByKey } from '../helpers/scenario.helpers.js'
 
 export const title = 'Registered licence with monitoring station (untagged)'
 export const description = 'Registered licence and monitoring station created separately with no tag between them'
@@ -12,5 +11,8 @@ export default function () {
   const registeredLicence = registeredLicenceScenario()
   const monitoringStation = monitoringStationData()
 
-  return mergeByKey(registeredLicence, monitoringStation)
+  return {
+    ...registeredLicence,
+    monitoringStation
+  }
 }

--- a/tests/support/scenarios/registered-licence-with-open-return-log-for-first-period.scenario.js
+++ b/tests/support/scenarios/registered-licence-with-open-return-log-for-first-period.scenario.js
@@ -1,6 +1,5 @@
 import primaryUserData from '../data/primary-user.data.js'
 import licenceWithOpenReturnLogForFirstPeriod from './licence-with-open-return-log-for-first-period.scenario.js'
-import { mergeByKey } from '../helpers/scenario.helpers.js'
 import { externalUserEmail } from '../default-values.js'
 
 export const title = 'Registered licence with open return log (first period)'
@@ -11,11 +10,14 @@ export default function (calculatedDates) {
   const licence = licenceWithOpenReturnLogForFirstPeriod(calculatedDates)
 
   // We then add the primary user, which is what makes the licence 'registered'
-  const primaryUser = primaryUserData(externalUserEmail, licence)
+  const primaryUser = primaryUserData(externalUserEmail, licence.company)
 
-  // Linking a primary user's company entity to the licence's 'licenceDocumentHeaders' is the only way we can link a
+  // Linking a primary user's company entity to the licence's licence document header is the only way we can link a
   // registered licence to a licence holder.
-  licence.licenceDocumentHeaders[0].companyEntityId = primaryUser.licenceEntityRoles[0].companyEntityId
+  licence.licenceDocumentHeader.companyEntityId = primaryUser.licenceEntityRole.companyEntityId
 
-  return mergeByKey(licence, primaryUser)
+  return {
+    ...licence,
+    ...primaryUser
+  }
 }

--- a/tests/support/scenarios/registered-licence-with-open-winter-return-log-bad-email.scenario.js
+++ b/tests/support/scenarios/registered-licence-with-open-winter-return-log-bad-email.scenario.js
@@ -7,10 +7,8 @@ export const description =
 export default function (calculatedDates) {
   const registeredLicenceWithOpenWinterReturnLog = registeredLicenceWithOpenWinterReturnLogScenario(calculatedDates)
 
-  const {
-    addresses: [address],
-    licenceEntities: [licenceEntity]
-  } = registeredLicenceWithOpenWinterReturnLog
+  const { address } = registeredLicenceWithOpenWinterReturnLog
+  const [licenceEntity] = registeredLicenceWithOpenWinterReturnLog.licenceEntities
 
   // We'll only set the due date on the OPEN return log if the alternate notification is successful. The Notify
   // service will reject the request if the address is not real, even though we're using our Notify test API key.

--- a/tests/support/scenarios/registered-licence-with-open-winter-return-log.scenario.js
+++ b/tests/support/scenarios/registered-licence-with-open-winter-return-log.scenario.js
@@ -1,6 +1,5 @@
 import primaryUserData from '../data/primary-user.data.js'
 import licenceWithOpenWinterReturnLog from './licence-with-open-winter-return-log.scenario.js'
-import { mergeByKey } from '../helpers/scenario.helpers.js'
 
 export const title = 'Registered licence with an open return log (winter cycle)'
 export const description =
@@ -11,11 +10,14 @@ export default function (calculatedDates) {
   const licence = licenceWithOpenWinterReturnLog(calculatedDates)
 
   // We then add the primary user, which is what makes the licence 'registered'
-  const primaryUser = primaryUserData('external@example.com', licence)
+  const primaryUser = primaryUserData('external@example.com', licence.company)
 
-  // Linking a primary user's company entity to the licence's 'licenceDocumentHeaders' is the only way we can link a
+  // Linking a primary user's company entity to the licence's licence document header is the only way we can link a
   // registered licence to a licence holder.
-  licence.licenceDocumentHeaders[0].companyEntityId = primaryUser.licenceEntityRoles[0].companyEntityId
+  licence.licenceDocumentHeader.companyEntityId = primaryUser.licenceEntityRole.companyEntityId
 
-  return mergeByKey(licence, primaryUser)
+  return {
+    ...licence,
+    ...primaryUser
+  }
 }

--- a/tests/support/scenarios/water-company-licence-with-open-winter-return-log.scenario.js
+++ b/tests/support/scenarios/water-company-licence-with-open-winter-return-log.scenario.js
@@ -7,7 +7,7 @@ export const description =
 export default function (calculatedDates) {
   const licence = licenceWithOpenWinterReturnLog(calculatedDates)
 
-  licence.licences[0].waterUndertaker = true
+  licence.licence.waterUndertaker = true
 
   return licence
 }


### PR DESCRIPTION
This continues the single-object migration, working through every scenario built on top of the ones migrated in the previous PR: the presroc-licence extenders, the registered-licence extenders, the licence-with-charge-version extenders (bill runs and return logs), the four return-log-based scenario families, and the licence-with-two-purposes extenders.

Same pattern throughout: split any newly-touched multi-entity data file into one file per entity (billing-account, return-requirement, return-submission, contact, primary-user's two licenceEntities rows), have each return the bare entity, and compose scenarios with a plain object spread instead of mergeByKey. Also fixed a pre-existing bug found along the way: licence-with-tpt-return-log-and-bill-run.scenario.js was passing the whole licence object where returnRequirementData expected a licenceVersionPurpose, which the new function signature surfaces immediately rather than silently misusing the data.

licence-with-two-purposes-and-requirements and licence-with-charge-version-and-two-purposes are included but parked alongside their still-unresolved licence-with-two-purposes base — verified correct at the data level, but their specs fail downstream of the same unresolved app-side issue. Every other scenario in this PR is verified end-to-end against a local environment; the handful without a direct spec are verified by inspecting the seeded payload's FK linkage instead.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>