### PR TITLE
Add bill run entity and use it in workflow bill run scenarios

### DIFF
--- a/tests/support/entities/bill-run.entity.js
+++ b/tests/support/entities/bill-run.entity.js
@@ -1,0 +1,31 @@
+import billRunData from '../data/bill-run.data.js'
+import { today } from '../helpers/date.helpers.js'
+import buildChargeVersionEntity from './charge-version.entity.js'
+
+/**
+ * Builds a bill run in its entirety: a charge version for the given licence, and a sent bill run for the financial
+ * year ending taken from the given billing period dates — the minimum valid data a bill run needs to exist against
+ * a licence.
+ *
+ * The bill run's batch type is left at the data file's default (annual). Scenarios needing a different batch type
+ * must set `billRun.batchType` themselves.
+ */
+export default function (licenceEntity, twoPartTariffDates) {
+  const chargeVersionEntity = buildChargeVersionEntity(
+    licenceEntity.company,
+    licenceEntity.address,
+    licenceEntity.licence,
+    licenceEntity.licenceVersionPurpose
+  )
+
+  const billRun = billRunData()
+
+  billRun.createdAt = today()
+  billRun.fromFinancialYearEnding = new Date(twoPartTariffDates.endDate).getUTCFullYear()
+  billRun.toFinancialYearEnding = new Date(twoPartTariffDates.endDate).getUTCFullYear()
+
+  return {
+    ...chargeVersionEntity,
+    billRun
+  }
+}

--- a/tests/support/scenarios/licence-with-workflow-and-annual-bill-run.scenario.js
+++ b/tests/support/scenarios/licence-with-workflow-and-annual-bill-run.scenario.js
@@ -1,8 +1,7 @@
-import billRunData from '../data/bill-run.data.js'
 import workflowData from '../data/workflow.data.js'
-import buildChargeVersionEntity from '../entities/charge-version.entity.js'
+import buildBillRunEntity from '../entities/bill-run.entity.js'
 import buildLicenceEntity from '../entities/licence.entity.js'
-import { today, yesterday } from '../helpers/date.helpers.js'
+import { yesterday } from '../helpers/date.helpers.js'
 
 export const title = 'Licence in workflow, and an annual bill run'
 export const description =
@@ -14,25 +13,14 @@ export const description =
  * This is omitted from the scenario name and description to keep them concise, but is still part of the scenario.
  */
 export default function (calculatedDates) {
-  const licenceEntity = buildLicenceEntity()
-  const chargeVersionEntity = buildChargeVersionEntity(
-    licenceEntity.company,
-    licenceEntity.address,
-    licenceEntity.licence,
-    licenceEntity.licenceVersionPurpose
-  )
-
   const {
     billingPeriods: {
       annual: [annualDates]
     }
   } = calculatedDates
 
-  const billRun = billRunData()
-
-  billRun.createdAt = today()
-  billRun.fromFinancialYearEnding = new Date(annualDates.endDate).getUTCFullYear()
-  billRun.toFinancialYearEnding = new Date(annualDates.endDate).getUTCFullYear()
+  const licenceEntity = buildLicenceEntity()
+  const billRunEntity = buildBillRunEntity(licenceEntity, annualDates)
 
   const workflow = workflowData(licenceEntity.licence)
 
@@ -42,8 +30,7 @@ export default function (calculatedDates) {
 
   return {
     ...licenceEntity,
-    ...chargeVersionEntity,
-    billRun,
+    ...billRunEntity,
     workflow
   }
 }

--- a/tests/support/scenarios/licence-with-workflow-and-two-part-tariff-bill-run.scenario.js
+++ b/tests/support/scenarios/licence-with-workflow-and-two-part-tariff-bill-run.scenario.js
@@ -1,8 +1,7 @@
-import billRunData from '../data/bill-run.data.js'
 import workflowData from '../data/workflow.data.js'
-import buildChargeVersionEntity from '../entities/charge-version.entity.js'
+import buildBillRunEntity from '../entities/bill-run.entity.js'
 import buildLicenceEntity from '../entities/licence.entity.js'
-import { today, yesterday } from '../helpers/date.helpers.js'
+import { yesterday } from '../helpers/date.helpers.js'
 
 export const title = 'Licence in workflow, and a two-part tariff bill run'
 export const description =
@@ -14,26 +13,16 @@ export const description =
  * This is omitted from the scenario name and description to keep them concise, but is still part of the scenario.
  */
 export default function (calculatedDates) {
-  const licenceEntity = buildLicenceEntity()
-  const chargeVersionEntity = buildChargeVersionEntity(
-    licenceEntity.company,
-    licenceEntity.address,
-    licenceEntity.licence,
-    licenceEntity.licenceVersionPurpose
-  )
-
   const {
     billingPeriods: {
       twoPartTariff: [twoPartTariffDates]
     }
   } = calculatedDates
 
-  const billRun = billRunData()
+  const licenceEntity = buildLicenceEntity()
+  const billRunEntity = buildBillRunEntity(licenceEntity, twoPartTariffDates)
 
-  billRun.createdAt = today()
-  billRun.batchType = 'two_part_tariff'
-  billRun.fromFinancialYearEnding = new Date(twoPartTariffDates.endDate).getUTCFullYear()
-  billRun.toFinancialYearEnding = new Date(twoPartTariffDates.endDate).getUTCFullYear()
+  billRunEntity.billRun.batchType = 'two_part_tariff'
 
   const workflow = workflowData(licenceEntity.licence)
 
@@ -44,8 +33,7 @@ export default function (calculatedDates) {
 
   return {
     ...licenceEntity,
-    ...chargeVersionEntity,
-    billRun,
+    ...billRunEntity,
     workflow
   }
 }


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/WATER-5722

Two of our scenarios duplicated the same charge version plus bill run setup inline. This adds a shared bill-run.entity.js that builds a charge version for a given licence and a sent bill run for a given set of billing period dates, defaulting the batch type to annual since that's the data file's default, with callers overriding it when they need two-part tariff instead. The annual and two-part tariff workflow bill run scenarios have been updated to use it in place of their duplicated logic.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>