### PR TITLE
Fix lic with tpt rtn log & bill run scenario

### DIFF
--- a/tests/support/scenarios/licence-with-tpt-return-log-and-bill-run.scenario.js
+++ b/tests/support/scenarios/licence-with-tpt-return-log-and-bill-run.scenario.js
@@ -28,7 +28,12 @@ export default function (calculatedDates) {
   // realistic, we alter the start date of the return version to match the return log we're seeding.
   returnVersion.returnVersions[0].startDate = previousPeriodDetails.startDate
 
-  const returnRequirement = returnRequirementData(returnVersion, licence)
+  const {
+    licenceVersionPurposes: [licenceVersionPurpose],
+    points
+  } = licence
+
+  const returnRequirement = returnRequirementData(returnVersion, licenceVersionPurpose, points)
 
   returnRequirement.returnRequirements[0].twoPartTariff = true
 


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5722

The scenario and test were added when we [Migrated editing-a-return supplementary billing flag test to Playwright](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/328).

But we also had [another change](https://github.com/DEFRA/water-abstraction-acceptance-tests/pull/322) that amended the way return requirements are generated.

The scenario is not up to date with that change, so the test is failing.

This change fixes it.