### PR TITLE
Fix Cypress billing fixtures 

### DIFF
--- a/cypress/fixtures/sroc-billing.json
+++ b/cypress/fixtures/sroc-billing.json
@@ -601,7 +601,6 @@
       "source": "tidal",
       "loss": "medium",
       "restrictedSource": false,
-      "factorsOverridden": false,
       "chargeCategoryId": {
         "schema": "public",
         "table": "chargeCategories",
@@ -612,7 +611,16 @@
       "waterModel": "no model",
       "volume": 100,
       "eiucRegion": "Southern",
-      "section127Agreement": false
+      "section127Agreement": false,
+      "additionalCharges": {},
+      "adjustments": {
+        "aggregate": null,
+        "s126": null,
+        "s127": false,
+        "s130": false,
+        "charge": null,
+        "winter": false
+      }
     },
     {
       "id": "851cbb90-f85d-4f1d-b8ef-9f493be00d46",
@@ -660,7 +668,6 @@
       "source": "tidal",
       "loss": "medium",
       "restrictedSource": false,
-      "factorsOverridden": false,
       "chargeCategoryId": {
         "schema": "public",
         "table": "chargeCategories",
@@ -671,7 +678,16 @@
       "waterModel": "no model",
       "volume": 100,
       "eiucRegion": "Southern",
-      "section127Agreement": false
+      "section127Agreement": false,
+      "additionalCharges": {},
+      "adjustments": {
+        "aggregate": null,
+        "s126": null,
+        "s127": false,
+        "s130": false,
+        "charge": null,
+        "winter": false
+      }
     },
     {
       "id": "3e9fb51f-644e-47f9-b2df-e61f7435f2d3",
@@ -719,7 +735,6 @@
       "source": "tidal",
       "loss": "medium",
       "restrictedSource": false,
-      "factorsOverridden": false,
       "chargeCategoryId": {
         "schema": "public",
         "table": "chargeCategories",
@@ -730,7 +745,16 @@
       "waterModel": "no model",
       "volume": 100,
       "eiucRegion": "Southern",
-      "section127Agreement": false
+      "section127Agreement": false,
+      "additionalCharges": {},
+      "adjustments": {
+        "aggregate": null,
+        "s126": null,
+        "s127": false,
+        "s130": false,
+        "charge": null,
+        "winter": false
+      }
     },
     {
       "id": "66576363-83df-46b8-80d5-3642382105fb",
@@ -740,7 +764,6 @@
       "source": "tidal",
       "loss": "medium",
       "restrictedSource": false,
-      "factorsOverridden": false,
       "chargeCategoryId": {
         "schema": "public",
         "table": "chargeCategories",
@@ -751,7 +774,16 @@
       "waterModel": "no model",
       "volume": 100,
       "eiucRegion": "Southern",
-      "section127Agreement": false
+      "section127Agreement": false,
+      "additionalCharges": {},
+      "adjustments": {
+        "aggregate": null,
+        "s126": null,
+        "s127": false,
+        "s130": false,
+        "charge": null,
+        "winter": false
+      }
     },
     {
       "id": "57474972-5978-4399-a189-50e71b6c71a9",
@@ -761,7 +793,6 @@
       "source": "tidal",
       "loss": "medium",
       "restrictedSource": false,
-      "factorsOverridden": false,
       "chargeCategoryId": {
         "schema": "public",
         "table": "chargeCategories",
@@ -772,7 +803,16 @@
       "waterModel": "no model",
       "volume": 750,
       "eiucRegion": "Southern",
-      "section127Agreement": false
+      "section127Agreement": false,
+      "additionalCharges": {},
+      "adjustments": {
+        "aggregate": null,
+        "s126": null,
+        "s127": false,
+        "s130": false,
+        "charge": null,
+        "winter": false
+      }
     }
   ],
   "chargeElements": [
@@ -786,7 +826,6 @@
       "authorisedAnnualQuantity": 15.54,
       "section127Agreement": false,
       "loss": "medium",
-      "factorsOverridden": false,
       "description": "SROC Charge Purpose 01",
       "purposeId": {
         "schema": "public",
@@ -820,7 +859,6 @@
       "authorisedAnnualQuantity": 15.54,
       "section127Agreement": false,
       "loss": "medium",
-      "factorsOverridden": false,
       "description": "SROC Charge Purpose 02",
       "purposeId": {
         "schema": "public",
@@ -854,7 +892,6 @@
       "authorisedAnnualQuantity": 15.54,
       "section127Agreement": false,
       "loss": "medium",
-      "factorsOverridden": false,
       "description": "SROC Charge Purpose 03",
       "purposeId": {
         "schema": "public",
@@ -888,7 +925,6 @@
       "authorisedAnnualQuantity": 15.54,
       "section127Agreement": false,
       "loss": "medium",
-      "factorsOverridden": false,
       "description": "SROC Charge Purpose 04",
       "purposeId": {
         "schema": "public",
@@ -922,7 +958,6 @@
       "authorisedAnnualQuantity": 10.5,
       "section127Agreement": false,
       "loss": "medium",
-      "factorsOverridden": false,
       "description": "SROC Charge Purpose 05",
       "purposeId": {
         "schema": "public",
@@ -956,7 +991,6 @@
       "authorisedAnnualQuantity": 12.5,
       "section127Agreement": false,
       "loss": "medium",
-      "factorsOverridden": false,
       "description": "SROC Charge Purpose 06",
       "purposeId": {
         "schema": "public",

--- a/cypress/fixtures/sroc-two-part-tariff-simple-licence-data.json
+++ b/cypress/fixtures/sroc-two-part-tariff-simple-licence-data.json
@@ -105,9 +105,10 @@
       "id": "fa3c73d0-0459-41f0-b6cf-0e0758775ca4",
       "chargeVersionId": "8e5626ee-5e4c-48f6-a668-471d35997e2c",
       "description": "SROC Charge Reference 01",
+      "scheme": "sroc",
       "source": "tidal",
       "loss": "medium",
-      "factorsOverridden": false,
+      "restrictedSource": false,
       "chargeCategoryId": {
         "schema": "public",
         "table": "chargeCategories",
@@ -115,17 +116,18 @@
         "value": "4.6.12",
         "select": "id"
       },
+      "waterModel": "no model",
+      "volume": 32,
+      "eiucRegion": "Southern",
+      "section127Agreement": true,
+      "additionalCharges": {},
       "adjustments": {
         "s126": null,
         "s127": true,
         "s130": false,
         "charge": null,
         "winter": false
-      },
-      "waterModel": "no model",
-      "volume": 32,
-      "eiucRegion": "Southern",
-      "section127Agreement": true
+      }
     }
   ],
   "chargeElements": [

--- a/cypress/support/fixture-builder/charge-references.js
+++ b/cypress/support/fixture-builder/charge-references.js
@@ -62,9 +62,10 @@ function _srocChargeReference(chargeVersion) {
     id: 'fa3c73d0-0459-41f0-b6cf-0e0758775ca4',
     chargeVersionId: chargeVersion.id,
     description: 'SROC Charge Reference',
+    scheme: 'sroc',
     source: 'tidal',
     loss: 'medium',
-    factorsOverridden: false,
+    restrictedSource: false,
     chargeCategoryId: {
       schema: 'public',
       table: 'chargeCategories',
@@ -72,6 +73,11 @@ function _srocChargeReference(chargeVersion) {
       value: '4.6.12',
       select: 'id'
     },
+    waterModel: 'no model',
+    volume: 32,
+    eiucRegion: 'Southern',
+    section127Agreement: false,
+    additionalCharges: {},
     adjustments: {
       aggregate: null,
       s126: null,
@@ -79,10 +85,6 @@ function _srocChargeReference(chargeVersion) {
       s130: false,
       charge: null,
       winter: false
-    },
-    waterModel: 'no model',
-    volume: 32,
-    eiucRegion: 'Southern',
-    section127Agreement: false
+    }
   }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5722

As part of migrating to Playwright, we realised there was an issue with some data we were trying to seed.

The Loader in **water-abstraction-system** relies on the test helpers. Initially, we created them to default most fields to reduce the load in the tests.

But we quickly realised that due to the complexity of the data, we'd often need to undo those defaults. So, we quickly switched to _only_ setting the minimum required to allow the INSERT to work. The tests are responsible for setting everything else.

The `ChargeReference` and `ChargeElement` helpers were still setting the record as if it was always SROC, and populating more fields than necessary.

We [updated it](https://github.com/DEFRA/water-abstraction-system/pull/3564) to only set the mandatory fields, but this has broken some of the Cypress tests. It looks like the old JSON fixtures were relying on the loader and the helpers to set certain values. Their not being set was causing the bill run engine to blow up.

This updates them to set the fields that are required for the bill run engine to work.