### PR TITLE
Refactor licence.entity.js consumers to buildLicenceEntity pattern

### DIFF
--- a/tests/support/scenarios/company-contact.scenario.js
+++ b/tests/support/scenarios/company-contact.scenario.js
@@ -1,42 +1,42 @@
 import companyContactData from '../data/company-contact.data.js'
 import contactData from '../data/contact.data.js'
 import notificationData from '../data/notification.data.js'
-import licenceEntity from '../entities/licence.entity.js'
+import buildLicenceEntity from '../entities/licence.entity.js'
 
 export const title = 'Company contact'
 export const description = 'A licence, licence holder, company, a contact and notification data'
 
 export default function () {
-  const licence = licenceEntity()
+  const licenceEntity = buildLicenceEntity()
 
   const contact = contactData()
-  const companyContact = companyContactData(contact, licence.company)
+  const companyContact = companyContactData(contact, licenceEntity.company)
 
   const editContact = contactData()
 
   editContact.department = 'Test Contact Edit Alerts'
   editContact.email = 'test.contact.edit@example.com'
 
-  const editCompanyContact = companyContactData(editContact, licence.company)
+  const editCompanyContact = companyContactData(editContact, licenceEntity.company)
 
   const removeContact = contactData()
 
   removeContact.department = 'Test Contact Remove'
   removeContact.email = 'test.contact.remove@example.com'
 
-  const removeCompanyContact = companyContactData(removeContact, licence.company)
+  const removeCompanyContact = companyContactData(removeContact, licenceEntity.company)
 
   const restoreContact = contactData()
 
   restoreContact.department = 'Test Contact Restore'
   restoreContact.email = 'test.contact.restore@example.com'
 
-  const restoreCompanyContact = companyContactData(restoreContact, licence.company)
+  const restoreCompanyContact = companyContactData(restoreContact, licenceEntity.company)
 
-  const notification = notificationData(licence.licence.licenceRef, restoreContact)
+  const notification = notificationData(licenceEntity.licence.licenceRef, restoreContact)
 
   return {
-    ...licence,
+    ...licenceEntity,
     contacts: [contact, editContact, removeContact, restoreContact],
     companyContacts: [companyContact, editCompanyContact, removeCompanyContact, restoreCompanyContact],
     ...notification

--- a/tests/support/scenarios/licence-with-agreement.scenario.js
+++ b/tests/support/scenarios/licence-with-agreement.scenario.js
@@ -1,15 +1,15 @@
 import licenceAgreementData from '../data/licence-agreement.data.js'
-import licenceEntity from '../entities/licence.entity.js'
+import buildLicenceEntity from '../entities/licence.entity.js'
 
 export const title = 'Licence with an agreement'
 export const description = 'A licence, licence holder, company and a section 127 two-part tariff agreement'
 
 export default function () {
-  const licence = licenceEntity()
-  const licenceAgreement = licenceAgreementData(licence.licence)
+  const licenceEntity = buildLicenceEntity()
+  const licenceAgreement = licenceAgreementData(licenceEntity.licence)
 
   return {
-    ...licence,
+    ...licenceEntity,
     licenceAgreement
   }
 }

--- a/tests/support/scenarios/licence-with-all-return-log-statuses.scenario.js
+++ b/tests/support/scenarios/licence-with-all-return-log-statuses.scenario.js
@@ -3,7 +3,7 @@ import returnRequirementData from '../data/return-requirement.data.js'
 import returnRequirementPointData from '../data/return-requirement-point.data.js'
 import returnRequirementPurposeData from '../data/return-requirement-purpose.data.js'
 import returnVersionData from '../data/return-version.data.js'
-import licenceEntity from '../entities/licence.entity.js'
+import buildLicenceEntity from '../entities/licence.entity.js'
 import { relativeToToday } from '../helpers/date.helpers.js'
 
 export const title = 'All return log statuses'
@@ -13,8 +13,8 @@ export default function (calculatedDates) {
   const currentPeriod = _currentPeriod(calculatedDates)
   const previousPeriod = _previousPeriod(currentPeriod)
 
-  const licence = licenceEntity()
-  const returnVersion = returnVersionData(licence.licence)
+  const licenceEntity = buildLicenceEntity()
+  const returnVersion = returnVersionData(licenceEntity.licence)
 
   // In the service return logs will cover the whole period of their matching return version. To ensure our test data is
   // realistic, we alter the start date of the return version to match the first return log we're seeding.
@@ -30,11 +30,11 @@ export default function (calculatedDates) {
   ]
 
   const results = periods.map((period) => {
-    return _returnLog(licence, returnVersion, period)
+    return _returnLog(licenceEntity, returnVersion, period)
   })
 
   return {
-    ...licence,
+    ...licenceEntity,
     returnVersion,
     returnRequirements: results.map((result) => {
       return result.returnRequirement
@@ -195,20 +195,20 @@ function _previousPeriod(currentPeriod) {
  *
  * @private
  */
-function _returnLog(licence, returnVersion, period) {
-  const returnRequirement = returnRequirementData(returnVersion, licence.licenceVersionPurpose)
+function _returnLog(licenceEntity, returnVersion, period) {
+  const returnRequirement = returnRequirementData(returnVersion, licenceEntity.licenceVersionPurpose)
 
   returnRequirement.legacyId = period.reference
   returnRequirement.reference = period.reference
 
-  const returnRequirementPoint = returnRequirementPointData(returnRequirement, licence.point)
-  const returnRequirementPurpose = returnRequirementPurposeData(returnRequirement, licence.licenceVersionPurpose)
+  const returnRequirementPoint = returnRequirementPointData(returnRequirement, licenceEntity.point)
+  const returnRequirementPurpose = returnRequirementPurposeData(returnRequirement, licenceEntity.licenceVersionPurpose)
 
   const returnLog = returnLogData(
-    licence.licence,
+    licenceEntity.licence,
     returnRequirement,
     [returnRequirementPurpose],
-    [licence.point],
+    [licenceEntity.point],
     period
   )
 

--- a/tests/support/scenarios/licence-with-charge-version.scenario.js
+++ b/tests/support/scenarios/licence-with-charge-version.scenario.js
@@ -1,20 +1,20 @@
 import buildChargeVersionEntity from '../entities/charge-version.entity.js'
-import licenceEntity from '../entities/licence.entity.js'
+import buildLicenceEntity from '../entities/licence.entity.js'
 
 export const title = 'Licence with a charge version'
 export const description = 'Licence with one charge version, reference and element based on the licence data'
 
 export default function () {
-  const licence = licenceEntity()
+  const licenceEntity = buildLicenceEntity()
   const chargeVersionEntity = buildChargeVersionEntity(
-    licence.company,
-    licence.address,
-    licence.licence,
-    licence.licenceVersionPurpose
+    licenceEntity.company,
+    licenceEntity.address,
+    licenceEntity.licence,
+    licenceEntity.licenceVersionPurpose
   )
 
   return {
-    ...licence,
+    ...licenceEntity,
     ...chargeVersionEntity
   }
 }

--- a/tests/support/scenarios/licence-with-due-winter-return-log.scenario.js
+++ b/tests/support/scenarios/licence-with-due-winter-return-log.scenario.js
@@ -3,7 +3,7 @@ import returnRequirementData from '../data/return-requirement.data.js'
 import returnRequirementPointData from '../data/return-requirement-point.data.js'
 import returnRequirementPurposeData from '../data/return-requirement-purpose.data.js'
 import returnVersionData from '../data/return-version.data.js'
-import licenceEntity from '../entities/licence.entity.js'
+import buildLicenceEntity from '../entities/licence.entity.js'
 import { previousPeriod } from '../helpers/date.helpers.js'
 
 export const title = 'Licence with an open return log (winter cycle)'
@@ -27,35 +27,35 @@ export default function (calculatedDates) {
     quarterly: false
   }
 
-  const licence = licenceEntity()
+  const licenceEntity = buildLicenceEntity()
 
-  const returnVersion = returnVersionData(licence.licence)
+  const returnVersion = returnVersionData(licenceEntity.licence)
 
   // In the service return logs will cover the whole period of their matching return version. To ensure our test data is
   // realistic, we alter the start date of the return version to match the first return log we're seeding.
   returnVersion.startDate = previousPeriodDetails.startDate
 
-  const returnRequirement = returnRequirementData(returnVersion, licence.licenceVersionPurpose)
-  const returnRequirementPoint = returnRequirementPointData(returnRequirement, licence.point)
-  const returnRequirementPurpose = returnRequirementPurposeData(returnRequirement, licence.licenceVersionPurpose)
+  const returnRequirement = returnRequirementData(returnVersion, licenceEntity.licenceVersionPurpose)
+  const returnRequirementPoint = returnRequirementPointData(returnRequirement, licenceEntity.point)
+  const returnRequirementPurpose = returnRequirementPurposeData(returnRequirement, licenceEntity.licenceVersionPurpose)
 
   const previousReturnLog = returnLogData(
-    licence.licence,
+    licenceEntity.licence,
     returnRequirement,
     [returnRequirementPurpose],
-    [licence.point],
+    [licenceEntity.point],
     previousPeriodDetails
   )
   const currentReturnLog = returnLogData(
-    licence.licence,
+    licenceEntity.licence,
     returnRequirement,
     [returnRequirementPurpose],
-    [licence.point],
+    [licenceEntity.point],
     currentPeriodDetails
   )
 
   return {
-    ...licence,
+    ...licenceEntity,
     returnVersion,
     returnRequirement,
     returnRequirementPoint,

--- a/tests/support/scenarios/licence-with-open-return-log-for-first-period.scenario.js
+++ b/tests/support/scenarios/licence-with-open-return-log-for-first-period.scenario.js
@@ -3,7 +3,7 @@ import returnRequirementData from '../data/return-requirement.data.js'
 import returnRequirementPointData from '../data/return-requirement-point.data.js'
 import returnRequirementPurposeData from '../data/return-requirement-purpose.data.js'
 import returnVersionData from '../data/return-version.data.js'
-import licenceEntity from '../entities/licence.entity.js'
+import buildLicenceEntity from '../entities/licence.entity.js'
 import { compareDates } from '../helpers/date.helpers.js'
 
 export const title = 'Licence with open return log (first period)'
@@ -19,30 +19,36 @@ export default function (calculatedDates) {
     quarterly: firstReturnPeriod.quarterly
   }
 
-  const licence = licenceEntity()
+  const licenceEntity = buildLicenceEntity()
 
   // We want the return logs for the licence to match with the first quarter shown in the journey. This is dynamically
   // calculated based on the current date, so could be a quarterly period, or the winter or summer cycle.
   // Only licences flagged as water undertakers are eligible for quarterly returns, so we ensure the licence aligns.
-  licence.licence.waterUndertaker = firstPeriod.quarterly
+  licenceEntity.licence.waterUndertaker = firstPeriod.quarterly
 
-  const returnVersion = returnVersionData(licence.licence)
+  const returnVersion = returnVersionData(licenceEntity.licence)
 
   // In the service return logs will cover the whole period of their matching return version. To ensure our test data is
   // realistic, we alter the start date of the return version to match the first return log we're seeding.
   returnVersion.startDate = firstPeriod.startDate
 
-  const returnRequirement = returnRequirementData(returnVersion, licence.licenceVersionPurpose)
-  const returnRequirementPoint = returnRequirementPointData(returnRequirement, licence.point)
-  const returnRequirementPurpose = returnRequirementPurposeData(returnRequirement, licence.licenceVersionPurpose)
+  const returnRequirement = returnRequirementData(returnVersion, licenceEntity.licenceVersionPurpose)
+  const returnRequirementPoint = returnRequirementPointData(returnRequirement, licenceEntity.point)
+  const returnRequirementPurpose = returnRequirementPurposeData(returnRequirement, licenceEntity.licenceVersionPurpose)
 
   const periods = _periods(firstPeriod, calculatedDates)
   const returnLogs = periods.map((period) => {
-    return returnLogData(licence.licence, returnRequirement, [returnRequirementPurpose], [licence.point], period)
+    return returnLogData(
+      licenceEntity.licence,
+      returnRequirement,
+      [returnRequirementPurpose],
+      [licenceEntity.point],
+      period
+    )
   })
 
   return {
-    ...licence,
+    ...licenceEntity,
     returnVersion,
     returnRequirement,
     returnRequirementPoint,

--- a/tests/support/scenarios/licence-with-open-winter-return-log.scenario.js
+++ b/tests/support/scenarios/licence-with-open-winter-return-log.scenario.js
@@ -3,7 +3,7 @@ import returnRequirementData from '../data/return-requirement.data.js'
 import returnRequirementPointData from '../data/return-requirement-point.data.js'
 import returnRequirementPurposeData from '../data/return-requirement-purpose.data.js'
 import returnVersionData from '../data/return-version.data.js'
-import licenceEntity from '../entities/licence.entity.js'
+import buildLicenceEntity from '../entities/licence.entity.js'
 import { previousPeriod } from '../helpers/date.helpers.js'
 
 export const title = 'Licence with an open return log (winter cycle)'
@@ -27,35 +27,35 @@ export default function (calculatedDates) {
     quarterly: false
   }
 
-  const licence = licenceEntity()
+  const licenceEntity = buildLicenceEntity()
 
-  const returnVersion = returnVersionData(licence.licence)
+  const returnVersion = returnVersionData(licenceEntity.licence)
 
   // In the service return logs will cover the whole period of their matching return version. To ensure our test data is
   // realistic, we alter the start date of the return version to match the first return log we're seeding.
   returnVersion.startDate = previousPeriodDetails.startDate
 
-  const returnRequirement = returnRequirementData(returnVersion, licence.licenceVersionPurpose)
-  const returnRequirementPoint = returnRequirementPointData(returnRequirement, licence.point)
-  const returnRequirementPurpose = returnRequirementPurposeData(returnRequirement, licence.licenceVersionPurpose)
+  const returnRequirement = returnRequirementData(returnVersion, licenceEntity.licenceVersionPurpose)
+  const returnRequirementPoint = returnRequirementPointData(returnRequirement, licenceEntity.point)
+  const returnRequirementPurpose = returnRequirementPurposeData(returnRequirement, licenceEntity.licenceVersionPurpose)
 
   const previousReturnLog = returnLogData(
-    licence.licence,
+    licenceEntity.licence,
     returnRequirement,
     [returnRequirementPurpose],
-    [licence.point],
+    [licenceEntity.point],
     previousPeriodDetails
   )
   const currentReturnLog = returnLogData(
-    licence.licence,
+    licenceEntity.licence,
     returnRequirement,
     [returnRequirementPurpose],
-    [licence.point],
+    [licenceEntity.point],
     currentPeriodDetails
   )
 
   return {
-    ...licence,
+    ...licenceEntity,
     returnVersion,
     returnRequirement,
     returnRequirementPoint,

--- a/tests/support/scenarios/licence-with-tpt-chg-vers-and-due-return-log.scenario.js
+++ b/tests/support/scenarios/licence-with-tpt-chg-vers-and-due-return-log.scenario.js
@@ -4,7 +4,7 @@ import returnRequirementPointData from '../data/return-requirement-point.data.js
 import returnRequirementPurposeData from '../data/return-requirement-purpose.data.js'
 import returnVersionData from '../data/return-version.data.js'
 import buildChargeVersionEntity from '../entities/charge-version.entity.js'
-import licenceEntity from '../entities/licence.entity.js'
+import buildLicenceEntity from '../entities/licence.entity.js'
 import { previousPeriod } from '../helpers/date.helpers.js'
 
 export const title = 'Licence with tpt charge version and due return log'
@@ -28,42 +28,42 @@ export default function (calculatedDates) {
     quarterly: false
   }
 
-  const licence = licenceEntity()
+  const licenceEntity = buildLicenceEntity()
   const chargeVersionEntity = buildChargeVersionEntity(
-    licence.company,
-    licence.address,
-    licence.licence,
-    licence.licenceVersionPurpose
+    licenceEntity.company,
+    licenceEntity.address,
+    licenceEntity.licence,
+    licenceEntity.licenceVersionPurpose
   )
 
-  const returnVersion = returnVersionData(licence.licence)
+  const returnVersion = returnVersionData(licenceEntity.licence)
 
   // In the service return logs will cover the whole period of their matching return version. To ensure our test data is
   // realistic, we alter the start date of the return version to match the first return log we're seeding.
   returnVersion.startDate = previousPeriodDetails.startDate
 
-  const returnRequirement = returnRequirementData(returnVersion, licence.licenceVersionPurpose)
+  const returnRequirement = returnRequirementData(returnVersion, licenceEntity.licenceVersionPurpose)
 
-  const returnRequirementPoint = returnRequirementPointData(returnRequirement, licence.point)
-  const returnRequirementPurpose = returnRequirementPurposeData(returnRequirement, licence.licenceVersionPurpose)
+  const returnRequirementPoint = returnRequirementPointData(returnRequirement, licenceEntity.point)
+  const returnRequirementPurpose = returnRequirementPurposeData(returnRequirement, licenceEntity.licenceVersionPurpose)
 
   const previousReturnLog = returnLogData(
-    licence.licence,
+    licenceEntity.licence,
     returnRequirement,
     [returnRequirementPurpose],
-    [licence.point],
+    [licenceEntity.point],
     previousPeriodDetails
   )
   const currentReturnLog = returnLogData(
-    licence.licence,
+    licenceEntity.licence,
     returnRequirement,
     [returnRequirementPurpose],
-    [licence.point],
+    [licenceEntity.point],
     currentPeriodDetails
   )
 
   return {
-    ...licence,
+    ...licenceEntity,
     ...chargeVersionEntity,
     returnVersion,
     returnRequirement,

--- a/tests/support/scenarios/licence-with-tpt-return-log-and-bill-run.scenario.js
+++ b/tests/support/scenarios/licence-with-tpt-return-log-and-bill-run.scenario.js
@@ -5,7 +5,7 @@ import returnRequirementPointData from '../data/return-requirement-point.data.js
 import returnRequirementPurposeData from '../data/return-requirement-purpose.data.js'
 import returnVersionData from '../data/return-version.data.js'
 import buildChargeVersionEntity from '../entities/charge-version.entity.js'
-import licenceEntity from '../entities/licence.entity.js'
+import buildLicenceEntity from '../entities/licence.entity.js'
 import { previousPeriod } from '../helpers/date.helpers.js'
 
 export const title = 'Licence with a two-part tariff return log and bill run'
@@ -22,32 +22,32 @@ export default function (calculatedDates) {
     quarterly: false
   })
 
-  const licence = licenceEntity()
+  const licenceEntity = buildLicenceEntity()
   const chargeVersionEntity = buildChargeVersionEntity(
-    licence.company,
-    licence.address,
-    licence.licence,
-    licence.licenceVersionPurpose
+    licenceEntity.company,
+    licenceEntity.address,
+    licenceEntity.licence,
+    licenceEntity.licenceVersionPurpose
   )
 
-  const returnVersion = returnVersionData(licence.licence)
+  const returnVersion = returnVersionData(licenceEntity.licence)
 
   // In the service return logs will cover the whole period of their matching return version. To ensure our test data is
   // realistic, we alter the start date of the return version to match the return log we're seeding.
   returnVersion.startDate = previousPeriodDetails.startDate
 
-  const returnRequirement = returnRequirementData(returnVersion, licence.licenceVersionPurpose)
+  const returnRequirement = returnRequirementData(returnVersion, licenceEntity.licenceVersionPurpose)
 
   returnRequirement.twoPartTariff = true
 
-  const returnRequirementPoint = returnRequirementPointData(returnRequirement, licence.point)
-  const returnRequirementPurpose = returnRequirementPurposeData(returnRequirement, licence.licenceVersionPurpose)
+  const returnRequirementPoint = returnRequirementPointData(returnRequirement, licenceEntity.point)
+  const returnRequirementPurpose = returnRequirementPurposeData(returnRequirement, licenceEntity.licenceVersionPurpose)
 
   const returnLog = returnLogData(
-    licence.licence,
+    licenceEntity.licence,
     returnRequirement,
     [returnRequirementPurpose],
-    [licence.point],
+    [licenceEntity.point],
     previousPeriodDetails
   )
 
@@ -62,7 +62,7 @@ export default function (calculatedDates) {
   billRun.toFinancialYearEnding = financialYearEnding
 
   return {
-    ...licence,
+    ...licenceEntity,
     ...chargeVersionEntity,
     returnVersion,
     returnRequirement,

--- a/tests/support/scenarios/licence-with-two-purposes.scenario.js
+++ b/tests/support/scenarios/licence-with-two-purposes.scenario.js
@@ -1,7 +1,7 @@
 import licenceVersionPurposeData from '../data/licence-version-purpose.data.js'
 import licenceVersionPurposePointData from '../data/licence-version-purpose-point.data.js'
 import pointData from '../data/point.data.js'
-import licenceEntity from '../entities/licence.entity.js'
+import buildLicenceEntity from '../entities/licence.entity.js'
 import { regionCode } from '../default-values.js'
 
 export const title = 'Licence with two purposes'
@@ -9,7 +9,7 @@ export const description =
   'A licence with two points and two licence version purposes, and no existing return requirements'
 
 export default function () {
-  const licence = licenceEntity()
+  const licenceEntity = buildLicenceEntity()
 
   const secondPoint = pointData()
 
@@ -21,7 +21,7 @@ export default function () {
   // behind after every run and collide with itself on the next.
   secondPoint.externalId = `${regionCode}:9000090`
 
-  const secondPurpose = licenceVersionPurposeData(licence.licenceVersion)
+  const secondPurpose = licenceVersionPurposeData(licenceEntity.licenceVersion)
 
   secondPurpose.purposeId.value = '280'
   secondPurpose.externalId = `${regionCode}:9000092`
@@ -29,9 +29,9 @@ export default function () {
   const secondPurposePoint = licenceVersionPurposePointData(secondPurpose, secondPoint)
 
   return {
-    ...licence,
-    points: [licence.point, secondPoint],
-    licenceVersionPurposes: [licence.licenceVersionPurpose, secondPurpose],
-    licenceVersionPurposePoints: [licence.licenceVersionPurposePoint, secondPurposePoint]
+    ...licenceEntity,
+    points: [licenceEntity.point, secondPoint],
+    licenceVersionPurposes: [licenceEntity.licenceVersionPurpose, secondPurpose],
+    licenceVersionPurposePoints: [licenceEntity.licenceVersionPurposePoint, secondPurposePoint]
   }
 }

--- a/tests/support/scenarios/licence-with-workflow-and-annual-bill-run.scenario.js
+++ b/tests/support/scenarios/licence-with-workflow-and-annual-bill-run.scenario.js
@@ -1,7 +1,7 @@
 import billRunData from '../data/bill-run.data.js'
 import workflowData from '../data/workflow.data.js'
 import buildChargeVersionEntity from '../entities/charge-version.entity.js'
-import licenceEntity from '../entities/licence.entity.js'
+import buildLicenceEntity from '../entities/licence.entity.js'
 import { today, yesterday } from '../helpers/date.helpers.js'
 
 export const title = 'Licence in workflow, and an annual bill run'
@@ -14,12 +14,12 @@ export const description =
  * This is omitted from the scenario name and description to keep them concise, but is still part of the scenario.
  */
 export default function (calculatedDates) {
-  const licence = licenceEntity()
+  const licenceEntity = buildLicenceEntity()
   const chargeVersionEntity = buildChargeVersionEntity(
-    licence.company,
-    licence.address,
-    licence.licence,
-    licence.licenceVersionPurpose
+    licenceEntity.company,
+    licenceEntity.address,
+    licenceEntity.licence,
+    licenceEntity.licenceVersionPurpose
   )
 
   const {
@@ -34,14 +34,14 @@ export default function (calculatedDates) {
   billRun.fromFinancialYearEnding = new Date(annualDates.endDate).getUTCFullYear()
   billRun.toFinancialYearEnding = new Date(annualDates.endDate).getUTCFullYear()
 
-  const workflow = workflowData(licence.licence)
+  const workflow = workflowData(licenceEntity.licence)
 
   // The workflow createdAt date is used to show the supplementary billing flag.
   workflow.createdAt = yesterday()
   workflow.updatedAt = yesterday()
 
   return {
-    ...licence,
+    ...licenceEntity,
     ...chargeVersionEntity,
     billRun,
     workflow

--- a/tests/support/scenarios/licence-with-workflow-and-two-part-tariff-bill-run.scenario.js
+++ b/tests/support/scenarios/licence-with-workflow-and-two-part-tariff-bill-run.scenario.js
@@ -1,7 +1,7 @@
 import billRunData from '../data/bill-run.data.js'
 import workflowData from '../data/workflow.data.js'
 import buildChargeVersionEntity from '../entities/charge-version.entity.js'
-import licenceEntity from '../entities/licence.entity.js'
+import buildLicenceEntity from '../entities/licence.entity.js'
 import { today, yesterday } from '../helpers/date.helpers.js'
 
 export const title = 'Licence in workflow, and a two-part tariff bill run'
@@ -14,12 +14,12 @@ export const description =
  * This is omitted from the scenario name and description to keep them concise, but is still part of the scenario.
  */
 export default function (calculatedDates) {
-  const licence = licenceEntity()
+  const licenceEntity = buildLicenceEntity()
   const chargeVersionEntity = buildChargeVersionEntity(
-    licence.company,
-    licence.address,
-    licence.licence,
-    licence.licenceVersionPurpose
+    licenceEntity.company,
+    licenceEntity.address,
+    licenceEntity.licence,
+    licenceEntity.licenceVersionPurpose
   )
 
   const {
@@ -35,7 +35,7 @@ export default function (calculatedDates) {
   billRun.fromFinancialYearEnding = new Date(twoPartTariffDates.endDate).getUTCFullYear()
   billRun.toFinancialYearEnding = new Date(twoPartTariffDates.endDate).getUTCFullYear()
 
-  const workflow = workflowData(licence.licence)
+  const workflow = workflowData(licenceEntity.licence)
 
   // The workflow createdAt date is used to show the supplementary billing flag.
   // It should be set to a date before the two-part tariff bill run's end date.
@@ -43,7 +43,7 @@ export default function (calculatedDates) {
   workflow.updatedAt = yesterday()
 
   return {
-    ...licence,
+    ...licenceEntity,
     ...chargeVersionEntity,
     billRun,
     workflow

--- a/tests/support/scenarios/licence-with-workflow.scenario.js
+++ b/tests/support/scenarios/licence-with-workflow.scenario.js
@@ -1,15 +1,15 @@
 import workflowData from '../data/workflow.data.js'
-import licenceEntity from '../entities/licence.entity.js'
+import buildLicenceEntity from '../entities/licence.entity.js'
 
 export const title = 'Licence in workflow'
 export const description = 'A licence, licence holder (company), and a workflow entry'
 
 export default function () {
-  const licence = licenceEntity()
-  const workflow = workflowData(licence.licence)
+  const licenceEntity = buildLicenceEntity()
+  const workflow = workflowData(licenceEntity.licence)
 
   return {
-    ...licence,
+    ...licenceEntity,
     workflow
   }
 }

--- a/tests/support/scenarios/licence.scenario.js
+++ b/tests/support/scenarios/licence.scenario.js
@@ -1,8 +1,8 @@
-import licenceEntity from '../entities/licence.entity.js'
+import buildLicenceEntity from '../entities/licence.entity.js'
 
 export const title = 'Licence only'
 export const description = 'Just the licence, licence version, and licence holder (company)'
 
 export default function () {
-  return licenceEntity()
+  return buildLicenceEntity()
 }

--- a/tests/support/scenarios/presroc-licence.scenario.js
+++ b/tests/support/scenarios/presroc-licence.scenario.js
@@ -1,17 +1,17 @@
-import licenceEntity from '../entities/licence.entity.js'
+import buildLicenceEntity from '../entities/licence.entity.js'
 
 export const title = 'Presroc licence'
 export const description = 'Licence with a start date before 2022-04-01'
 
 export default function () {
-  const licence = licenceEntity()
+  const licenceEntity = buildLicenceEntity()
 
   const preSrocDate = '2018-04-01'
 
-  licence.licence.startDate = preSrocDate
-  licence.licenceVersion.startDate = preSrocDate
-  licence.licenceDocument.startDate = preSrocDate
-  licence.licenceDocumentRole.startDate = preSrocDate
+  licenceEntity.licence.startDate = preSrocDate
+  licenceEntity.licenceVersion.startDate = preSrocDate
+  licenceEntity.licenceDocument.startDate = preSrocDate
+  licenceEntity.licenceDocumentRole.startDate = preSrocDate
 
-  return licence
+  return licenceEntity
 }

--- a/tests/support/scenarios/registered-licence.scenario.js
+++ b/tests/support/scenarios/registered-licence.scenario.js
@@ -1,21 +1,21 @@
 import primaryUserData from '../data/primary-user.data.js'
-import licenceEntity from '../entities/licence.entity.js'
+import buildLicenceEntity from '../entities/licence.entity.js'
 import { externalUserEmail } from '../default-values.js'
 
 export const title = 'Registered licence'
 export const description = 'A licence that has been registered (primary user), licence holder and a company'
 
 export default function () {
-  const licence = licenceEntity()
+  const licenceEntity = buildLicenceEntity()
 
-  const primaryUser = primaryUserData(externalUserEmail, licence.company)
+  const primaryUser = primaryUserData(externalUserEmail, licenceEntity.company)
 
   // Linking a primary user's company entity to the licence's licence document header is the only way we can link a
   // registered licence to a licence holder.
-  licence.licenceDocumentHeader.companyEntityId = primaryUser.licenceEntityRole.companyEntityId
+  licenceEntity.licenceDocumentHeader.companyEntityId = primaryUser.licenceEntityRole.companyEntityId
 
   return {
-    ...licence,
+    ...licenceEntity,
     ...primaryUser
   }
 }

--- a/tests/support/scenarios/water-company-licence-with-charge-version.scenario.js
+++ b/tests/support/scenarios/water-company-licence-with-charge-version.scenario.js
@@ -1,23 +1,23 @@
 import buildChargeVersionEntity from '../entities/charge-version.entity.js'
-import licenceEntity from '../entities/licence.entity.js'
+import buildLicenceEntity from '../entities/licence.entity.js'
 
 export const title = 'Water company licence with a charge version'
 export const description =
   'Water company licence with one charge version, reference and element based on the licence data'
 
 export default function () {
-  const licence = licenceEntity()
+  const licenceEntity = buildLicenceEntity()
   const chargeVersionEntity = buildChargeVersionEntity(
-    licence.company,
-    licence.address,
-    licence.licence,
-    licence.licenceVersionPurpose
+    licenceEntity.company,
+    licenceEntity.address,
+    licenceEntity.licence,
+    licenceEntity.licenceVersionPurpose
   )
 
-  licence.licence.waterUndertaker = true
+  licenceEntity.licence.waterUndertaker = true
 
   return {
-    ...licence,
+    ...licenceEntity,
     ...chargeVersionEntity
   }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5722

Aligns licence.entity.js's 17 consumers with the buildFooEntity convention already used by billing-account.entity.js and charge-version.entity.js. The import is now buildLicenceEntity and the built result is assigned to licenceEntity, so the import name and the variable's name match. Every downstream reference to the composite object was updated to the new variable name.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>